### PR TITLE
feat(sdk/react-native): support expo 51

### DIFF
--- a/packages/sdks/react-native/package.json
+++ b/packages/sdks/react-native/package.json
@@ -22,8 +22,8 @@
   },
   "peerDependencies": {
     "react-native": "^0.73.4",
-    "expo-application": "^5.3.0 || ^5.8.4",
-    "expo-constants": "^14.4.2 || ^15.4.6"
+    "expo-application": "^5.3.0 || ^5.8.4 || ^5.9.1",
+    "expo-constants": "^14.4.2 || ^15.4.6 || ^16.0.2"
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
Not sure if this is getting messy and bad practice, but in order to support expo 51 (latest expo version), we need to add the later package versions of expo-application and expo-constants

If this is ok like this, please also make a release on NPM 🙏 