### PR TITLE
feat(dashboard): formatTime add seconds

### DIFF
--- a/apps/dashboard/src/utils/date.ts
+++ b/apps/dashboard/src/utils/date.ts
@@ -43,6 +43,7 @@ export function formatTime(date: Date) {
   return new Intl.DateTimeFormat(getLocale(), {
     hour: 'numeric',
     minute: 'numeric',
+    second: 'numeric',
   }).format(date);
 }
 


### PR DESCRIPTION
Hi!

I think it would be very useful in the events and profile tables to see the seconds. The `formatTime` utility is being used specifically when the event or profile timestamp is today.

![CleanShot 2024-09-10 at 18 14 19@2x](https://github.com/user-attachments/assets/7c2ed45f-2d7d-4dcc-ac3b-2bbc9ab4ec2c)

Maybe even better would be to use the same tooltip like on the profiles table where you get the exact timestamp when you hover over it.

![CleanShot 2024-09-10 at 18 22 00@2x](https://github.com/user-attachments/assets/30c3fa5e-e96d-40fe-9e45-b19069ac4acd)

Would love to help implementing that if that sounds good.
