### PR TITLE
chore: Update nuqs to v2

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -79,7 +79,7 @@
     "next-auth": "^4.24.5",
     "next-themes": "^0.2.1",
     "nextjs-toploader": "^1.6.11",
-    "nuqs": "^2.0.0",
+    "nuqs": "^2.0.2",
     "prisma-error-enum": "^0.1.3",
     "pushmodal": "^1.0.3",
     "ramda": "^0.29.1",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -79,7 +79,7 @@
     "next-auth": "^4.24.5",
     "next-themes": "^0.2.1",
     "nextjs-toploader": "^1.6.11",
-    "nuqs": "^1.16.1",
+    "nuqs": "^2.0.0",
     "prisma-error-enum": "^0.1.3",
     "pushmodal": "^1.0.3",
     "ramda": "^0.29.1",

--- a/apps/dashboard/src/app/(app)/[organizationSlug]/[projectId]/events/page.tsx
+++ b/apps/dashboard/src/app/(app)/[organizationSlug]/[projectId]/events/page.tsx
@@ -1,6 +1,6 @@
 import { PageTabs, PageTabsLink } from '@/components/page-tabs';
 import { Padding } from '@/components/ui/padding';
-import { parseAsStringEnum } from 'nuqs';
+import { parseAsStringEnum } from 'nuqs/server';
 
 import Charts from './charts';
 import Conversions from './conversions';

--- a/apps/dashboard/src/app/(app)/[organizationSlug]/[projectId]/pages/page.tsx
+++ b/apps/dashboard/src/app/(app)/[organizationSlug]/[projectId]/pages/page.tsx
@@ -1,6 +1,6 @@
 import { PageTabs, PageTabsLink } from '@/components/page-tabs';
 import { Padding } from '@/components/ui/padding';
-import { parseAsStringEnum } from 'nuqs';
+import { parseAsStringEnum } from 'nuqs/server';
 
 import { Pages } from './pages';
 

--- a/apps/dashboard/src/app/(app)/[organizationSlug]/[projectId]/profiles/page.tsx
+++ b/apps/dashboard/src/app/(app)/[organizationSlug]/[projectId]/profiles/page.tsx
@@ -1,6 +1,6 @@
 import { PageTabs, PageTabsLink } from '@/components/page-tabs';
 import { Padding } from '@/components/ui/padding';
-import { parseAsStringEnum } from 'nuqs';
+import { parseAsStringEnum } from 'nuqs/server';
 
 import PowerUsers from './power-users';
 import Profiles from './profiles';

--- a/apps/dashboard/src/app/(app)/[organizationSlug]/[projectId]/settings/integrations/page.tsx
+++ b/apps/dashboard/src/app/(app)/[organizationSlug]/[projectId]/settings/integrations/page.tsx
@@ -2,7 +2,7 @@ import { ActiveIntegrations } from '@/components/integrations/active-integration
 import { AllIntegrations } from '@/components/integrations/all-integrations';
 import { PageTabs, PageTabsLink } from '@/components/page-tabs';
 import { Padding } from '@/components/ui/padding';
-import { parseAsStringEnum } from 'nuqs';
+import { parseAsStringEnum } from 'nuqs/server';
 
 interface PageProps {
   params: {

--- a/apps/dashboard/src/app/(app)/[organizationSlug]/[projectId]/settings/notifications/page.tsx
+++ b/apps/dashboard/src/app/(app)/[organizationSlug]/[projectId]/settings/notifications/page.tsx
@@ -2,7 +2,7 @@ import { NotificationRules } from '@/components/notifications/notification-rules
 import { Notifications } from '@/components/notifications/notifications';
 import { PageTabs, PageTabsLink } from '@/components/page-tabs';
 import { Padding } from '@/components/ui/padding';
-import { parseAsStringEnum } from 'nuqs';
+import { parseAsStringEnum } from 'nuqs/server';
 
 interface PageProps {
   params: {

--- a/apps/dashboard/src/app/(app)/[organizationSlug]/[projectId]/settings/organization/page.tsx
+++ b/apps/dashboard/src/app/(app)/[organizationSlug]/[projectId]/settings/organization/page.tsx
@@ -1,11 +1,10 @@
-import PageLayout from '@/app/(app)/[organizationSlug]/[projectId]/page-layout';
 import { FullPageEmptyState } from '@/components/full-page-empty-state';
 import { PageTabs, PageTabsLink } from '@/components/page-tabs';
 import { Padding } from '@/components/ui/padding';
 import { auth } from '@clerk/nextjs/server';
 import { ShieldAlertIcon } from 'lucide-react';
 import { notFound } from 'next/navigation';
-import { parseAsStringEnum } from 'nuqs';
+import { parseAsStringEnum } from 'nuqs/server';
 
 import { db } from '@openpanel/db';
 

--- a/apps/dashboard/src/app/providers.tsx
+++ b/apps/dashboard/src/app/providers.tsx
@@ -9,6 +9,7 @@ import { ClerkProvider, useAuth } from '@clerk/nextjs';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { httpLink } from '@trpc/client';
 import { ThemeProvider } from 'next-themes';
+import { NuqsAdapter } from 'nuqs/adapters/next/app';
 import type React from 'react';
 import { useRef, useState } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -75,12 +76,14 @@ function AllProviders({ children }: { children: React.ReactNode }) {
       <ReduxProvider store={storeRef.current}>
         <api.Provider client={trpcClient} queryClient={queryClient}>
           <QueryClientProvider client={queryClient}>
-            <TooltipProvider delayDuration={200}>
-              {children}
-              <NotificationProvider />
-              <Toaster />
-              <ModalProvider />
-            </TooltipProvider>
+            <NuqsAdapter>
+              <TooltipProvider delayDuration={200}>
+                {children}
+                <NotificationProvider />
+                <Toaster />
+                <ModalProvider />
+              </TooltipProvider>
+            </NuqsAdapter>
           </QueryClientProvider>
         </api.Provider>
       </ReduxProvider>

--- a/apps/dashboard/src/components/fullscreen-toggle.tsx
+++ b/apps/dashboard/src/components/fullscreen-toggle.tsx
@@ -20,7 +20,6 @@ export const useFullscreen = () =>
     'fullscreen',
     parseAsBoolean.withDefault(false).withOptions({
       history: 'push',
-      clearOnDefault: true,
     }),
   );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,8 +362,8 @@ importers:
         specifier: ^1.6.11
         version: 1.6.11(next@14.2.1)(react-dom@18.2.0)(react@18.2.0)
       nuqs:
-        specifier: ^1.16.1
-        version: 1.17.0(next@14.2.1)
+        specifier: ^2.0.0
+        version: 2.0.0(@opentelemetry/api@1.8.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
       prisma-error-enum:
         specifier: ^0.1.3
         version: 0.1.3
@@ -7632,6 +7632,57 @@ packages:
       reselect: 4.1.8
     dev: false
 
+  /@remix-run/react@2.13.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-kZevCoKMz0ZDOOzTnG95yfM7M9ju38FkWNY1wtxCy+NnUJYrmTerGQtiBsJgMzYD6i29+w4EwoQsdqys7DmMSg==}
+    engines: {node: '>=18.0.0'}
+    requiresBuild: true
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+      typescript: ^5.1.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@remix-run/router': 1.20.0
+      '@remix-run/server-runtime': 2.13.1(typescript@5.3.3)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-router: 6.27.0(react@18.2.0)
+      react-router-dom: 6.27.0(react-dom@18.2.0)(react@18.2.0)
+      turbo-stream: 2.4.0
+      typescript: 5.3.3
+    dev: false
+    optional: true
+
+  /@remix-run/router@1.20.0:
+    resolution: {integrity: sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==}
+    engines: {node: '>=14.0.0'}
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@remix-run/server-runtime@2.13.1(typescript@5.3.3):
+    resolution: {integrity: sha512-2DfBPRcHKVzE4bCNsNkKB50BhCCKF73x+jiS836OyxSIAL+x0tguV2AEjmGXefEXc5AGGzoxkus0AUUEYa29Vg==}
+    engines: {node: '>=18.0.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: ^5.1.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@remix-run/router': 1.20.0
+      '@types/cookie': 0.6.0
+      '@web3-storage/multipart-parser': 1.0.0
+      cookie: 0.6.0
+      set-cookie-parser: 2.6.0
+      source-map: 0.7.4
+      turbo-stream: 2.4.0
+      typescript: 5.3.3
+    dev: false
+    optional: true
+
   /@rollup/rollup-android-arm-eabi@4.12.0:
     resolution: {integrity: sha512-+ac02NL/2TCKRrJu2wffk1kZ+RyqxVUlbjSagNgPm94frxtr+XDL12E5Ll1enWskLrtrZ2r8L3wED1orIibV/w==}
     cpu: [arm]
@@ -8166,6 +8217,12 @@ packages:
   /@types/content-disposition@0.5.8:
     resolution: {integrity: sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg==}
     dev: false
+
+  /@types/cookie@0.6.0:
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@types/cookies@0.9.0:
     resolution: {integrity: sha512-40Zk8qR147RABiQ7NQnBzWzDcjKzNrntB5BAmeGCb2p/MIyOE+4BVvc17wumsUqUw00bJYqoXFHYygQnEFh4/Q==}
@@ -8857,6 +8914,12 @@ packages:
       graphql: 15.8.0
       wonka: 4.0.15
     dev: false
+
+  /@web3-storage/multipart-parser@1.0.0:
+    resolution: {integrity: sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@xmldom/xmldom@0.7.13:
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
@@ -16122,13 +16185,25 @@ packages:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
     dev: false
 
-  /nuqs@1.17.0(next@14.2.1):
-    resolution: {integrity: sha512-Lp2qLETMb7AAYhDtRtx20oAZNkYYTPApZcaX7Q5nQz7bfy893TCIe92IYVIfl9ZUqQLTsl9855KGEsA57dylPQ==}
+  /nuqs@2.0.0(@opentelemetry/api@1.8.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-atnb/zVSGF25ULMGe+udBWtnNKRzi/oqd8e+6xPYw/ScMMO63P62g+iCyTlE6j5qnrw44boIw4SNhPyenEYCHg==}
     peerDependencies:
-      next: '>=13.4 <14.0.2 || ^14.0.3'
+      react: '>= 18.2.0'
     dependencies:
       mitt: 3.0.1
+      react: 18.2.0
+    optionalDependencies:
+      '@remix-run/react': 2.13.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
       next: 14.2.1(@opentelemetry/api@1.8.0)(react-dom@18.2.0)(react@18.2.0)
+      react-router-dom: 6.27.0(react-dom@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@opentelemetry/api'
+      - '@playwright/test'
+      - babel-plugin-macros
+      - react-dom
+      - sass
+      - typescript
     dev: false
 
   /oauth@0.9.15:
@@ -17431,6 +17506,33 @@ packages:
       react: 18.2.0
       shallow-equal: 1.2.1
     dev: false
+
+  /react-router-dom@6.27.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==}
+    engines: {node: '>=14.0.0'}
+    requiresBuild: true
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.20.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-router: 6.27.0(react@18.2.0)
+    dev: false
+    optional: true
+
+  /react-router@6.27.0(react@18.2.0):
+    resolution: {integrity: sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==}
+    engines: {node: '>=14.0.0'}
+    requiresBuild: true
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.20.0
+      react: 18.2.0
+    dev: false
+    optional: true
 
   /react-shallow-renderer@16.15.0(react@18.2.0):
     resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
@@ -19247,6 +19349,12 @@ packages:
       tslib: 1.14.1
       typescript: 5.3.3
     dev: false
+
+  /turbo-stream@2.4.0:
+    resolution: {integrity: sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,8 +362,8 @@ importers:
         specifier: ^1.6.11
         version: 1.6.11(next@14.2.1)(react-dom@18.2.0)(react@18.2.0)
       nuqs:
-        specifier: ^2.0.0
-        version: 2.0.0(@opentelemetry/api@1.8.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+        specifier: ^2.0.2
+        version: 2.0.2(next@14.2.1)(react@18.2.0)
       prisma-error-enum:
         specifier: ^0.1.3
         version: 0.1.3
@@ -7632,57 +7632,6 @@ packages:
       reselect: 4.1.8
     dev: false
 
-  /@remix-run/react@2.13.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-kZevCoKMz0ZDOOzTnG95yfM7M9ju38FkWNY1wtxCy+NnUJYrmTerGQtiBsJgMzYD6i29+w4EwoQsdqys7DmMSg==}
-    engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-      typescript: ^5.1.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@remix-run/router': 1.20.0
-      '@remix-run/server-runtime': 2.13.1(typescript@5.3.3)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-router: 6.27.0(react@18.2.0)
-      react-router-dom: 6.27.0(react-dom@18.2.0)(react@18.2.0)
-      turbo-stream: 2.4.0
-      typescript: 5.3.3
-    dev: false
-    optional: true
-
-  /@remix-run/router@1.20.0:
-    resolution: {integrity: sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==}
-    engines: {node: '>=14.0.0'}
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@remix-run/server-runtime@2.13.1(typescript@5.3.3):
-    resolution: {integrity: sha512-2DfBPRcHKVzE4bCNsNkKB50BhCCKF73x+jiS836OyxSIAL+x0tguV2AEjmGXefEXc5AGGzoxkus0AUUEYa29Vg==}
-    engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    peerDependencies:
-      typescript: ^5.1.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@remix-run/router': 1.20.0
-      '@types/cookie': 0.6.0
-      '@web3-storage/multipart-parser': 1.0.0
-      cookie: 0.6.0
-      set-cookie-parser: 2.6.0
-      source-map: 0.7.4
-      turbo-stream: 2.4.0
-      typescript: 5.3.3
-    dev: false
-    optional: true
-
   /@rollup/rollup-android-arm-eabi@4.12.0:
     resolution: {integrity: sha512-+ac02NL/2TCKRrJu2wffk1kZ+RyqxVUlbjSagNgPm94frxtr+XDL12E5Ll1enWskLrtrZ2r8L3wED1orIibV/w==}
     cpu: [arm]
@@ -8217,12 +8166,6 @@ packages:
   /@types/content-disposition@0.5.8:
     resolution: {integrity: sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg==}
     dev: false
-
-  /@types/cookie@0.6.0:
-    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /@types/cookies@0.9.0:
     resolution: {integrity: sha512-40Zk8qR147RABiQ7NQnBzWzDcjKzNrntB5BAmeGCb2p/MIyOE+4BVvc17wumsUqUw00bJYqoXFHYygQnEFh4/Q==}
@@ -8914,12 +8857,6 @@ packages:
       graphql: 15.8.0
       wonka: 4.0.15
     dev: false
-
-  /@web3-storage/multipart-parser@1.0.0:
-    resolution: {integrity: sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==}
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /@xmldom/xmldom@0.7.13:
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
@@ -16185,25 +16122,24 @@ packages:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
     dev: false
 
-  /nuqs@2.0.0(@opentelemetry/api@1.8.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-atnb/zVSGF25ULMGe+udBWtnNKRzi/oqd8e+6xPYw/ScMMO63P62g+iCyTlE6j5qnrw44boIw4SNhPyenEYCHg==}
+  /nuqs@2.0.2(next@14.2.1)(react@18.2.0):
+    resolution: {integrity: sha512-m9o8avj1CI6ryO0jhjFi8dhFA8jLXb+6esZbkki8tJixBnexPFoVZ5wFgmANVumbyeLemZ/ujhYn23iERRYwlA==}
     peerDependencies:
+      '@remix-run/react': '>= 2'
+      next: '>= 14.2.0'
       react: '>= 18.2.0'
+      react-router-dom: '>= 6'
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      next:
+        optional: true
+      react-router-dom:
+        optional: true
     dependencies:
       mitt: 3.0.1
-      react: 18.2.0
-    optionalDependencies:
-      '@remix-run/react': 2.13.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
       next: 14.2.1(@opentelemetry/api@1.8.0)(react-dom@18.2.0)(react@18.2.0)
-      react-router-dom: 6.27.0(react-dom@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@opentelemetry/api'
-      - '@playwright/test'
-      - babel-plugin-macros
-      - react-dom
-      - sass
-      - typescript
+      react: 18.2.0
     dev: false
 
   /oauth@0.9.15:
@@ -17506,33 +17442,6 @@ packages:
       react: 18.2.0
       shallow-equal: 1.2.1
     dev: false
-
-  /react-router-dom@6.27.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==}
-    engines: {node: '>=14.0.0'}
-    requiresBuild: true
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-    dependencies:
-      '@remix-run/router': 1.20.0
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-router: 6.27.0(react@18.2.0)
-    dev: false
-    optional: true
-
-  /react-router@6.27.0(react@18.2.0):
-    resolution: {integrity: sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==}
-    engines: {node: '>=14.0.0'}
-    requiresBuild: true
-    peerDependencies:
-      react: '>=16.8'
-    dependencies:
-      '@remix-run/router': 1.20.0
-      react: 18.2.0
-    dev: false
-    optional: true
 
   /react-shallow-renderer@16.15.0(react@18.2.0):
     resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
@@ -19349,12 +19258,6 @@ packages:
       tslib: 1.14.1
       typescript: 5.3.3
     dev: false
-
-  /turbo-stream@2.4.0:
-    resolution: {integrity: sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==}
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}


### PR DESCRIPTION
Aside from the adapter in layout.tsx, the main impactful change seems to be about `clearOnDefault` which is now true by default.

That means any search param with a default value will remove itself from the URL when the default value is set.

Let me know if there are mission-critical params that you need to keep and I'll update the PR.

Another review point is the location of the `NuqsAdapter` in the providers: If the TooltipProvider, NotificationsProvider, Toaster and ModalProviders don't render nuqs-aware components, the adapter could be moved down to only wrap the `{children}`.

Migration guide for reference: https://nuqs.47ng.com/docs/migrations/v2
