### PR TITLE
fix(public): Fix misspelled word in Hero CTA

### DIFF
--- a/apps/public/components/hero.tsx
+++ b/apps/public/components/hero.tsx
@@ -36,7 +36,7 @@ export function Hero() {
             </Link>
           </Button>
           <p className="text-sm text-muted-foreground">
-            Free trail for 30 days, no credit card required
+            Free trial for 30 days, no credit card required
           </p>
         </div>
 


### PR DESCRIPTION
Fixes #94 
<img width="1030" alt="image" src="https://github.com/user-attachments/assets/350fd413-51ab-451f-ac24-910b9303f78a">
