### PR TITLE
fix: replace `COOKIE_SECRET` variable value and not name in setup script

### DIFF
--- a/self-hosting/quiz.ts
+++ b/self-hosting/quiz.ts
@@ -123,7 +123,7 @@ function writeEnvFile(envs: {
   const envTemplate = fs.readFileSync(envTemplatePath, 'utf-8');
 
   const newEnvFile = envTemplate
-    .replace('COOKIE_SECRET', envs.COOKIE_SECRET)
+    .replace('$COOKIE_SECRET', envs.COOKIE_SECRET)
     .replace('$CLICKHOUSE_URL', envs.CLICKHOUSE_URL)
     .replace('$REDIS_URL', envs.REDIS_URL)
     .replace('$DATABASE_URL', envs.DATABASE_URL)


### PR DESCRIPTION
In the self-hosting setup script, the variable `COOKIE_SECRET` is not replaced correctly, and instead of replacing the variable value, it replaced the name, this PR fixes that.