### PR TITLE
fix: missing import on sdk/web

### DIFF
--- a/packages/sdks/web/src/types.d.ts
+++ b/packages/sdks/web/src/types.d.ts
@@ -1,4 +1,7 @@
 import type { OpenPanel, OpenPanelOptions } from './';
+import type {
+  TrackProperties,
+} from '@openpanel/sdk';
 
 type ExposedMethodsNames =
   | 'track'
@@ -19,7 +22,7 @@ export type OpenPanelMethodNames = ExposedMethodsNames | 'init' | 'screenView';
 export type OpenPanelMethods =
   | ExposedMethods
   | ['init', OpenPanelOptions]
-  | ['screenView', string | TrackProperties, TrackProperties];
+  | ['screenView', string | TrackProperties | undefined, TrackProperties | undefined];
 
 declare global {
   interface Window {


### PR DESCRIPTION
Added missing `TrackProperties` import on web and updated OpenPanelMethods to fix type errors

Fixes https://github.com/Openpanel-dev/openpanel/issues/146