### PR TITLE
docs(nextjs): fix small example mistake

### DIFF
--- a/apps/public/content/docs/sdks/nextjs.mdx
+++ b/apps/public/content/docs/sdks/nextjs.mdx
@@ -32,7 +32,7 @@ Add `OpenPanelComponent` to your root layout component.
 ```tsx
 import { OpenPanelComponent } from '@openpanel/nextjs';
 
-export default RootLayout({ children }) {
+export default function RootLayout({ children }) {
   return (
     <>
       <OpenPanelComponent


### PR DESCRIPTION
Hey, in the nextjs docs, there is a small mistake on the first example:

```ts
import { OpenPanelComponent } from '@openpanel/nextjs';
 
export default RootLayout({ children }) {
  return (
    <>
      <OpenPanelComponent
        clientId="your-client-id"
        trackScreenViews={true}
        // trackAttributes={true}
        // trackOutgoingLinks={true}
        // If you have a user id, you can pass it here to identify the user
        // profileId={'123'}
      />
      {children}
    </>
  )
}
```
There is no function with the name "RootLayout", a "function" keyword is missing in front of it.

Hope I can help,
Henri