### PR TITLE
fix(dashboard): Copy `payment/packages.json` in the Dockerfile

### DIFF
--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -44,6 +44,7 @@ COPY packages/constants/package.json packages/constants/package.json
 COPY packages/validation/package.json packages/validation/package.json
 COPY packages/integrations/package.json packages/integrations/package.json
 COPY packages/sdks/sdk/package.json packages/sdks/sdk/package.json
+COPY packages/payments/package.json packages/payments/package.json
 
 # BUILD
 FROM base AS build


### PR DESCRIPTION
Otherwise payment package + `polar-sh` not found when building the next standalone version

Fix: #170 