### PR TITLE
chore(dashboard): added report name on save report toast

### DIFF
--- a/apps/dashboard/src/modals/SaveReport.tsx
+++ b/apps/dashboard/src/modals/SaveReport.tsx
@@ -49,7 +49,7 @@ export default function SaveReport({
       };
 
       toast('Report created', {
-        description: <div>Hello world</div>,
+        description: `${res.name}`,
         action: {
           label: 'View report',
           onClick: () => goToReport(),


### PR DESCRIPTION
Added name of created report to toast, previously `Hello World`

<img width="477" alt="Screenshot 2025-06-10 at 6 27 34 pm" src="https://github.com/user-attachments/assets/25f75cbc-d4aa-4428-a00f-c71104ca995f" />
