### PR TITLE
Self hosted docker container log limits

### DIFF
--- a/self-hosting/docker-compose.template.yml
+++ b/self-hosting/docker-compose.template.yml
@@ -16,6 +16,11 @@ services:
         condition: service_healthy
       op-api:
         condition: service_healthy
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   op-db:
     image: postgres:14-alpine
@@ -30,6 +35,11 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     # Uncomment to expose ports
     # ports:
     #   - 5432:5432
@@ -45,6 +55,11 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     # Uncomment to expose ports
     # ports:
     #   - 6379:6379
@@ -67,6 +82,11 @@ services:
       nofile:
         soft: 262144
         hard: 262144
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   op-api:
     image: lindesvard/openpanel-api:latest
@@ -92,6 +112,11 @@ services:
         condition: service_healthy
     env_file:
       - .env
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
 
   op-dashboard:
     image: lindesvard/openpanel-dashboard:latest
@@ -106,6 +131,11 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "3"
 
   op-worker:
     image: lindesvard/openpanel-worker:latest
@@ -123,6 +153,11 @@ services:
     deploy:
       mode: replicated
       replicas: $OP_WORKER_REPLICAS
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "30m"
+        max-file: "3"
 
 volumes:
   op-db-data:


### PR DESCRIPTION
### Problem

While using the self hosted variant on a VM, the logs files grow outrageously (I don't do active maintenance/cleanup)

Example here
<img width="951" height="180" alt="image" src="https://github.com/user-attachments/assets/59b5b324-a271-4563-a994-b3fb954e5026" />
200G of just logs :(

This leads to application going down, because the VM storage is all consumed

---
### Solution

This PR introduces log limits to all the docker services used by open panel


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized per-service container log rotation for self-hosting, with sensible defaults and increased retention for key services, improving observability and preventing excessive disk usage.

* **Bug Fixes**
  * Corrected volume configuration syntax for the proxy configuration to ensure Docker Compose compatibility and smoother deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->