### PR TITLE
fix: handle conversion condition for all clickhouse versions

### DIFF
--- a/packages/db/src/services/conversion.service.ts
+++ b/packages/db/src/services/conversion.service.ts
@@ -104,7 +104,7 @@ export class ConversionService {
           nullIf(min(b.b_time), '1970-01-01 00:00:00.000') AS conversion_time
         FROM event_a AS a
         LEFT JOIN event_b AS b ON a.${group} = b.${group}
-          AND b.b_time BETWEEN a.a_time AND a.a_time + INTERVAL ${funnelWindow} HOUR
+          WHERE b.b_time BETWEEN a.a_time AND a.a_time + INTERVAL ${funnelWindow} HOUR
         GROUP BY a.${group}, a.a_time, a.event_day${breakdownGroupBy.length ? `, ${breakdownGroupBy.join(', ')}` : ''})
       `),
       )


### PR DESCRIPTION
The changes handles conversion chart error:

`Unsupported JOIN ON conditions. Unexpected 'b_time >= a_time': While processing b_time >= a_time.`

I am assuming this error is from Clickhouse, and on further investigation I found clickHouse doesn't support range conditions (BETWEEN, >=, <=) directly in JOIN ON clauses for regular JOINs!

Code Ref - https://github.com/Openpanel-dev/openpanel/blame/main/packages/db/src/services/conversion.service.ts#L103C33-L103C34

Can be reproduced here - https://demo.openpanel.dev/demo/shoey/reports/8be16ef5-1b77-4c1b-8044-80bf41785625, by selection `Conversion` chart


Fix:
Code changes moves away from AND condition in JOIN to WHERE condition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced conversion tracking by refining data filtering logic to ensure accurate handling of conversion records and improve reporting reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->