### PR TITLE
FIX incorrect error message for invalid uuidv4 client ID

### DIFF
--- a/apps/api/src/utils/auth.ts
+++ b/apps/api/src/utils/auth.ts
@@ -73,7 +73,7 @@ export async function validateSdkRequest(
       clientId,
     )
   ) {
-    throw createError('Ingestion: Clean ID must be a valid UUIDv4');
+    throw createError('Ingestion: Client ID must be a valid UUIDv4');
   }
 
   const client = await getClientByIdCached(clientId);


### PR DESCRIPTION
Currently if we send an invalid UUID V4 as Client ID in payload, a seemingly misleading error.

It seems like it is a minor typo. Please consider the change.

<img width="2185" height="456" alt="image" src="https://github.com/user-attachments/assets/13274471-61e7-47d1-9ba0-338182a9d5d6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clarity in validation error messages for Client ID format requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->