### PR TITLE
fix: remove duplicate "Cookie-Free by Default" feature in posthog comparison

### DIFF
--- a/apps/public/content/compare/posthog-alternative.json
+++ b/apps/public/content/compare/posthog-alternative.json
@@ -61,7 +61,7 @@
         "notes": "OpenPanel's SDK is over 20x smaller than PostHog's core library, resulting in faster page loads and better Core Web Vitals."
       },
       {
-        "label": "Cookie-Free by Default",
+        "label": "Cookie-Free",
         "openpanel": "Yes",
         "competitor": "Requires Configuration",
         "notes": "OpenPanel is truly cookie-free out of the box. PostHog requires specific configuration for cookieless tracking with reduced functionality."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature labels in the comparison page content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->