### PR TITLE
Update react native Installation docs

### DIFF
--- a/apps/public/content/docs/(tracking)/sdks/react-native.mdx
+++ b/apps/public/content/docs/(tracking)/sdks/react-native.mdx
@@ -32,7 +32,9 @@ npx expo install expo-application expo-constants
 On native we use a clientSecret to authenticate the app.
 
 ```typescript
-const op = new Openpanel({
+import { OpenPanel } from '@openpanel/react-native';
+
+const op = new OpenPanel({
   clientId: '{YOUR_CLIENT_ID}',
   clientSecret: '{YOUR_CLIENT_SECRET}',
 });


### PR DESCRIPTION
The second "p" in `new Openpanel` should be capitalized. I was wondering why Vscode cannot detect the import :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated React Native SDK documentation with standardized API class naming conventions for consistency.
- Clarified explicit import syntax and patterns for proper SDK module integration.
- Refined documentation structure to provide developers with clear guidance on SDK setup and initialization best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->