### PR TITLE
Allow copying value as object

### DIFF
--- a/apps/start/src/components/ui/key-value-grid.tsx
+++ b/apps/start/src/components/ui/key-value-grid.tsx
@@ -102,7 +102,18 @@ export function KeyValueGrid({
             <button
               onClick={(e) => {
                 e.stopPropagation();
-                clipboard(item.value);
+                if (typeof item.value === 'object') {
+                  try {
+                    const value = JSON.stringify(item.value);
+                    clipboard(value);
+                  }
+                  catch {
+                    clipboard(item.value);
+                  }
+                }
+                else {
+                  clipboard(item.value);
+                }
               }}
               type="button"
               className="absolute left-2 top-1/2 -translate-y-1/2 -translate-x-full opacity-0 group-hover:translate-x-0 group-hover:opacity-100 transition-all duration-200 ease-out bg-background border border-border rounded p-1 shadow-sm z-10"


### PR DESCRIPTION
<img width="506" height="513" alt="image" src="https://github.com/user-attachments/assets/49e5f7b1-9da7-4318-92a1-61e827cb3bb7" />

<img width="419" height="140" alt="image" src="https://github.com/user-attachments/assets/dadf87d7-5ddc-4658-a85c-de9cf061ccd1" />


I'm passing some data to the `identify()` as JSON. When I copy the value it gives me "[object Object]" mainly because the `clipboard(item.value)` is converting the value to string using `value.toString()`.


I suppose we could adjust the code a lil' bit to make it work with object?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copy-to-clipboard functionality in the key-value grid to better handle complex values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->