### PR TITLE
fix(api): update deprecated Claude model and support arbitrary model strings

### DIFF
--- a/apps/api/src/utils/ai.ts
+++ b/apps/api/src/utils/ai.ts
@@ -4,12 +4,19 @@ import { chartTypes, operators, timeWindows } from '@openpanel/constants';
 import { mapKeys } from '@openpanel/validation';
 
 export const getChatModel = () => {
-  switch (process.env.AI_MODEL) {
+  const model = process.env.AI_MODEL;
+  switch (model) {
     case 'gpt-4o':
       return openai('gpt-4o');
-    case 'claude-3-5':
-      return anthropic('claude-3-5-haiku-latest');
+    case 'claude':
+      return anthropic('claude-sonnet-4-20250514');
     default:
+      if (model?.startsWith('claude-')) {
+        return anthropic(model);
+      }
+      if (model?.startsWith('gpt-') || model?.startsWith('o')) {
+        return openai(model);
+      }
       return openai('gpt-4.1-mini');
   }
 };

--- a/apps/public/content/docs/self-hosting/deploy-coolify.mdx
+++ b/apps/public/content/docs/self-hosting/deploy-coolify.mdx
@@ -46,7 +46,7 @@ Coolify will automatically configure most settings, but you may want to customiz
   - `RESEND_API_KEY`: Your Resend API key for email features
   - `EMAIL_SENDER`: Email sender address
   - `OPENAI_API_KEY`: OpenAI API key for AI features (optional)
-  - `AI_MODEL`: AI model to use (`gpt-4o-mini`, `gpt-4o`, or `claude-3-5`)
+  - `AI_MODEL`: AI model to use (`gpt-4o`, `claude`, or any model identifier)
 
 <Callout>
 Coolify automatically handles:

--- a/apps/public/content/docs/self-hosting/deploy-kubernetes.mdx
+++ b/apps/public/content/docs/self-hosting/deploy-kubernetes.mdx
@@ -243,7 +243,7 @@ Enable AI-powered features:
 
 ```yaml
 config:
-  aiModel: "gpt-4o-mini"  # Options: gpt-4o, gpt-4o-mini, claude-3-5
+  aiModel: "gpt-4o-mini"  # Options: gpt-4o, claude, or any model identifier
 
 secrets:
   openaiApiKey: "sk-xxxxxxxxxxxxx"  # For OpenAI models

--- a/apps/public/content/docs/self-hosting/environment-variables.mdx
+++ b/apps/public/content/docs/self-hosting/environment-variables.mdx
@@ -268,7 +268,7 @@ ALLOW_INVITATION=false
 **Required**: No  
 **Default**: `gpt-4.1-mini`
 
-AI model to use for the analytics assistant. Options: `gpt-4o`, `gpt-4o-mini`, `claude-3-5`.
+AI model to use for the analytics assistant. Options: `gpt-4o`, `claude`, or any model identifier (e.g. `claude-sonnet-4-20250514`, `gpt-4.1-mini`). Models prefixed with `claude-` use Anthropic; models prefixed with `gpt-` or `o` use OpenAI.
 
 **Example**:
 ```bash
@@ -294,7 +294,7 @@ OPENAI_API_KEY=sk-your-openai-api-key-here
 **Required**: No (required if using Claude models)  
 **Default**: None
 
-Anthropic API key for Claude AI models. Required if `AI_MODEL` is set to `claude-3-5`.
+Anthropic API key for Claude AI models. Required if `AI_MODEL` is set to `claude` or any `claude-*` model.
 
 **Example**:
 ```bash

--- a/apps/public/content/docs/self-hosting/self-hosting.mdx
+++ b/apps/public/content/docs/self-hosting/self-hosting.mdx
@@ -124,7 +124,8 @@ OpenPanel includes an AI-powered analytics assistant that can help you analyze d
   - `gpt-4o` - More powerful but higher cost
   - `gpt-4o-mini` - Default model, good balance of performance and cost
 - **Anthropic**
-  - `claude-3-5-haiku-latest` - Fast and cost-effective
+  - `claude` - Uses `claude-sonnet-4-20250514` by default
+  - Any `claude-*` model identifier (e.g. `claude-haiku-3-5-20241022`)
 
 #### Configuration
 
@@ -141,7 +142,7 @@ AI_MODEL=gpt-4o-mini  # Optional: defaults to gpt-4o-mini
 
 ```bash title=".env"
 ANTHROPIC_API_KEY=your-anthropic-api-key-here
-AI_MODEL=claude-3-5
+AI_MODEL=claude
 ```
 
 #### Getting API Keys


### PR DESCRIPTION
## Summary

- Replaces the deprecated `claude-3-5` config value with `claude` (defaults to `claude-sonnet-4-20250514`)
- Adds pass-through support for arbitrary model identifiers via `AI_MODEL` env var — models prefixed with `claude-` route to Anthropic, `gpt-`/`o` prefix routes to OpenAI
- Updates all self-hosting docs to reflect the new configuration options

## Issue

Fixes #314

## Changes

- `apps/api/src/utils/ai.ts` — Updated model selection logic to support arbitrary model strings
- `apps/public/content/docs/self-hosting/self-hosting.mdx` — Updated supported models list and example
- `apps/public/content/docs/self-hosting/environment-variables.mdx` — Updated AI_MODEL description
- `apps/public/content/docs/self-hosting/deploy-coolify.mdx` — Updated model options
- `apps/public/content/docs/self-hosting/deploy-kubernetes.mdx` — Updated model options comment

## Migration

Users with `AI_MODEL=claude-3-5` should update to either:
- `AI_MODEL=claude` (uses latest default Claude model)
- `AI_MODEL=claude-sonnet-4-20250514` (or any specific model identifier)

The old `claude-3-5` value will no longer match a named shortcut but will still be passed through to Anthropic since it starts with `claude-`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flexible AI model configuration now supports any model identifier via environment variables, with automatic provider routing based on model prefixes (e.g., `claude-*` for Anthropic, `gpt-*` or `o*` for OpenAI).

* **Documentation**
  * Updated deployment guides to reflect expanded model selection options and updated Anthropic API key requirements for all `claude-*` models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->