### PR TITLE
fix(ai): default series type to event in funnel report tool

### DIFF
--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -76,10 +76,13 @@ export const zChartEventWithType = zChartEvent.extend({
   type: z.literal('event'),
 });
 
-export const zChartEventItem = z.discriminatedUnion('type', [
-  zChartEventWithType,
-  zChartFormula,
-]);
+export const zChartEventItem = z
+  .preprocess((val) => {
+    if (typeof val === 'object' && val !== null && !('type' in val)) {
+      return { ...val, type: 'event' };
+    }
+    return val;
+  }, z.discriminatedUnion('type', [zChartEventWithType, zChartFormula]));
 
 export const zChartBreakdown = z.object({
   id: z.string().optional(),


### PR DESCRIPTION
## Summary
- Adds a `z.preprocess` wrapper around the `zChartEventItem` discriminated union to default `type` to `"event"` when the field is missing
- Prevents Zod `invalid_union_discriminator` errors when the LLM omits the `type` field in series objects during AI chat funnel report generation

## Issue
Fixes #327

## Changes
- `packages/validation/src/index.ts`: Wrapped `zChartEventItem` with `z.preprocess()` that adds `type: "event"` to objects missing the `type` field before discriminated union validation

## Testing
- Ask the AI chat to generate a funnel report
- Verify the tool call succeeds even if the LLM omits `type` in series objects
- Verify that explicitly passing `type: "event"` or `type: "formula"` still works as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced chart event validation to automatically handle inputs without explicit type specifications, reducing validation errors and improving data compatibility for chart operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->