### PR TITLE
feat(ui): add Y-axis with numbers to project overview charts

### DIFF
--- a/apps/start/src/components/projects/project-chart.tsx
+++ b/apps/start/src/components/projects/project-chart.tsx
@@ -16,6 +16,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import { useYAxisProps } from '../report-chart/common/axis';
 
 type ChartDataItem = {
   value: number;
@@ -107,6 +108,7 @@ export function ProjectChart({
 
   const maxValue = Math.max(...data.map((d) => d.value), 0);
   const maxRevenue = Math.max(...data.map((d) => d.revenue), 0);
+  const yAxisProps = useYAxisProps({});
 
   const getColorValue = () => {
     if (color === 'green') return '#16a34a';
@@ -120,7 +122,7 @@ export function ProjectChart({
         <ResponsiveContainer width="100%" height="100%">
           <ComposedChart
             data={chartData}
-            margin={{ top: 10, right: 10, bottom: 10, left: 10 }}
+            margin={{ top: 10, right: 10, bottom: 10, left: 0 }}
             onMouseMove={(e) => {
               setActiveBar(e.activeTooltipIndex ?? -1);
             }}
@@ -132,7 +134,10 @@ export function ProjectChart({
               domain={['dataMin', 'dataMax']}
               hide
             />
-            <YAxis domain={[0, maxValue || 'dataMax']} hide width={0} />
+            <YAxis
+              {...yAxisProps}
+              domain={[0, maxValue || 'dataMax']}
+            />
             <YAxis
               yAxisId="right"
               orientation="right"


### PR DESCRIPTION
## Summary
- Show Y-axis tick labels on project card charts so users can quickly read values without hovering

## Issue
Fixes #326

## Changes
- Import and use the existing `useYAxisProps` hook in `ProjectChart` component
- Replace hidden Y-axis (`hide width={0}`) with visible Y-axis using consistent formatting (short numbers: 1K, 10K, etc.)
- Adjust left margin from 10px to 0px since the Y-axis labels now provide spacing

## Testing
- Navigate to the organization projects overview page (`/:organizationId/`)
- Verify each project card chart now displays Y-axis labels with formatted numbers
- Hover over chart points to confirm tooltip still works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved project chart Y-axis configuration and layout to use a more flexible property system.
  * Adjusted chart margins for better visual spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->