### PR TITLE
feat: add custom days input to time window picker

### DIFF
--- a/apps/start/src/components/time-window-picker.tsx
+++ b/apps/start/src/components/time-window-picker.tsx
@@ -50,8 +50,9 @@ export function TimeWindowPicker({
   const handleCustomDays = useCallback(
     (days: number) => {
       if (days < 1 || days > 365) return;
-      const end = endOfDay(new Date());
-      const start = startOfDay(subDays(new Date(), days - 1));
+      const now = new Date();
+      const end = endOfDay(now);
+      const start = startOfDay(subDays(now, days - 1));
       onStartDateChange(format(start, 'yyyy-MM-dd HH:mm:ss'));
       onEndDateChange(format(end, 'yyyy-MM-dd HH:mm:ss'));
       onChange('custom');
@@ -222,6 +223,7 @@ export function TimeWindowPicker({
           >
             <span className="text-sm whitespace-nowrap">Last</span>
             <Input
+              aria-label="Number of days for custom date filter"
               type="number"
               min={1}
               max={365}
@@ -230,6 +232,7 @@ export function TimeWindowPicker({
               onChange={(e) => setCustomDays(e.target.value)}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {
+                  e.preventDefault();
                   const days = Number.parseInt(customDays, 10);
                   if (days >= 1 && days <= 365) {
                     handleCustomDays(days);

--- a/apps/start/src/components/time-window-picker.tsx
+++ b/apps/start/src/components/time-window-picker.tsx
@@ -227,14 +227,15 @@ export function TimeWindowPicker({
               type="number"
               min={1}
               max={365}
+              step={1}
               placeholder="X"
               value={customDays}
               onChange={(e) => setCustomDays(e.target.value)}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {
                   e.preventDefault();
-                  const days = Number.parseInt(customDays, 10);
-                  if (days >= 1 && days <= 365) {
+                  const days = Number(customDays);
+                  if (Number.isInteger(days) && days >= 1 && days <= 365) {
                     handleCustomDays(days);
                     setCustomDays('');
                   }

--- a/apps/start/src/components/time-window-picker.tsx
+++ b/apps/start/src/components/time-window-picker.tsx
@@ -1,10 +1,9 @@
 import { getDefaultIntervalByDates, timeWindows } from '@openpanel/constants';
 import type { IChartRange, IInterval } from '@openpanel/validation';
 import { bind } from 'bind-event-listener';
-import { endOfDay, format, startOfDay, subDays } from 'date-fns';
+import { addDays, endOfDay, format, startOfDay, subDays } from 'date-fns';
 import { CalendarIcon } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -16,6 +15,7 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { InputEnter } from '@/components/ui/input-enter';
 import { pushModal, useOnPushModal } from '@/modals';
 import { cn } from '@/utils/cn';
 import { shouldIgnoreKeypress } from '@/utils/should-ignore-keypress';
@@ -45,14 +45,18 @@ export function TimeWindowPicker({
     isDateRangerPickerOpen.current = open;
   });
   const timeWindow = timeWindows[value ?? '30d'];
-  const [customDays, setCustomDays] = useState('');
+  const [open, setOpen] = useState(false);
+  const [customDaysKey, setCustomDaysKey] = useState(0);
 
   const handleCustomDays = useCallback(
-    (days: number) => {
-      if (days < 1 || days > 365) return;
+    (raw: string) => {
+      const days = Number(raw);
+      if (!Number.isInteger(days) || days < 1 || days > 365) {
+        return;
+      }
       const now = new Date();
-      const end = endOfDay(now);
       const start = startOfDay(subDays(now, days - 1));
+      const end = startOfDay(addDays(now, 1));
       onStartDateChange(format(start, 'yyyy-MM-dd HH:mm:ss'));
       onEndDateChange(format(end, 'yyyy-MM-dd HH:mm:ss'));
       onChange('custom');
@@ -63,6 +67,8 @@ export function TimeWindowPicker({
       if (interval) {
         onIntervalChange(interval);
       }
+      setCustomDaysKey((k) => k + 1);
+      setOpen(false);
     },
     [onChange, onStartDateChange, onEndDateChange, onIntervalChange]
   );
@@ -105,7 +111,7 @@ export function TimeWindowPicker({
   }, [handleCustom]);
 
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={setOpen} open={open}>
       <DropdownMenuTrigger asChild>
         <Button
           className={cn('justify-start', className)}
@@ -216,36 +222,31 @@ export function TimeWindowPicker({
         <DropdownMenuSeparator />
 
         <DropdownMenuGroup>
+          {/** biome-ignore lint/a11y/noNoninteractiveElementInteractions: none */}
+          {/** biome-ignore lint/a11y/noStaticElementInteractions: none */}
           <div
-            className="flex items-center gap-2 px-2 py-1.5"
+            className="flex items-center gap-4 rounded-sm px-2 py-1.5"
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => e.stopPropagation()}
           >
-            <span className="text-sm whitespace-nowrap">Last</span>
-            <Input
+            <span className="whitespace-nowrap">Last days</span>
+            <InputEnter
               aria-label="Number of days for custom date filter"
-              type="number"
-              min={1}
+              className="h-7 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+              inputMode="numeric"
+              key={customDaysKey}
               max={365}
+              min={1}
+              onChangeValue={handleCustomDays}
+              placeholder="X days"
               step={1}
-              placeholder="X"
-              value={customDays}
-              onChange={(e) => setCustomDays(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault();
-                  const days = Number(customDays);
-                  if (Number.isInteger(days) && days >= 1 && days <= 365) {
-                    handleCustomDays(days);
-                    setCustomDays('');
-                  }
-                }
-                e.stopPropagation();
-              }}
-              className="h-7 w-16 text-center"
+              type="number"
+              value=""
             />
-            <span className="text-sm whitespace-nowrap">days</span>
           </div>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
           <DropdownMenuItem onClick={() => handleCustom()}>
             {timeWindows.custom.label}
             <DropdownMenuShortcut>

--- a/apps/start/src/components/time-window-picker.tsx
+++ b/apps/start/src/components/time-window-picker.tsx
@@ -1,9 +1,10 @@
-import { timeWindows } from '@openpanel/constants';
+import { getDefaultIntervalByDates, timeWindows } from '@openpanel/constants';
 import type { IChartRange, IInterval } from '@openpanel/validation';
 import { bind } from 'bind-event-listener';
-import { endOfDay, format, startOfDay } from 'date-fns';
+import { endOfDay, format, startOfDay, subDays } from 'date-fns';
 import { CalendarIcon } from 'lucide-react';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -44,6 +45,26 @@ export function TimeWindowPicker({
     isDateRangerPickerOpen.current = open;
   });
   const timeWindow = timeWindows[value ?? '30d'];
+  const [customDays, setCustomDays] = useState('');
+
+  const handleCustomDays = useCallback(
+    (days: number) => {
+      if (days < 1 || days > 365) return;
+      const end = endOfDay(new Date());
+      const start = startOfDay(subDays(new Date(), days - 1));
+      onStartDateChange(format(start, 'yyyy-MM-dd HH:mm:ss'));
+      onEndDateChange(format(end, 'yyyy-MM-dd HH:mm:ss'));
+      onChange('custom');
+      const interval = getDefaultIntervalByDates(
+        start.toISOString(),
+        end.toISOString()
+      );
+      if (interval) {
+        onIntervalChange(interval);
+      }
+    },
+    [onChange, onStartDateChange, onEndDateChange, onIntervalChange]
+  );
 
   const handleCustom = useCallback(() => {
     pushModal('DateRangerPicker', {
@@ -194,6 +215,33 @@ export function TimeWindowPicker({
         <DropdownMenuSeparator />
 
         <DropdownMenuGroup>
+          <div
+            className="flex items-center gap-2 px-2 py-1.5"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+          >
+            <span className="text-sm whitespace-nowrap">Last</span>
+            <Input
+              type="number"
+              min={1}
+              max={365}
+              placeholder="X"
+              value={customDays}
+              onChange={(e) => setCustomDays(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  const days = Number.parseInt(customDays, 10);
+                  if (days >= 1 && days <= 365) {
+                    handleCustomDays(days);
+                    setCustomDays('');
+                  }
+                }
+                e.stopPropagation();
+              }}
+              className="h-7 w-16 text-center"
+            />
+            <span className="text-sm whitespace-nowrap">days</span>
+          </div>
           <DropdownMenuItem onClick={() => handleCustom()}>
             {timeWindows.custom.label}
             <DropdownMenuShortcut>

--- a/apps/start/src/components/ui/input-enter.tsx
+++ b/apps/start/src/components/ui/input-enter.tsx
@@ -1,7 +1,7 @@
 import { motion } from 'framer-motion';
 
 import { AnimatePresence } from 'framer-motion';
-import { RefreshCcwIcon } from 'lucide-react';
+import { CornerDownLeftIcon } from 'lucide-react';
 import { type InputHTMLAttributes, useEffect, useState } from 'react';
 import { Badge } from './badge';
 import { Input, type InputProps } from './input';
@@ -51,9 +51,12 @@ export function InputEnter({
               exit={{ opacity: 0, scale: 0.8 }}
               onClick={() => onChangeValue(internalValue)}
             >
-              <Badge variant="secondary">
-                Press enter
-                <RefreshCcwIcon className="ml-1 h-3 w-3" />
+              <Badge
+                variant="secondary"
+                className="gap-1 px-1.5 py-0 text-xs"
+              >
+                Press
+                <CornerDownLeftIcon className="h-3 w-3" />
               </Badge>
             </motion.button>
           )}


### PR DESCRIPTION
## Summary
- Adds a **"Last X days"** input to the time window dropdown (#168)
- Users can type any number (1-365) and press Enter to filter by that many days
- Uses the existing `custom` range mechanism — no backend or constant changes needed
- Single file change: `apps/start/src/components/time-window-picker.tsx`

## How it works
1. Open the time window dropdown
2. At the bottom, there's a "Last [X] days" input
3. Type a number (e.g., 14) and press Enter
4. The dashboard filters to the last 14 days with auto-detected interval

## Implementation details
- Calculates `startOfDay(today - X + 1)` to `endOfDay(today)`
- Uses `getDefaultIntervalByDates()` to auto-select hour/day/month interval
- Input is isolated from dropdown keyboard shortcuts via `stopPropagation`
- Validated: 1-365 days range

## Test plan
- [ ] Open time window dropdown, verify "Last X days" input appears
- [ ] Enter "14" and press Enter — dashboard shows last 14 days
- [ ] Enter "1" — equivalent to "Today"
- [ ] Enter "90" — shows last 90 days with appropriate interval
- [ ] Verify keyboard shortcuts (W, T, etc.) still work when input is not focused
- [ ] Verify typing in the input does not trigger preset shortcuts

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an inline "Last X days" quick-entry to the time window picker (1–365 days). Validates input, applies start/end dates, selects the "custom" window, clears after submission, prevents dropdown propagation while typing, and updates sampling interval when applicable.

* **UI**
  * Updated the animated "enter" prompt: new icon, shorter label ("Press"), and adjusted badge styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->