### PR TITLE
fix: prevent value overflow in KeyValueGrid

### DIFF
--- a/apps/start/src/components/ui/key-value-grid.tsx
+++ b/apps/start/src/components/ui/key-value-grid.tsx
@@ -126,7 +126,7 @@ export function KeyValueGrid({
           </div>
           <div
             className={cn(
-              'text-right text-sm font-mono truncate',
+              'text-right text-sm font-mono truncate min-w-0 max-w-[60%]',
               valueClassName,
             )}
             title={typeof item.value === 'string' ? item.value : undefined}


### PR DESCRIPTION
## Summary
- Fixes long values overflowing into the key column in `KeyValueGrid` (#305)
- Adds `min-w-0` and `max-w-[60%]` to the value container so `truncate` works correctly within the flex layout

## Before
Values that are too long push into the key column, breaking the layout.

## Fix
Single line change in `apps/start/src/components/ui/key-value-grid.tsx`:
- `min-w-0` allows the flex child to shrink below its content size
- `max-w-[60%]` ensures the value never takes more than 60% of the row width
- The existing `truncate` class then clips with ellipsis as expected

## Test plan
- [ ] Navigate to any page using `KeyValueGrid` (event details, session details, profile properties)
- [ ] Verify long values are truncated with ellipsis instead of overflowing
- [ ] Verify short values display normally
- [ ] Hover over truncated values to see full text via the existing `title` attribute

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout constraints and truncation behavior in the key-value grid display for better visual presentation of values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->