### PR TITLE
feat(start): include project name in browser tab title

### DIFF
--- a/apps/start/src/hooks/use-project-document-title.ts
+++ b/apps/start/src/hooks/use-project-document-title.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from 'react';
+
+const BASE_SUFFIX = ' | OpenPanel.dev';
+
+function inject(title: string, projectName: string): string {
+  if (!title.endsWith(BASE_SUFFIX)) return title;
+  if (title.includes(` | ${projectName}${BASE_SUFFIX}`)) return title;
+  return title.replace(BASE_SUFFIX, ` | ${projectName}${BASE_SUFFIX}`);
+}
+
+// Browser tab titles are set by each route's `head()` (server + client).
+// Rather than threading project name through every route's loader/head,
+// we patch the title imperatively on the client whenever it changes —
+// observed via a MutationObserver on <title>. This keeps the change
+// localized to one hook mounted under the project layout.
+export function useProjectDocumentTitle(projectName: string | undefined) {
+  const lastApplied = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!projectName) return;
+
+    const apply = () => {
+      const current = document.title;
+      if (current === lastApplied.current) return;
+      const next = inject(current, projectName);
+      if (next !== current) {
+        document.title = next;
+      }
+      lastApplied.current = document.title;
+    };
+
+    apply();
+
+    // Observe the whole <head> rather than the <title> element directly,
+    // so we still catch updates if React swaps the title node entirely.
+    const observer = new MutationObserver(apply);
+    observer.observe(document.head, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+    return () => observer.disconnect();
+  }, [projectName]);
+}

--- a/apps/start/src/routes/_app.$organizationId.$projectId.tsx
+++ b/apps/start/src/routes/_app.$organizationId.$projectId.tsx
@@ -1,4 +1,5 @@
 import BillingPrompt from '@/components/organization/billing-prompt';
+import { useProjectDocumentTitle } from '@/hooks/use-project-document-title';
 import { useTRPC } from '@/integrations/trpc/react';
 import { PAGE_TITLES, createProjectTitle } from '@/utils/title';
 import { FREE_PRODUCT_IDS } from '@openpanel/payments';
@@ -17,22 +18,33 @@ export const Route = createFileRoute('/_app/$organizationId/$projectId')({
     };
   },
   loader: async ({ context, params }) => {
-    await context.queryClient.prefetchQuery(
-      context.trpc.organization.get.queryOptions({
-        organizationId: params.organizationId,
-      }),
-    );
+    await Promise.all([
+      context.queryClient.prefetchQuery(
+        context.trpc.organization.get.queryOptions({
+          organizationId: params.organizationId,
+        }),
+      ),
+      context.queryClient.prefetchQuery(
+        context.trpc.project.getProjectWithClients.queryOptions({
+          projectId: params.projectId,
+        }),
+      ),
+    ]);
   },
 });
 
 function ProjectDashboard() {
-  const { organizationId } = Route.useParams();
+  const { organizationId, projectId } = Route.useParams();
   const trpc = useTRPC();
   const { data: organization } = useSuspenseQuery(
     trpc.organization.get.queryOptions({
       organizationId,
     }),
   );
+  const { data: project } = useSuspenseQuery(
+    trpc.project.getProjectWithClients.queryOptions({ projectId }),
+  );
+  useProjectDocumentTitle(project?.name);
 
   if (
     organization.subscriptionProductId &&


### PR DESCRIPTION
Closes #177.

## Problem
Every browser tab reads `<Page> | OpenPanel.dev` regardless of which project is open, so users with multiple projects pinned can't tell tabs apart at a glance.

## Approach
The existing `createProjectTitle()` helper in `apps/start/src/utils/title.ts` already accepts an optional `projectName` arg — it just isn't passed by any caller. Threading it through every route's `loader` + `head()` would touch ~30 files.

Instead, this adds a single `useProjectDocumentTitle` hook mounted in the project layout (`_app.$organizationId.$projectId.tsx`) that:

1. Reads the project from the existing tRPC cache (now prefetched in the layout's loader, alongside the organization).
2. Patches `document.title` on the client whenever it changes — observed via a `MutationObserver` on `<head>` so it re-applies after route navigation and when the project query first resolves.

Result on a project named `MyProject`:
- Before: `Dashboard | OpenPanel.dev`
- After: `Dashboard | MyProject | OpenPanel.dev`

SSR title is unchanged — this is purely a browser tab UX improvement.

## Files
- `apps/start/src/hooks/use-project-document-title.ts` — new hook
- `apps/start/src/routes/_app.$organizationId.$projectId.tsx` — prefetch project in loader, mount hook

## Verified

`pnpm --filter start typecheck` — clean.

End-to-end in a real browser against a local stack (Postgres / Redis / ClickHouse via docker-compose, `pnpm dev`, fresh signup → workspace `Acme Inc` → project `MyProject`):

| URL | `document.title` |
| --- | --- |
| `/acme-inc` (org page, outside project context) | `Projects \| Organization \| OpenPanel.dev` (unchanged — hook unmounts) |
| `/acme-inc/myproject` | `Dashboard \| MyProject \| OpenPanel.dev` ✅ |
| `/acme-inc/myproject/realtime` | `Realtime \| MyProject \| OpenPanel.dev` ✅ |
| `/acme-inc/myproject/events` | `Events \| MyProject \| OpenPanel.dev` ✅ |

Confirms (a) project name is injected on every project route, (b) the hook re-applies on intra-project navigation via the `MutationObserver`, and (c) it cleanly falls back outside the project layout.
