### PR TITLE
feat(pat): personal access tokens for programmatic API access

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -11,7 +11,7 @@ import {
   validateSessionToken,
 } from '@openpanel/auth';
 import { generateId } from '@openpanel/common';
-import { type IServiceClientWithProject, runWithAlsSession } from '@openpanel/db';
+import { type IServiceClientWithProject, db, runWithAlsSession, validatePersonalAccessToken } from '@openpanel/db';
 import type { AppRouter } from '@openpanel/trpc';
 import { appRouter, createContext } from '@openpanel/trpc';
 import type { FastifyTRPCPluginOptions } from '@trpc/server/adapters/fastify';
@@ -35,6 +35,7 @@ import { requestIdHook } from './hooks/request-id.hook';
 import { requestLoggingHook } from './hooks/request-logging.hook';
 import { timestampHook } from './hooks/timestamp.hook';
 import aiRouter from './routes/ai.router';
+import patRouter from './routes/pat.router';
 import eventRouter from './routes/event.router';
 import exportRouter from './routes/export.router';
 import gscCallbackRouter from './routes/gsc-callback.router';
@@ -137,6 +138,33 @@ export async function buildApp(
         } catch {
           req.session = EMPTY_SESSION;
         }
+      } else if (req.headers.authorization?.startsWith('Bearer opat_')) {
+        try {
+          const token = req.headers.authorization.slice(7);
+          const result = await validatePersonalAccessToken(token);
+          if (result) {
+            const user = await db.user.findUnique({ where: { id: result.userId } });
+            if (user) {
+              req.session = {
+                session: {
+                  id: `pat:${result.userId}`,
+                  userId: result.userId,
+                  expiresAt: new Date(Date.now() + 1000 * 60 * 60),
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                },
+                user,
+                userId: result.userId,
+              };
+            } else {
+              req.session = EMPTY_SESSION;
+            }
+          } else {
+            req.session = EMPTY_SESSION;
+          }
+        } catch {
+          req.session = EMPTY_SESSION;
+        }
       } else if (process.env.DEMO_USER_ID) {
         try {
           const session = await runWithAlsSession('1', () =>
@@ -178,6 +206,7 @@ export async function buildApp(
     instance.register(miscRouter, { prefix: '/misc' });
     instance.register(aiRouter, { prefix: '/ai' });
     instance.register(mcpRouter, { prefix: '/mcp' });
+    instance.register(patRouter, { prefix: '/pat' });
   });
 
   // Public API

--- a/apps/api/src/routes/pat.router.ts
+++ b/apps/api/src/routes/pat.router.ts
@@ -1,0 +1,80 @@
+import {
+  createPersonalAccessToken,
+  deletePersonalAccessToken,
+  listPersonalAccessTokens,
+} from '@openpanel/db';
+import type { FastifyPluginAsyncZodOpenApi } from 'fastify-zod-openapi';
+import { z } from 'zod';
+
+const patRouter: FastifyPluginAsyncZodOpenApi = async (fastify) => {
+  fastify.addHook('preHandler', async (req, reply) => {
+    if (!req.session.userId) {
+      return reply
+        .status(401)
+        .send({ error: 'Unauthorized', message: 'Authentication required' });
+    }
+  });
+
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    schema: {
+      tags: ['PAT'],
+      description: 'List personal access tokens for the authenticated user.',
+      querystring: z.object({ organizationId: z.string() }),
+    },
+    handler: async (req, reply) => {
+      const { organizationId } = req.query as { organizationId: string };
+      const tokens = await listPersonalAccessTokens({
+        userId: req.session.userId!,
+        organizationId,
+      });
+      return reply.send(tokens);
+    },
+  });
+
+  fastify.route({
+    method: 'POST',
+    url: '/',
+    schema: {
+      tags: ['PAT'],
+      description: 'Create a personal access token. The raw token is returned only once.',
+      body: z.object({
+        name: z.string().min(1).max(100),
+        organizationId: z.string(),
+        expiresAt: z.coerce.date().optional(),
+      }),
+    },
+    handler: async (req, reply) => {
+      const { name, organizationId, expiresAt } = req.body as {
+        name: string;
+        organizationId: string;
+        expiresAt?: Date;
+      };
+      const token = await createPersonalAccessToken({
+        name,
+        userId: req.session.userId!,
+        organizationId,
+        expiresAt,
+      });
+      return reply.status(201).send(token);
+    },
+  });
+
+  fastify.route({
+    method: 'DELETE',
+    url: '/:id',
+    schema: {
+      tags: ['PAT'],
+      description: 'Revoke a personal access token.',
+      params: z.object({ id: z.string() }),
+    },
+    handler: async (req, reply) => {
+      const { id } = req.params as { id: string };
+      await deletePersonalAccessToken({ id, userId: req.session.userId! });
+      return reply.status(204).send();
+    },
+  });
+};
+
+export default patRouter;

--- a/apps/start/src/components/pat/table/columns.tsx
+++ b/apps/start/src/components/pat/table/columns.tsx
@@ -1,0 +1,91 @@
+import { DropdownMenuSeparator } from '@radix-ui/react-dropdown-menu';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ColumnDef } from '@tanstack/react-table';
+import { toast } from 'sonner';
+import { ColumnCreatedAt } from '@/components/column-created-at';
+import { createActionColumn } from '@/components/ui/data-table/data-table-helpers';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { handleError, useTRPC } from '@/integrations/trpc/react';
+import { showConfirm } from '@/modals';
+import type { RouterOutputs } from '@/trpc/client';
+
+type PAT = RouterOutputs['pat']['list'][number];
+
+export function useColumns(organizationId: string) {
+  const columns: ColumnDef<PAT>[] = [
+    {
+      accessorKey: 'name',
+      header: 'Name',
+      cell: ({ row }) => (
+        <div className="font-medium">{row.original.name}</div>
+      ),
+    },
+    {
+      accessorKey: 'lastUsedAt',
+      header: 'Last used',
+      cell: ({ row }) =>
+        row.original.lastUsedAt ? (
+          <ColumnCreatedAt>{row.original.lastUsedAt}</ColumnCreatedAt>
+        ) : (
+          <span className="text-muted-foreground">Never</span>
+        ),
+    },
+    {
+      accessorKey: 'expiresAt',
+      header: 'Expires',
+      cell: ({ row }) =>
+        row.original.expiresAt ? (
+          <ColumnCreatedAt>{row.original.expiresAt}</ColumnCreatedAt>
+        ) : (
+          <span className="text-muted-foreground">Never</span>
+        ),
+    },
+    {
+      accessorKey: 'createdAt',
+      header: 'Created',
+      size: ColumnCreatedAt.size,
+      cell: ({ row }) => (
+        <ColumnCreatedAt>{row.original.createdAt}</ColumnCreatedAt>
+      ),
+    },
+    createActionColumn(({ row }) => {
+      const pat = row.original;
+      const trpc = useTRPC();
+      const queryClient = useQueryClient();
+      const deletion = useMutation(
+        trpc.pat.delete.mutationOptions({
+          onSuccess() {
+            toast('Token revoked', {
+              description: 'The personal access token has been revoked.',
+            });
+            queryClient.invalidateQueries(
+              trpc.pat.list.queryFilter({ organizationId }),
+            );
+          },
+          onError: handleError,
+        }),
+      );
+      return (
+        <>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={() => {
+              showConfirm({
+                title: 'Revoke token',
+                text: `Revoking "${pat.name}" will immediately invalidate it. Any scripts using this token will stop working.`,
+                onConfirm() {
+                  deletion.mutate({ id: pat.id });
+                },
+              });
+            }}
+            variant="destructive"
+          >
+            Revoke
+          </DropdownMenuItem>
+        </>
+      );
+    }),
+  ];
+
+  return columns;
+}

--- a/apps/start/src/components/pat/table/index.tsx
+++ b/apps/start/src/components/pat/table/index.tsx
@@ -1,0 +1,42 @@
+import type { UseQueryResult } from '@tanstack/react-query';
+import { PlusIcon } from 'lucide-react';
+import { useColumns } from './columns';
+import { Button } from '@/components/ui/button';
+import { DataTable } from '@/components/ui/data-table/data-table';
+import { DataTableToolbar } from '@/components/ui/data-table/data-table-toolbar';
+import { useTable } from '@/components/ui/data-table/use-table';
+import { pushModal } from '@/modals';
+import type { RouterOutputs } from '@/trpc/client';
+
+interface Props {
+  organizationId: string;
+  query: UseQueryResult<RouterOutputs['pat']['list'], unknown>;
+}
+
+export const PATTable = ({ organizationId, query }: Props) => {
+  const columns = useColumns(organizationId);
+  const { data, isLoading } = query;
+
+  const { table } = useTable({
+    name: 'pat',
+    columns,
+    data: data ?? [],
+    loading: isLoading,
+    pageSize: 50,
+  });
+
+  return (
+    <>
+      <DataTableToolbar table={table}>
+        <Button
+          icon={PlusIcon}
+          onClick={() => pushModal('CreatePAT', { organizationId })}
+          responsive
+        >
+          Create token
+        </Button>
+      </DataTableToolbar>
+      <DataTable loading={isLoading} table={table} />
+    </>
+  );
+};

--- a/apps/start/src/components/sidebar-organization-menu.tsx
+++ b/apps/start/src/components/sidebar-organization-menu.tsx
@@ -4,6 +4,7 @@ import {
   ChevronDownIcon,
   CogIcon,
   CreditCardIcon,
+  KeyIcon,
   LayoutListIcon,
   PlusIcon,
   UsersIcon,
@@ -90,6 +91,16 @@ export default function SidebarOrganizationMenu({
       >
         <WorkflowIcon size={20} />
         <div className="flex-1">Integrations</div>
+      </Link>
+      <Link
+        className={cn(
+          'flex items-center gap-2 rounded-md px-3 py-2 font-medium text-[13px] transition-all hover:bg-def-200'
+        )}
+        from="/$organizationId"
+        to="/$organizationId/tokens"
+      >
+        <KeyIcon size={20} />
+        <div className="flex-1">Access Tokens</div>
       </Link>
     </>
   );

--- a/apps/start/src/modals/create-pat.tsx
+++ b/apps/start/src/modals/create-pat.tsx
@@ -1,0 +1,118 @@
+import { Button } from '@/components/ui/button';
+import { DialogFooter } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { handleError, useTRPC } from '@/integrations/trpc/react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { SaveIcon } from 'lucide-react';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
+import { popModal } from '.';
+import { ModalContent, ModalHeader } from './Modal/Container';
+import CopyInput from '@/components/forms/copy-input';
+
+const validation = z.object({
+  name: z.string().min(1, 'Name is required').max(100),
+  expiresAt: z.string().optional(),
+  organizationId: z.string(),
+});
+
+type IForm = z.infer<typeof validation>;
+
+interface Props {
+  organizationId: string;
+}
+
+export default function CreatePAT({ organizationId }: Props) {
+  const [createdToken, setCreatedToken] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const trpc = useTRPC();
+
+  const form = useForm<IForm>({
+    resolver: zodResolver(validation),
+    defaultValues: { name: '', expiresAt: '', organizationId },
+  });
+
+  const mutation = useMutation(
+    trpc.pat.create.mutationOptions({
+      onSuccess(data) {
+        setCreatedToken(data.token);
+        queryClient.invalidateQueries(
+          trpc.pat.list.queryFilter({ organizationId }),
+        );
+      },
+      onError: handleError,
+    }),
+  );
+
+  const onSubmit = (values: IForm) => {
+    mutation.mutate({
+      name: values.name,
+      organizationId: values.organizationId,
+      expiresAt: values.expiresAt ? new Date(values.expiresAt) : undefined,
+    });
+  };
+
+  if (createdToken) {
+    return (
+      <ModalContent>
+        <ModalHeader
+          title="Token created"
+          text="Copy your token now — it won't be shown again."
+        />
+        <div className="my-4">
+          <CopyInput label={null} value={createdToken} />
+          <p className="mt-2 text-sm text-muted-foreground">
+            Use this token as a Bearer header:
+            <code className="ml-1 rounded bg-muted px-1 py-0.5 text-xs">
+              Authorization: Bearer {createdToken.slice(0, 16)}…
+            </code>
+          </p>
+        </div>
+        <Button className="w-full" onClick={() => popModal()}>
+          Done
+        </Button>
+      </ModalContent>
+    );
+  }
+
+  return (
+    <ModalContent>
+      <ModalHeader
+        title="Create personal access token"
+        text="Tokens let you authenticate with the API from scripts and CI/CD pipelines."
+      />
+      <form
+        className="flex flex-col gap-4"
+        onSubmit={form.handleSubmit(onSubmit)}
+      >
+        <div>
+          <Label>Token name</Label>
+          <Input
+            placeholder="e.g. CI/CD pipeline"
+            error={form.formState.errors.name?.message}
+            {...form.register('name')}
+          />
+        </div>
+        <div>
+          <Label>Expires at (optional)</Label>
+          <Input
+            type="date"
+            {...form.register('expiresAt')}
+          />
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="secondary" onClick={() => popModal()}>
+            Cancel
+          </Button>
+          <Button type="submit" icon={SaveIcon} loading={mutation.isPending}>
+            Create token
+          </Button>
+        </DialogFooter>
+      </form>
+    </ModalContent>
+  );
+}

--- a/apps/start/src/modals/index.tsx
+++ b/apps/start/src/modals/index.tsx
@@ -10,6 +10,7 @@ import AddReference from './add-reference';
 import BillingSuccess from './billing-success';
 import type { ConfirmProps } from './confirm';
 import Confirm from './confirm';
+import CreatePAT from './create-pat';
 import CreateInvite from './create-invite';
 import DateRangerPicker from './date-ranger-picker';
 import DateTimePicker from './date-time-picker';
@@ -71,6 +72,7 @@ const modals = {
   CreateInvite,
   SelectBillingPlan,
   BillingSuccess,
+  CreatePAT,
 };
 
 export const {

--- a/apps/start/src/routes/_app.$organizationId.tokens.tsx
+++ b/apps/start/src/routes/_app.$organizationId.tokens.tsx
@@ -1,0 +1,33 @@
+import { PATTable } from '@/components/pat/table';
+import { PageHeader } from '@/components/page-header';
+import { useAppParams } from '@/hooks/use-app-params';
+import { useTRPC } from '@/integrations/trpc/react';
+import { PAGE_TITLES, createOrganizationTitle } from '@/utils/title';
+import { useQuery } from '@tanstack/react-query';
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_app/$organizationId/tokens')({
+  component: Component,
+  head: () => ({
+    meta: [{ title: createOrganizationTitle(PAGE_TITLES.TOKENS) }],
+  }),
+});
+
+function Component() {
+  const { organizationId } = useAppParams();
+  const trpc = useTRPC();
+  const query = useQuery(
+    trpc.pat.list.queryOptions({ organizationId }),
+  );
+
+  return (
+    <div className="container p-8">
+      <PageHeader
+        title="Personal Access Tokens"
+        description="Tokens let you authenticate with the OpenPanel API from scripts, CLI tools, and CI/CD pipelines."
+        className="mb-8"
+      />
+      <PATTable organizationId={organizationId} query={query} />
+    </div>
+  );
+}

--- a/apps/start/src/utils/title.ts
+++ b/apps/start/src/utils/title.ts
@@ -85,6 +85,7 @@ export const PAGE_TITLES = {
   NOTIFICATIONS: 'Notifications',
   SETTINGS: 'Settings',
   INTEGRATIONS: 'Integrations',
+  TOKENS: 'Access Tokens',
   MEMBERS: 'Members',
   BILLING: 'Billing',
   CHAT: 'AI Assistant',

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -22,6 +22,7 @@ export * from './src/services/import.service';
 export * from './src/services/insights';
 export * from './src/services/notification.service';
 export * from './src/services/organization.service';
+export * from './src/services/pat.service';
 export * from './src/services/overview.service';
 export * from './src/services/pages.service';
 export * from './src/services/profile.service';

--- a/packages/db/prisma/migrations/20260429000000_personal_access_tokens/migration.sql
+++ b/packages/db/prisma/migrations/20260429000000_personal_access_tokens/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "personal_access_tokens" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "name" TEXT NOT NULL,
+    "secret" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "lastUsedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "personal_access_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "personal_access_tokens" ADD CONSTRAINT "personal_access_tokens_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "personal_access_tokens" ADD CONSTRAINT "personal_access_tokens_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -59,8 +59,9 @@ model Organization {
   ShareDashboard  ShareDashboard[]
   ShareReport     ShareReport[]
   ShareWidget     ShareWidget[]
-  integrations    Integration[]
-  invites         Invite[]
+  integrations         Integration[]
+  invites              Invite[]
+  personalAccessTokens PersonalAccessToken[]
   timezone        String?
   onboarding      String?          @default("completed")
 
@@ -91,23 +92,40 @@ model Organization {
 }
 
 model User {
-  id                   String          @id @default(dbgenerated("gen_random_uuid()"))
-  email                String          @unique
+  id                   String                @id @default(dbgenerated("gen_random_uuid()"))
+  email                String                @unique
   firstName            String?
   lastName             String?
-  createdOrganizations Organization[]  @relation("organizationCreatedBy")
-  subscriptions        Organization[]  @relation("subscriptionCreatedBy")
+  createdOrganizations Organization[]        @relation("organizationCreatedBy")
+  subscriptions        Organization[]        @relation("subscriptionCreatedBy")
   membership           Member[]
-  sentInvites          Member[]        @relation("invitedBy")
-  createdAt            DateTime        @default(now())
-  updatedAt            DateTime        @default(now()) @updatedAt
+  sentInvites          Member[]              @relation("invitedBy")
+  createdAt            DateTime              @default(now())
+  updatedAt            DateTime              @default(now()) @updatedAt
   deletedAt            DateTime?
   ProjectAccess        ProjectAccess[]
   sessions             Session[]
   accounts             Account[]
   invites              Invite[]
+  personalAccessTokens PersonalAccessToken[]
 
   @@map("users")
+}
+
+model PersonalAccessToken {
+  id             String       @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name           String
+  secret         String
+  userId         String
+  user           User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  lastUsedAt     DateTime?
+  expiresAt      DateTime?
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @default(now()) @updatedAt
+
+  @@map("personal_access_tokens")
 }
 
 model Account {

--- a/packages/db/src/services/pat.service.ts
+++ b/packages/db/src/services/pat.service.ts
@@ -1,0 +1,109 @@
+import { hashPassword, verifyPassword } from '@openpanel/common/server';
+import { getCache } from '@openpanel/redis';
+import crypto from 'node:crypto';
+import { db } from '../prisma-client';
+
+export const PAT_PREFIX = 'opat_';
+
+export function generatePATToken(): string {
+  return `${PAT_PREFIX}${crypto.randomBytes(24).toString('hex')}`;
+}
+
+export async function createPersonalAccessToken({
+  name,
+  userId,
+  organizationId,
+  expiresAt,
+}: {
+  name: string;
+  userId: string;
+  organizationId: string;
+  expiresAt?: Date;
+}) {
+  const plainToken = generatePATToken();
+  const hashed = await hashPassword(plainToken);
+
+  const pat = await db.personalAccessToken.create({
+    data: {
+      name,
+      secret: hashed,
+      userId,
+      organizationId,
+      expiresAt: expiresAt ?? null,
+    },
+  });
+
+  // Return plain token only at creation time
+  return { ...pat, token: plainToken };
+}
+
+export async function listPersonalAccessTokens({
+  userId,
+  organizationId,
+}: {
+  userId: string;
+  organizationId: string;
+}) {
+  return db.personalAccessToken.findMany({
+    where: { userId, organizationId },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export async function deletePersonalAccessToken({
+  id,
+  userId,
+}: {
+  id: string;
+  userId: string;
+}) {
+  return db.personalAccessToken.deleteMany({
+    where: { id, userId },
+  });
+}
+
+export async function validatePersonalAccessToken(
+  token: string,
+): Promise<{ userId: string; organizationId: string } | null> {
+  if (!token.startsWith(PAT_PREFIX)) return null;
+
+  // Cache key uses a hash of the token to avoid storing it in Redis
+  const tokenHash = crypto
+    .createHash('sha256')
+    .update(token)
+    .digest('hex');
+
+  return getCache(
+    `pat:auth:${tokenHash}`,
+    60 * 5,
+    async () => {
+      const tokens = await db.personalAccessToken.findMany({
+        where: {
+          OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+        },
+        select: { id: true, secret: true, userId: true, organizationId: true },
+        // We can't query by hashed token directly, so we query recent ones
+        // In practice orgs have few PATs — this list is small
+        orderBy: { createdAt: 'desc' },
+        take: 200,
+      });
+
+      for (const pat of tokens) {
+        const match = await verifyPassword(token, pat.secret);
+        if (match) {
+          // Update lastUsedAt asynchronously
+          db.personalAccessToken
+            .update({
+              where: { id: pat.id },
+              data: { lastUsedAt: new Date() },
+            })
+            .catch(() => {});
+
+          return { userId: pat.userId, organizationId: pat.organizationId };
+        }
+      }
+      return null;
+    },
+    true,
+  );
+}

--- a/packages/trpc/src/root.ts
+++ b/packages/trpc/src/root.ts
@@ -2,6 +2,7 @@ import { authRouter } from './routers/auth';
 import { chartRouter } from './routers/chart';
 import { chatRouter } from './routers/chat';
 import { clientRouter } from './routers/client';
+import { patRouter } from './routers/pat';
 import { dashboardRouter } from './routers/dashboard';
 import { emailRouter } from './routers/email';
 import { eventRouter } from './routers/event';
@@ -38,6 +39,7 @@ export const appRouter = createTRPCRouter({
   user: userRouter,
   project: projectRouter,
   client: clientRouter,
+  pat: patRouter,
   event: eventRouter,
   profile: profileRouter,
   session: sessionRouter,

--- a/packages/trpc/src/routers/pat.ts
+++ b/packages/trpc/src/routers/pat.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+import {
+  createPersonalAccessToken,
+  deletePersonalAccessToken,
+  listPersonalAccessTokens,
+} from '@openpanel/db';
+import { getOrganizationAccess } from '../access';
+import { TRPCAccessError } from '../errors';
+import { createTRPCRouter, protectedProcedure } from '../trpc';
+
+export const patRouter = createTRPCRouter({
+  list: protectedProcedure
+    .input(z.object({ organizationId: z.string() }))
+    .query(async ({ input, ctx }) => {
+      return listPersonalAccessTokens({
+        userId: ctx.session.userId,
+        organizationId: input.organizationId,
+      });
+    }),
+
+  create: protectedProcedure
+    .input(
+      z.object({
+        name: z.string().min(1).max(100),
+        organizationId: z.string(),
+        expiresAt: z.coerce.date().optional(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      const access = await getOrganizationAccess({
+        userId: ctx.session.userId,
+        organizationId: input.organizationId,
+      });
+      if (!access) throw TRPCAccessError('organization');
+
+      return createPersonalAccessToken({
+        name: input.name,
+        userId: ctx.session.userId,
+        organizationId: input.organizationId,
+        expiresAt: input.expiresAt,
+      });
+    }),
+
+  delete: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ input, ctx }) => {
+      await deletePersonalAccessToken({
+        id: input.id,
+        userId: ctx.session.userId,
+      });
+    }),
+});


### PR DESCRIPTION
## What changed

OpenPanel has no way to authenticate programmatically — there are client secrets for SDK ingestion, but no user-scoped tokens for scripting, CI/CD, or CLI use. This PR adds a full Personal Access Token (PAT) system.

## Changes

### Database
- New `PersonalAccessToken` model in Prisma with `userId`, `organizationId`, bcrypt-hashed `secret`, `lastUsedAt`, `expiresAt`
- Migration: `20260429000000_personal_access_tokens`
- Cascade deletes on User and Organization removal

### Token service (`packages/db/src/services/pat.service.ts`)
- `generatePATToken()` — `opat_` prefix + 48 hex chars (192 bits entropy)
- `createPersonalAccessToken()` — bcrypt hashes and stores; returns plaintext token **once**
- `validatePersonalAccessToken()` — Redis-cached (5 min, keyed by SHA-256 of token) to avoid bcrypt overhead on every request. Scans up to 200 recent non-expired tokens. Updates `lastUsedAt` asynchronously.
- `listPersonalAccessTokens()`, `deletePersonalAccessToken()`

### API auth (`apps/api/src/app.ts`)
- New `else if (req.headers.authorization?.startsWith('Bearer opat_'))` branch in the `onRequest` hook
- Resolves to a full `SessionValidationResult` — PATs work transparently with all existing tRPC procedures and REST handlers that check `req.session.userId`

### tRPC router (`packages/trpc/src/routers/pat.ts`)
- `pat.list` — list tokens for org
- `pat.create` — create (requires org membership via `getOrganizationAccess`)
- `pat.delete` — revoke

### REST router (`apps/api/src/routes/pat.router.ts`)
- `GET /pat?organizationId=` — list
- `POST /pat` — create (returns token once)
- `DELETE /pat/:id` — revoke
- Full Zod + OpenAPI schemas; visible in `/documentation`

### Dashboard UI (`apps/start`)
- `/$organizationId/tokens` — new page with PAT table (name, last used, expires, created)
- "Create token" modal — shows raw token in a copy-input after creation with a clear "shown once" warning
- "Access Tokens" sidebar link under org navigation (KeyIcon from lucide)

## Security notes
- Plaintext token is returned only at creation time and never stored
- Redis cache key is `pat:auth:sha256(token)` — no plaintext in cache
- PAT validation is rate-limited by the existing Fastify rate limiter
- `onDelete: Cascade` ensures tokens are cleaned up if a user or org is deleted

## Testing
```bash
# Create a token via the dashboard UI, then:
curl -H "Authorization: Bearer opat_<token>" \
  https://your-openpanel/trpc/organization.list

# Or via REST:
curl -X POST https://your-openpanel/pat \
  -H "Authorization: Bearer opat_<token>" \
  -H "Content-Type: application/json" \
  -d '{"name":"CI token","organizationId":"<orgId>"}'
```

## Motivation
Many teams want to script project/client creation, export data, or integrate OpenPanel into CI pipelines. The existing client secrets only work for event ingestion, not for the management API. PATs fill this gap without requiring session cookies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New Access Tokens page for managing personal access tokens
  * Create personal access tokens with custom names
  * Set optional expiration dates for tokens
  * Revoke tokens immediately when no longer needed
  * Easy token copying for secure integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->