### PR TITLE
fix: don't shutdown api/worker on unhandledRejection

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -27,9 +27,14 @@ const startServer = async () => {
         logger.error({ err: error }, 'Uncaught exception');
         await shutdown(fastify, 'uncaughtException', 1);
       });
-      process.on('unhandledRejection', async (reason, promise) => {
+      // Log-only on unhandledRejection. Calling shutdown() here takes the
+      // API down on transient upstream errors (e.g. Postgres or ClickHouse
+      // ECONNRESET under load), and depending on the container init the
+      // process exit may not propagate to a restart — leaving the service
+      // hard-down. Healthchecks + orchestrator restart policies are the
+      // right place to detect genuine bad state. See #271.
+      process.on('unhandledRejection', (reason, promise) => {
         logger.error({ reason, promise }, 'Unhandled rejection');
-        await shutdown(fastify, 'unhandledRejection', 1);
       });
     }
 

--- a/apps/worker/src/boot-workers.ts
+++ b/apps/worker/src/boot-workers.ts
@@ -380,14 +380,21 @@ export function bootWorkers() {
     process.exit(exitCode);
   }
 
-  ['uncaughtException', 'unhandledRejection', 'SIGTERM', 'SIGINT'].forEach(
-    (evt) => {
-      process.on(evt, (code) => {
-        setShuttingDown(true);
-        exitHandler(evt, code);
-      });
-    }
-  );
+  ['uncaughtException', 'SIGTERM', 'SIGINT'].forEach((evt) => {
+    process.on(evt, (code) => {
+      setShuttingDown(true);
+      exitHandler(evt, code);
+    });
+  });
+
+  // Log-only on unhandledRejection. Mirror of the API fix: transient
+  // upstream errors (ClickHouse / Postgres / Redis ECONNRESET) should not
+  // exit the worker process, since the process exit may not propagate to
+  // a restart depending on container init, leaving workers hard-down.
+  // Healthchecks + orchestrator restart policies cover genuine failures.
+  process.on('unhandledRejection', (reason, promise) => {
+    logger.error({ reason, promise }, 'Unhandled rejection');
+  });
 
   return workers;
 }


### PR DESCRIPTION
## Summary

`unhandledRejection` currently routes through `shutdown()` (api) /
`exitHandler()` (worker) and exits the process. On transient upstream
errors (e.g. Postgres / ClickHouse / Redis `ECONNRESET` under load), the
process exit may not propagate to a container restart depending on the
container init layer — leaving the service hard-down with no unhealthy
signal for autoheal / orchestrator restart policies to act on.

This was reported in #271 (closed as not-reproducible). I reproduced it
in a self-hosted deployment: ClickHouse-induced `ECONNRESET` triggered
`shutdown()`, Node exited, but the pnpm-wrapped container kept
reporting "running" → ~48h outage before manual intervention.

## Change

Decouple `unhandledRejection` from `shutdown()` / `exitHandler()`:
- Log the rejection
- Keep the process alive
- Let healthchecks + orchestrator restart policies handle genuine bad
  state

`uncaughtException`, `SIGTERM`, `SIGINT` keep their current behaviour.
(Sync errors via `uncaughtException` may imply corrupt state, so
exiting is still defensible there.)

## Tradeoff

Standard Node.js best-practice tradeoff: rare risk of operating with
"dirty" promise state after a rejection, vs frequent risk of transient
errors taking the service down. For a long-running service that
processes events best-effort, log-and-continue is the safer default.

## Test

- Tested in a self-hosted deployment with this patch applied for ~12h:
  no API / worker exits observed under intermittent upstream errors that
  previously triggered shutdown.
- No new automated test added (would require simulating an unhandled
  rejection in the running process). Happy to add one if you'd prefer.

Fixes #271.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to prevent unnecessary service restarts. Unhandled promise rejections from transient network or upstream errors no longer trigger system shutdown, allowing services to remain available during brief connectivity disruptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Openpanel-dev/openpanel/pull/367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->