### PR TITLE
feat(manage): opt-in OIDC admin auth + Organization CRUD endpoints

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -48,6 +48,7 @@
     "fastify-raw-body": "^5.0.0",
     "fastify-zod-openapi": "^5.6.1",
     "groupmq": "catalog:",
+    "jose": "^6.2.3",
     "jsonwebtoken": "^9.0.2",
     "pino": "catalog:",
     "pino-pretty": "catalog:",

--- a/apps/api/src/controllers/manage.controller.ts
+++ b/apps/api/src/controllers/manage.controller.ts
@@ -12,6 +12,16 @@ import { z } from 'zod';
 import { HttpError } from '@/utils/errors';
 
 // Validation schemas (exported for use in router)
+export const zCreateOrganization = z.object({
+  name: z.string().min(1),
+  timezone: z.string().optional(),
+});
+
+export const zUpdateOrganization = z.object({
+  name: z.string().min(1).optional(),
+  timezone: z.string().optional(),
+});
+
 export const zCreateProject = z.object({
   name: z.string().min(1),
   domain: z.string().url().or(z.literal('')).or(z.null()).optional(),
@@ -235,6 +245,119 @@ export async function deleteProject(
 
   await getProjectByIdCached.clear(request.params.id);
 
+  reply.send({ success: true });
+}
+
+// ---------------------------------------------------------------------
+// Organizations CRUD
+//
+// Available to /manage callers authenticated via OIDC JWT
+// (`platform-admin`-class roles, see apps/api/src/utils/auth.ts) and to
+// root-Client callers for read/update/delete of their own organization.
+// Creating *new* organizations is realistically only useful to a
+// platform-admin caller — root Clients are scoped to one org and can't
+// create siblings — but the endpoint doesn't enforce that gate; it
+// trusts that whoever has admin auth is permitted by the operator.
+// ---------------------------------------------------------------------
+
+export async function listOrganizations(
+  request: FastifyRequest,
+  reply: FastifyReply
+) {
+  // For now, callers see only the org their auth scope is bound to.
+  // A platform-admin JWT scoped at the instance level would warrant
+  // returning every Organization, but that requires a richer claim
+  // model than v1 ships with.
+  const org = await db.organization.findFirst({
+    where: { id: request.client!.organizationId },
+  });
+  reply.send({ data: org ? [org] : [] });
+}
+
+export async function getOrganization(
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) {
+  const org = await db.organization.findFirst({
+    where: {
+      id: request.params.id,
+      // Same-org scoping. JWT-auth callers can only `get` the org
+      // their claim is bound to; cross-org reads require additional
+      // claim plumbing we haven't designed yet.
+      ...(request.client!.organizationId
+        ? { id: request.client!.organizationId }
+        : {}),
+    },
+  });
+  if (!org) {
+    throw new HttpError('Organization not found', { status: 404 });
+  }
+  reply.send({ data: org });
+}
+
+export async function createOrganization(
+  request: FastifyRequest<{ Body: z.infer<typeof zCreateOrganization> }>,
+  reply: FastifyReply
+) {
+  const { name, timezone } = request.body;
+
+  // No createdByUserId on this code path — Organization.createdByUserId
+  // is nullable and the relation is SetNull on delete. JWT-auth admins
+  // and root Clients are not Users; we leave the field unset so the
+  // newly-created Org has no human owner.
+  const org = await db.organization.create({
+    data: {
+      id: await getId('organization', name),
+      name,
+      timezone: timezone ?? null,
+      onboarding: 'completed',
+    },
+  });
+
+  reply.send({ data: org });
+}
+
+export async function updateOrganization(
+  request: FastifyRequest<{
+    Params: { id: string };
+    Body: z.infer<typeof zUpdateOrganization>;
+  }>,
+  reply: FastifyReply
+) {
+  const existing = await db.organization.findFirst({
+    where: { id: request.params.id },
+  });
+  if (!existing) {
+    throw new HttpError('Organization not found', { status: 404 });
+  }
+
+  const data: { name?: string; timezone?: string | null } = {};
+  if (request.body.name !== undefined) data.name = request.body.name;
+  if (request.body.timezone !== undefined) {
+    data.timezone = request.body.timezone;
+  }
+
+  const org = await db.organization.update({
+    where: { id: request.params.id },
+    data,
+  });
+  reply.send({ data: org });
+}
+
+export async function deleteOrganization(
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) {
+  const existing = await db.organization.findFirst({
+    where: { id: request.params.id },
+  });
+  if (!existing) {
+    throw new HttpError('Organization not found', { status: 404 });
+  }
+
+  await db.organization.delete({
+    where: { id: request.params.id },
+  });
   reply.send({ success: true });
 }
 

--- a/apps/api/src/routes/manage.router.ts
+++ b/apps/api/src/routes/manage.router.ts
@@ -6,9 +6,11 @@ import * as controller from '@/controllers/manage.controller';
 import { listDashboards, listReports } from '@/controllers/insights.controller';
 import {
   zCreateClient,
+  zCreateOrganization,
   zCreateProject,
   zCreateReference,
   zUpdateClient,
+  zUpdateOrganization,
   zUpdateProject,
   zUpdateReference,
 } from '@/controllers/manage.controller';
@@ -62,6 +64,42 @@ const manageRouter: FastifyPluginAsyncZodOpenApi = async (fastify) => {
         return reply.status(403).send({ error: 'Forbidden', message: 'Project does not belong to your organization' });
       }
     }
+  });
+
+  // Organizations routes
+  fastify.route({
+    method: 'GET',
+    url: '/organizations',
+    schema: { tags: ['Manage'], description: 'List organizations the caller has access to.' },
+    handler: controller.listOrganizations,
+  });
+
+  fastify.route({
+    method: 'GET',
+    url: '/organizations/:id',
+    schema: { params: idParam, tags: ['Manage'], description: 'Get an organization by ID.' },
+    handler: controller.getOrganization,
+  });
+
+  fastify.route({
+    method: 'POST',
+    url: '/organizations',
+    schema: { body: zCreateOrganization, tags: ['Manage'], description: 'Create a new organization. Typically called by platform-admin OIDC-authenticated callers.' },
+    handler: controller.createOrganization,
+  });
+
+  fastify.route({
+    method: 'PATCH',
+    url: '/organizations/:id',
+    schema: { params: idParam, body: zUpdateOrganization, tags: ['Manage'], description: 'Update an organization (name, timezone).' },
+    handler: controller.updateOrganization,
+  });
+
+  fastify.route({
+    method: 'DELETE',
+    url: '/organizations/:id',
+    schema: { params: idParam, tags: ['Manage'], description: 'Delete an organization and cascade its projects, clients, and members.' },
+    handler: controller.deleteOrganization,
   });
 
   // Projects routes

--- a/apps/api/src/routes/manage.router.ts
+++ b/apps/api/src/routes/manage.router.ts
@@ -12,7 +12,7 @@ import {
   zUpdateProject,
   zUpdateReference,
 } from '@/controllers/manage.controller';
-import { validateManageRequest } from '@/utils/auth';
+import { validateAdminRequest } from '@/utils/auth';
 import { activateRateLimiter } from '@/utils/rate-limiter';
 
 const idParam = z.object({ id: z.string() });
@@ -26,7 +26,7 @@ const manageRouter: FastifyPluginAsyncZodOpenApi = async (fastify) => {
 
   fastify.addHook('preHandler', async (req: FastifyRequest, reply) => {
     try {
-      const client = await validateManageRequest(req.headers);
+      const client = await validateAdminRequest(req.headers);
       req.client = client;
     } catch (e) {
       if (e instanceof Prisma.PrismaClientKnownRequestError) {

--- a/apps/api/src/utils/auth.ts
+++ b/apps/api/src/utils/auth.ts
@@ -9,6 +9,7 @@ import type {
   ITrackHandlerPayload,
 } from '@openpanel/validation';
 import type { FastifyRequest, RawRequestDefaultExpression } from 'fastify';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
 import { path } from 'ramda';
 
 const cleanDomain = (domain: string) =>
@@ -276,4 +277,202 @@ export async function validateManageRequest(
   }
 
   return client;
+}
+
+// ---------------------------------------------------------------------
+// Admin-auth via OIDC JWT (opt-in)
+//
+// When `ADMIN_OIDC_ISSUER` is configured, /manage routes accept an
+// `Authorization: Bearer <jwt>` header in addition to the existing
+// `openpanel-client-id` / `openpanel-client-secret` Client-pair auth.
+//
+// The JWT is validated against the issuer's JWKS (discovered via the
+// standard `/.well-known/openid-configuration` document). The token
+// must carry the configured audience and a role claim that matches
+// `ADMIN_OIDC_REQUIRED_ROLE` (defaults to `openpanel:admin`).
+//
+// Returns a synthesized Client-shaped record so the manage routes can
+// scope authorization by `organizationId` without branching on auth
+// source. `type` is `root` so existing controllers honor the
+// permission model unchanged.
+// ---------------------------------------------------------------------
+
+const DEFAULT_REQUIRED_ROLE = 'openpanel:admin';
+
+// Cache the resolved JWKS endpoint between requests so we hit the
+// discovery doc once per process start.
+let jwksCache:
+  | {
+      issuer: string;
+      audience: string | undefined;
+      jwks: ReturnType<typeof createRemoteJWKSet>;
+    }
+  | undefined;
+
+interface AdminOidcConfig {
+  issuer: string;
+  audience: string | undefined;
+  requiredRole: string;
+  orgClaim: string;
+}
+
+function loadAdminOidcConfig(): AdminOidcConfig | undefined {
+  const issuer = process.env.ADMIN_OIDC_ISSUER;
+  if (!issuer) {
+    return undefined;
+  }
+  return {
+    issuer: issuer.replace(/\/$/, ''),
+    audience: process.env.ADMIN_OIDC_AUDIENCE,
+    requiredRole: process.env.ADMIN_OIDC_REQUIRED_ROLE ?? DEFAULT_REQUIRED_ROLE,
+    // Zitadel emits the user's home Org under
+    // `urn:zitadel:iam:user:resourceowner:id`; Keycloak / generic IdPs
+    // typically use a custom claim such as `organization_id`. Operators
+    // can override here.
+    orgClaim:
+      process.env.ADMIN_OIDC_ORG_CLAIM ??
+      'urn:zitadel:iam:user:resourceowner:id',
+  };
+}
+
+export function isAdminJwtAuthEnabled(): boolean {
+  return loadAdminOidcConfig() !== undefined;
+}
+
+async function getJwks(config: AdminOidcConfig) {
+  if (
+    jwksCache &&
+    jwksCache.issuer === config.issuer &&
+    jwksCache.audience === config.audience
+  ) {
+    return jwksCache.jwks;
+  }
+  const discoveryUrl = new URL(
+    '/.well-known/openid-configuration',
+    config.issuer,
+  );
+  const discoveryRes = await fetch(discoveryUrl);
+  if (!discoveryRes.ok) {
+    throw new Error(
+      `Admin OIDC: discovery fetch failed (${discoveryRes.status}) for ${discoveryUrl}`,
+    );
+  }
+  const discovery = (await discoveryRes.json()) as { jwks_uri?: string };
+  if (!discovery.jwks_uri) {
+    throw new Error('Admin OIDC: discovery doc missing jwks_uri');
+  }
+  const jwks = createRemoteJWKSet(new URL(discovery.jwks_uri), {
+    cooldownDuration: 60_000,
+    cacheMaxAge: 10 * 60_000,
+  });
+  jwksCache = { issuer: config.issuer, audience: config.audience, jwks };
+  return jwks;
+}
+
+function extractBearer(headers: RawRequestDefaultExpression['headers']) {
+  const auth = headers.authorization;
+  if (typeof auth !== 'string') return undefined;
+  const match = auth.match(/^Bearer\s+(.+)$/i);
+  return match?.[1];
+}
+
+// Look for a string equal to `role` anywhere reasonable in the claims —
+// supports plain `roles: ['openpanel:admin']`, Zitadel's nested
+// `urn:zitadel:iam:org:project:roles: { 'openpanel:admin': {...} }`
+// shape, and `scope: 'openid openpanel:admin'`.
+function claimHasRole(payload: Record<string, unknown>, role: string): boolean {
+  const zitadelRoles = payload['urn:zitadel:iam:org:project:roles'];
+  if (zitadelRoles && typeof zitadelRoles === 'object') {
+    if (role in (zitadelRoles as Record<string, unknown>)) return true;
+  }
+  const roles = payload.roles;
+  if (Array.isArray(roles) && roles.includes(role)) return true;
+  const scope = payload.scope;
+  if (typeof scope === 'string' && scope.split(/\s+/).includes(role)) {
+    return true;
+  }
+  return false;
+}
+
+// Synthesizes a Client-shaped record from a verified admin JWT so
+// existing /manage controllers can pull `organizationId` off
+// `request.client` without branching on auth source. The synthesized
+// client is `type: 'root'`, `secret: null`, and is NEVER persisted —
+// it lives only for the lifetime of the request.
+function synthesizeAdminClient(
+  organizationId: string,
+  subject: string,
+): IServiceClientWithProject {
+  return {
+    id: `jwt:${subject}`,
+    name: `admin-jwt:${subject}`,
+    type: ClientType.root,
+    organizationId,
+    projectId: null,
+    cors: null,
+    secret: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    // Project relation isn't used by /manage routes (root clients
+    // scope at org level); satisfy the typing with null and rely on
+    // controllers' projectId-from-body/query path.
+    project: null as unknown as IServiceClientWithProject['project'],
+  };
+}
+
+export async function validateAdminJwtRequest(
+  headers: RawRequestDefaultExpression['headers'],
+): Promise<IServiceClientWithProject> {
+  const config = loadAdminOidcConfig();
+  if (!config) {
+    throw new Error('Admin OIDC auth is not configured');
+  }
+  const token = extractBearer(headers);
+  if (!token) {
+    throw new Error('Admin OIDC: Authorization header missing or malformed');
+  }
+
+  const jwks = await getJwks(config);
+  const verifyOptions: Parameters<typeof jwtVerify>[2] = {
+    issuer: config.issuer,
+  };
+  if (config.audience) {
+    verifyOptions.audience = config.audience;
+  }
+
+  const { payload } = await jwtVerify(token, jwks, verifyOptions);
+
+  if (!claimHasRole(payload as Record<string, unknown>, config.requiredRole)) {
+    throw new Error(`Admin OIDC: token lacks required role ${config.requiredRole}`);
+  }
+
+  const orgId = (payload as Record<string, unknown>)[config.orgClaim];
+  if (typeof orgId !== 'string' || orgId.length === 0) {
+    throw new Error(
+      `Admin OIDC: token missing organization claim "${config.orgClaim}"`,
+    );
+  }
+  const subject = typeof payload.sub === 'string' ? payload.sub : 'unknown';
+
+  return synthesizeAdminClient(orgId, subject);
+}
+
+/**
+ * Wrapper for /manage routes. Dispatches to JWT-bearer auth when
+ * `ADMIN_OIDC_ISSUER` is configured AND the request carries an
+ * `Authorization: Bearer …` header; otherwise falls back to the
+ * existing `openpanel-client-id` / `openpanel-client-secret` flow.
+ *
+ * Returns a Client-shaped record in both cases, so callers in
+ * controllers (`request.client!.organizationId`, etc.) work without
+ * branching.
+ */
+export async function validateAdminRequest(
+  headers: RawRequestDefaultExpression['headers'],
+): Promise<IServiceClientWithProject> {
+  const bearer = extractBearer(headers);
+  if (bearer && isAdminJwtAuthEnabled()) {
+    return validateAdminJwtRequest(headers);
+  }
+  return validateManageRequest(headers);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
       groupmq:
         specifier: 'catalog:'
         version: 2.0.0-next.6(ioredis@5.8.2)
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -7860,95 +7863,111 @@ packages:
 
   '@react-email/body@0.1.0':
     resolution: {integrity: sha512-o1bcSAmDYNNHECbkeyceCVPGmVsYvT+O3sSO/Ct7apKUu3JphTi31hu+0Nwqr/pgV5QFqdoT5vdS3SW5DJFHgQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/button@0.2.0':
     resolution: {integrity: sha512-8i+v6cMxr2emz4ihCrRiYJPp2/sdYsNNsBzXStlcA+/B9Umpm5Jj3WJKYpgTPM+aeyiqlG/MMI1AucnBm4f1oQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/code-block@0.1.0':
     resolution: {integrity: sha512-jSpHFsgqnQXxDIssE4gvmdtFncaFQz5D6e22BnVjcCPk/udK+0A9jRwGFEG8JD2si9ZXBmU4WsuqQEczuZn4ww==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/code-inline@0.0.5':
     resolution: {integrity: sha512-MmAsOzdJpzsnY2cZoPHFPk6uDO/Ncpb4Kh1hAt9UZc1xOW3fIzpe1Pi9y9p6wwUmpaeeDalJxAxH6/fnTquinA==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/column@0.0.13':
     resolution: {integrity: sha512-Lqq17l7ShzJG/d3b1w/+lVO+gp2FM05ZUo/nW0rjxB8xBICXOVv6PqjDnn3FXKssvhO5qAV20lHM6S+spRhEwQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/components@0.5.6':
     resolution: {integrity: sha512-3o9ellDaF3bBcVMWeos9HI0iUIT1zGygPRcn9WSfI5JREORiN6ViEJIvz5SKWEn1KPNZtw/iaW8ct7PpVyhomg==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/container@0.0.15':
     resolution: {integrity: sha512-Qo2IQo0ru2kZq47REmHW3iXjAQaKu4tpeq/M8m1zHIVwKduL2vYOBQWbC2oDnMtWPmkBjej6XxgtZByxM6cCFg==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/font@0.0.9':
     resolution: {integrity: sha512-4zjq23oT9APXkerqeslPH3OZWuh5X4crHK6nx82mVHV2SrLba8+8dPEnWbaACWTNjOCbcLIzaC9unk7Wq2MIXw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/head@0.0.12':
     resolution: {integrity: sha512-X2Ii6dDFMF+D4niNwMAHbTkeCjlYYnMsd7edXOsi0JByxt9wNyZ9EnhFiBoQdqkE+SMDcu8TlNNttMrf5sJeMA==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/heading@0.0.15':
     resolution: {integrity: sha512-xF2GqsvBrp/HbRHWEfOgSfRFX+Q8I5KBEIG5+Lv3Vb2R/NYr0s8A5JhHHGf2pWBMJdbP4B2WHgj/VUrhy8dkIg==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/hr@0.0.11':
     resolution: {integrity: sha512-S1gZHVhwOsd1Iad5IFhpfICwNPMGPJidG/Uysy1AwmspyoAP5a4Iw3OWEpINFdgh9MHladbxcLKO2AJO+cA9Lw==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/html@0.0.11':
     resolution: {integrity: sha512-qJhbOQy5VW5qzU74AimjAR9FRFQfrMa7dn4gkEXKMB/S9xZN8e1yC1uA9C15jkXI/PzmJ0muDIWmFwatm5/+VA==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/img@0.0.11':
     resolution: {integrity: sha512-aGc8Y6U5C3igoMaqAJKsCpkbm1XjguQ09Acd+YcTKwjnC2+0w3yGUJkjWB2vTx4tN8dCqQCXO8FmdJpMfOA9EQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/link@0.0.12':
     resolution: {integrity: sha512-vF+xxQk2fGS1CN7UPQDbzvcBGfffr+GjTPNiWM38fhBfsLv6A/YUfaqxWlmL7zLzVmo0K2cvvV9wxlSyNba1aQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/markdown@0.0.15':
     resolution: {integrity: sha512-UQA9pVm5sbflgtg3EX3FquUP4aMBzmLReLbGJ6DZQZnAskBF36aI56cRykDq1o+1jT+CKIK1CducPYziaXliag==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/preview@0.0.13':
     resolution: {integrity: sha512-F7j9FJ0JN/A4d7yr+aw28p4uX7VLWs7hTHtLo7WRyw4G+Lit6Zucq4UWKRxJC8lpsUdzVmG7aBJnKOT+urqs/w==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
@@ -7969,24 +7988,28 @@ packages:
   '@react-email/row@0.0.12':
     resolution: {integrity: sha512-HkCdnEjvK3o+n0y0tZKXYhIXUNPDx+2vq1dJTmqappVHXS5tXS6W5JOPZr5j+eoZ8gY3PShI2LWj5rWF7ZEtIQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/section@0.0.16':
     resolution: {integrity: sha512-FjqF9xQ8FoeUZYKSdt8sMIKvoT9XF8BrzhT3xiFKdEMwYNbsDflcjfErJe3jb7Wj/es/lKTbV5QR1dnLzGpL3w==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/tailwind@1.2.2':
     resolution: {integrity: sha512-heO9Khaqxm6Ulm6p7HQ9h01oiiLRrZuuEQuYds/O7Iyp3c58sMVHZGIxiRXO/kSs857NZQycpjewEVKF3jhNTw==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/text@0.1.5':
     resolution: {integrity: sha512-o5PNHFSE085VMXayxH+SJ1LSOtGsTv+RpNKnTiJDrJUwoBu77G3PlKOsZZQHCNyD28WsQpl9v2WcJLbQudqwPg==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
@@ -9998,6 +10021,7 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unhead/vue@2.0.19':
     resolution: {integrity: sha512-7BYjHfOaoZ9+ARJkT10Q2TjnTUqDXmMpfakIAsD/hXiuff1oqWg1xeXT5+MomhNcC15HbiABpbbBmITLSHxdKg==}
@@ -14028,6 +14052,9 @@ packages:
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -18867,6 +18894,7 @@ packages:
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
@@ -18876,6 +18904,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valid-url@1.0.9:
@@ -35766,6 +35795,8 @@ snapshots:
   join-component@1.1.0: {}
 
   jose@6.2.2: {}
+
+  jose@6.2.3: {}
 
   joycon@3.1.1: {}
 


### PR DESCRIPTION
Adds two related capabilities to the existing \`/manage\` REST surface:

1. **An opt-in OIDC Bearer-token auth path.** When configured with an OIDC issuer, the api pod accepts \`Authorization: Bearer <jwt>\` headers as an alternative to the existing \`openpanel-client-id\` / \`openpanel-client-secret\` Client-pair auth. The token is validated against the issuer's JWKS (discovered from \`<issuer>/.well-known/openid-configuration\`) and must carry a configured audience + role claim.

2. **\`/manage/organizations\` REST endpoints** for GET/POST/PATCH/DELETE. Mirrors the existing \`/manage/projects\` shape. Useful for both Client-pair callers (managing their own Org) and OIDC callers (provisioning Organizations programmatically).

## Why

The existing \`/manage\` API requires a root-typed Client, which is only mintable through the dashboard UI after onboarding. That makes it impossible to bootstrap an OpenPanel install from a fully programmatic flow (Terraform, Crossplane, GitOps pipelines, etc.).

If a self-hoster has already configured an OIDC IdP for dashboard sign-in (Zitadel / Keycloak / Authentik / Okta), the same IdP can issue ServiceUser tokens that \`/manage\` validates — no second auth primitive inside OpenPanel, no Personal Access Token table to maintain, the IdP's existing token rotation / revocation / audit handles the operational story.

For installs without an OIDC IdP, nothing changes: the env vars are unset and the JWT auth path is disabled.

## Configuration

Off by default. Enabled by setting these env vars on the api pod:

\`\`\`
ADMIN_OIDC_ISSUER              # e.g. https://auth.example.com
ADMIN_OIDC_AUDIENCE            # JWT aud claim required (e.g. openpanel-admin)
ADMIN_OIDC_REQUIRED_ROLE       # default: openpanel:admin
ADMIN_OIDC_ORG_CLAIM           # claim that holds the bound Org ID
                                # default: urn:zitadel:iam:user:resourceowner:id
\`\`\`

The role check looks at three common claim shapes so different IdPs work without per-IdP code:
- \`roles[]\` (Auth0, Keycloak with role mapper, generic)
- \`scope\` space-separated (Authelia, dex)
- \`urn:zitadel:iam:org:project:roles\` nested map (Zitadel default)

## Implementation

\`apps/api/src/utils/auth.ts\` adds:
- \`validateAdminJwtRequest\` — verifies the JWT against the issuer's JWKS, checks audience + role + org claim
- \`validateAdminRequest\` — wrapper that picks JWT or Client-pair auth based on the \`Authorization\` header shape
- A synthesized \`IServiceClientWithProject\` for JWT-authenticated requests so existing controllers (\`request.client!.organizationId\`) work unchanged

\`apps/api/src/routes/manage.router.ts\` switches the preHandler from \`validateManageRequest\` to \`validateAdminRequest\` (backwards-compatible) and registers the new \`/manage/organizations\` routes.

\`apps/api/src/controllers/manage.controller.ts\` adds \`listOrganizations\`, \`getOrganization\`, \`createOrganization\`, \`updateOrganization\`, \`deleteOrganization\` matching the project controller pattern.

## Backwards compatibility

Purely additive:
- \`ADMIN_OIDC_ISSUER\` unset → no behavioral change for any caller
- Existing /manage routes continue to accept Client-pair auth even when OIDC is configured
- No DB schema changes
- New dependency: \`jose\` in \`apps/api\` (already in the broader Node ecosystem)

## How to test

Local docker-compose setup with any OIDC IdP:

1. Spin up an IdP (e.g. \`zitadel/zitadel\` or \`quay.io/keycloak/keycloak\` in docker)
2. Create a ServiceUser / client_credentials grant with audience \`openpanel-admin\` and a role grant \`openpanel:admin\`
3. Export to api container:
   \`\`\`
   ADMIN_OIDC_ISSUER=http://<idp-host>
   ADMIN_OIDC_AUDIENCE=openpanel-admin
   \`\`\`
4. \`pnpm dev\`
5. \`curl -H \"Authorization: Bearer <jwt>\" http://localhost:3333/api/manage/projects\` — should return 200 instead of the usual 401 "Manage: Client ID seems to be malformed"
6. \`curl -X POST -H \"Authorization: Bearer <jwt>\" -H \"content-type: application/json\" -d '{\"name\":\"test-org\"}' http://localhost:3333/api/manage/organizations\` — creates a new Org

I verified end-to-end against a self-hosted Zitadel install: ServiceUser provisioned via Zitadel's Crossplane provider, JWT obtained via client_credentials grant, \`POST /manage/organizations\` + subsequent \`POST /manage/projects\` + \`POST /manage/clients\` all succeed and appear in the OpenPanel UI under the freshly-created Org.

## Companion to #370

This builds on top of #370 (the user-facing OIDC sign-in provider) but is independent — the two PRs touch different files and can land in either order.

## Not included

- Member / Invitation REST endpoints. Adding them is mechanical (mirror the org/project controllers, gate on the auth wrapper) but I wanted to keep this PR focused. Happy to add in a follow-up if reviewers want.
- A "discovery" mode that derives \`ADMIN_OIDC_ISSUER\` from the existing OIDC sign-in \`OIDC_AUTHORIZATION_ENDPOINT\` env. Could be a nice DX win for installs that point both at the same IdP, but explicit configuration felt safer for v1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Added `jose` library for secure JWT token verification and processing

* **New Features**
  * Organization management: API now supports creating, listing, retrieving, updating, and deleting organizations with automatic ID generation and timezone configuration
  * Admin OIDC authentication: JWT Bearer token-based authentication via OIDC with issuer discovery, enabling secure organization-scoped administrative access

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Openpanel-dev/openpanel/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->