### PR TITLE
fix: honor inviteId on existing-user sign-in paths (#385)

### DIFF
--- a/apps/api/src/controllers/oauth-callback.controller.tsx
+++ b/apps/api/src/controllers/oauth-callback.controller.tsx
@@ -53,11 +53,13 @@ async function handleExistingUser({
   account,
   oauthUser,
   providerName,
+  inviteId,
   reply,
 }: {
   account: Account;
   oauthUser: OAuthUser;
   providerName: Provider;
+  inviteId: string | undefined | null;
   reply: FastifyReply;
 }) {
   const sessionToken = generateSessionToken();
@@ -71,6 +73,24 @@ async function handleExistingUser({
       email: oauthUser.email,
     },
   });
+
+  if (inviteId) {
+    try {
+      const user = await db.user.findUniqueOrThrow({
+        where: { id: account.userId },
+      });
+      await connectUserToOrganization({ user, inviteId });
+    } catch (error) {
+      reply.log.error(
+        {
+          error,
+          inviteId,
+          userId: account.userId,
+        },
+        'error connecting existing user to organization'
+      );
+    }
+  }
 
   setSessionTokenCookie(
     (...args) => reply.setCookie(...args),
@@ -301,6 +321,7 @@ export async function githubCallback(req: FastifyRequest, reply: FastifyReply) {
         account,
         oauthUser: githubUser,
         providerName: 'github',
+        inviteId,
         reply,
       });
     }
@@ -344,6 +365,7 @@ export async function googleCallback(req: FastifyRequest, reply: FastifyReply) {
         account: existingUser,
         oauthUser: googleUser,
         providerName: 'google',
+        inviteId,
         reply,
       });
     }

--- a/apps/start/src/components/auth/sign-in-email-form.tsx
+++ b/apps/start/src/components/auth/sign-in-email-form.tsx
@@ -13,7 +13,10 @@ import { Button } from '../ui/button';
 const validator = zSignInEmail;
 type IForm = z.infer<typeof validator>;
 
-export function SignInEmailForm({ isLastUsed }: { isLastUsed?: boolean }) {
+export function SignInEmailForm({
+  isLastUsed,
+  inviteId,
+}: { isLastUsed?: boolean; inviteId?: string }) {
   const trpc = useTRPC();
   const mutation = useMutation(
     trpc.auth.signInEmail.mutationOptions({
@@ -40,6 +43,7 @@ export function SignInEmailForm({ isLastUsed }: { isLastUsed?: boolean }) {
   const onSubmit: SubmitHandler<IForm> = (values) => {
     mutation.mutate({
       ...values,
+      inviteId,
     });
   };
 

--- a/apps/start/src/components/auth/sign-in-github.tsx
+++ b/apps/start/src/components/auth/sign-in-github.tsx
@@ -29,7 +29,7 @@ export function SignInGithub({
         onClick={() =>
           mutation.mutate({
             provider: 'github',
-            inviteId: type === 'sign-up' ? inviteId : undefined,
+            inviteId,
           })
         }
       >

--- a/apps/start/src/components/auth/sign-in-google.tsx
+++ b/apps/start/src/components/auth/sign-in-google.tsx
@@ -36,7 +36,7 @@ export function SignInGoogle({
         onClick={() =>
           mutation.mutate({
             provider: 'google',
-            inviteId: type === 'sign-up' ? inviteId : undefined,
+            inviteId,
           })
         }
         size="lg"

--- a/apps/start/src/routes/_login.login.tsx
+++ b/apps/start/src/routes/_login.login.tsx
@@ -20,11 +20,12 @@ export const Route = createFileRoute('/_login/login')({
   validateSearch: z.object({
     error: z.string().optional(),
     correlationId: z.string().optional(),
+    inviteId: z.string().optional(),
   }),
 });
 
 function LoginPage() {
-  const { error, correlationId } = Route.useSearch();
+  const { error, correlationId, inviteId } = Route.useSearch();
   const [lastProvider] = useCookieStore<null | string>(
     'last-auth-provider',
     null
@@ -72,11 +73,19 @@ function LoginPage() {
       )}
 
       <div className="space-y-4">
-        <SignInGoogle isLastUsed={lastProvider === 'google'} type="sign-in" />
-        <SignInGithub isLastUsed={lastProvider === 'github'} type="sign-in" />
+        <SignInGoogle
+          inviteId={inviteId}
+          isLastUsed={lastProvider === 'google'}
+          type="sign-in"
+        />
+        <SignInGithub
+          inviteId={inviteId}
+          isLastUsed={lastProvider === 'github'}
+          type="sign-in"
+        />
       </div>
       <Or />
-      <SignInEmailForm isLastUsed={lastProvider === 'email'} />
+      <SignInEmailForm inviteId={inviteId} isLastUsed={lastProvider === 'email'} />
     </div>
   );
 }

--- a/apps/start/src/routes/_public.onboarding.tsx
+++ b/apps/start/src/routes/_public.onboarding.tsx
@@ -82,7 +82,14 @@ function Component() {
         </p>
         <p className="mt-3 text-muted-foreground">
           Already have an account?{' '}
-          <a className="font-medium text-foreground underline" href="/login">
+          <a
+            className="font-medium text-foreground underline"
+            href={
+              inviteId
+                ? `/login?inviteId=${encodeURIComponent(inviteId)}`
+                : '/login'
+            }
+          >
             Sign in
           </a>
         </p>

--- a/packages/db/prisma/migrations/20260603111500_add_member_org_user_unique/migration.sql
+++ b/packages/db/prisma/migrations/20260603111500_add_member_org_user_unique/migration.sql
@@ -1,0 +1,16 @@
+-- Remove duplicate memberships before enforcing uniqueness.
+-- Keep the earliest-created row per (organizationId, userId); tie-break on id.
+-- Rows with a NULL userId (pending email-only invites) are left untouched
+-- because NULLs are treated as distinct by the unique index below.
+DELETE FROM "public"."members" m
+USING "public"."members" keep
+WHERE m."userId" IS NOT NULL
+  AND m."organizationId" = keep."organizationId"
+  AND m."userId" = keep."userId"
+  AND (
+    m."createdAt" > keep."createdAt"
+    OR (m."createdAt" = keep."createdAt" AND m."id" > keep."id")
+  );
+
+-- CreateIndex
+CREATE UNIQUE INDEX "members_organizationId_userId_key" ON "public"."members"("organizationId", "userId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -204,6 +204,7 @@ model Member {
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @default(now()) @updatedAt
 
+  @@unique([organizationId, userId])
   @@map("members")
 }
 

--- a/packages/db/src/services/organization.service.ts
+++ b/packages/db/src/services/organization.service.ts
@@ -162,26 +162,26 @@ export async function connectUserToOrganization({
   }
 
   // The invite might be consumed by a user who is already a member of the
-  // organization (e.g. accepting it a second time). Avoid creating a duplicate
-  // membership in that case and just consume the invite below.
-  const existingMember = await db.member.findFirst({
+  // organization (e.g. accepting it a second time). Upsert atomically against
+  // the (organizationId, userId) unique constraint so concurrent consumption
+  // cannot create duplicate membership rows; an existing membership is reused
+  // unchanged and the invite is still consumed below.
+  const member = await db.member.upsert({
     where: {
-      organizationId: invite.organizationId,
-      userId: user.id,
-    },
-  });
-
-  const member =
-    existingMember ??
-    (await db.member.create({
-      data: {
+      organizationId_userId: {
         organizationId: invite.organizationId,
         userId: user.id,
-        role: invite.role,
-        email: user.email,
-        invitedById: invite.createdById,
       },
-    }));
+    },
+    update: {},
+    create: {
+      organizationId: invite.organizationId,
+      userId: user.id,
+      role: invite.role,
+      email: user.email,
+      invitedById: invite.createdById,
+    },
+  });
 
   await getOrganizationAccess.clear({
     userId: user.id,

--- a/packages/db/src/services/organization.service.ts
+++ b/packages/db/src/services/organization.service.ts
@@ -161,15 +161,27 @@ export async function connectUserToOrganization({
     throw new Error('Invite expired');
   }
 
-  const member = await db.member.create({
-    data: {
+  // The invite might be consumed by a user who is already a member of the
+  // organization (e.g. accepting it a second time). Avoid creating a duplicate
+  // membership in that case and just consume the invite below.
+  const existingMember = await db.member.findFirst({
+    where: {
       organizationId: invite.organizationId,
       userId: user.id,
-      role: invite.role,
-      email: user.email,
-      invitedById: invite.createdById,
     },
   });
+
+  const member =
+    existingMember ??
+    (await db.member.create({
+      data: {
+        organizationId: invite.organizationId,
+        userId: user.id,
+        role: invite.role,
+        email: user.email,
+        invitedById: invite.createdById,
+      },
+    }));
 
   await getOrganizationAccess.clear({
     userId: user.id,

--- a/packages/trpc/src/routers/auth.ts
+++ b/packages/trpc/src/routers/auth.ts
@@ -50,8 +50,30 @@ import {
 
 const TWO_FACTOR_COOKIE = '2fa_challenge';
 const TWO_FACTOR_CHALLENGE_TTL_SECONDS = 5 * 60;
+const INVITE_COOKIE = 'inviteId';
 
 const zProvider = z.enum(['email', 'google', 'github']);
+
+/**
+ * Best-effort consumption of an invite for a user that just authenticated.
+ * Failures (expired/invalid invite) must not block the sign-in itself, so we
+ * swallow and log the error instead of rethrowing.
+ */
+async function consumeInviteForUser(
+  userId: string,
+  inviteId: string,
+  log: { error: (obj: unknown, msg?: string) => void }
+) {
+  try {
+    const user = await db.user.findUniqueOrThrow({ where: { id: userId } });
+    await connectUserToOrganization({ user, inviteId });
+  } catch (error) {
+    log.error(
+      { userId, inviteId, error },
+      'Failed to connect user to organization via invite'
+    );
+  }
+}
 
 async function getIsRegistrationAllowed(inviteId?: string | null) {
   // ALLOW_REGISTRATION is always undefined in cloud
@@ -255,6 +277,13 @@ export const authRouter = createTRPCRouter({
         ctx.setCookie(TWO_FACTOR_COOKIE, challengeId, {
           maxAge: TWO_FACTOR_CHALLENGE_TTL_SECONDS,
         });
+        // Carry the invite through the 2FA challenge so it can be consumed once
+        // the user completes the second factor in `signInTotp`.
+        if (input.inviteId) {
+          ctx.setCookie(INVITE_COOKIE, input.inviteId, {
+            maxAge: TWO_FACTOR_CHALLENGE_TTL_SECONDS,
+          });
+        }
         return { type: 'totp_required' as const };
       }
 
@@ -262,6 +291,11 @@ export const authRouter = createTRPCRouter({
       const session = await createSession(token, user.id);
       setSessionTokenCookie(ctx.setCookie, token, session.expiresAt);
       setLastAuthProviderCookie(ctx.setCookie, 'email');
+
+      if (input.inviteId) {
+        await consumeInviteForUser(user.id, input.inviteId, ctx.req.log);
+      }
+
       return {
         type: 'email' as const,
       };
@@ -333,6 +367,13 @@ export const authRouter = createTRPCRouter({
       const session = await createSession(token, challenge.userId);
       setSessionTokenCookie(ctx.setCookie, token, session.expiresAt);
       setLastAuthProviderCookie(ctx.setCookie, 'email');
+
+      const inviteId = ctx.cookies[INVITE_COOKIE];
+      if (inviteId) {
+        await consumeInviteForUser(challenge.userId, inviteId, ctx.req.log);
+        ctx.setCookie(INVITE_COOKIE, '', { maxAge: 0 });
+      }
+
       return { type: 'email' as const };
     }),
 

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -545,6 +545,7 @@ export const zPassword = z.string().min(8);
 export const zSignInEmail = z.object({
   email: z.string().email().min(1),
   password: zPassword,
+  inviteId: z.string().nullish(),
 });
 export type ISignInEmail = z.infer<typeof zSignInEmail>;
 


### PR DESCRIPTION
Invites were only consumed during new-account creation, so an invited person who authenticated as an existing user (OAuth sign-in or email sign-in) had their inviteId silently dropped. With zero org memberships they were redirected into the Create Project onboarding wizard instead of joining the inviting organization.

- connectUserToOrganization is now idempotent: reuse an existing membership instead of creating a duplicate (no unique constraint on members.organizationId+userId), then still consume the invite.
- OAuth handleExistingUser now accepts inviteId and connects the org (best-effort, logged) for both GitHub and Google callbacks.
- signInEmail accepts an optional inviteId and consumes it on success; for 2FA users it is carried through the challenge via a short-lived cookie and consumed in signInTotp.
- Frontend forwards inviteId on the sign-in path (email + OAuth), the login route reads it from search params, and the onboarding "Sign in" link preserves ?inviteId so returning users don't lose it.

closes #385 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can accept organization invites during sign-in for email, Google, and GitHub.
  * Invite context is preserved across login, sign-up, and onboarding flows (including links to the login page).
  * Pending invites are applied after completing 2FA so invites complete post-authentication.

* **Bug Fixes**
  * Prevents creating duplicate organization memberships when an invited user is already a member.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->