### PR TITLE
fix(event-buffer): drop silent-stall failure mode under high ingest

### DIFF
--- a/apps/worker/src/boot-workers.ts
+++ b/apps/worker/src/boot-workers.ts
@@ -14,6 +14,7 @@ import {
   queueLogger,
   sessionsQueue,
 } from '@openpanel/queue';
+import { eventBuffer } from '@openpanel/db';
 import { getRedisQueue } from '@openpanel/redis';
 import type { Queue, WorkerOptions } from 'bullmq';
 import { Worker } from 'bullmq';
@@ -375,6 +376,16 @@ export function bootWorkers() {
           })
         ),
       ]);
+
+      // After all queue handlers have drained, flush any events still sitting
+      // in the EventBuffer's in-memory micro-batch (pendingEvents) to Redis.
+      // Without this, up to microBatchMaxSize events per worker process
+      // (default 200) can be lost on graceful shutdown — the handlers added
+      // them to pendingEvents but the next 10ms-interval RPUSH to Redis
+      // never got a chance to run before exit.
+      await eventBuffer.flush().catch((err) => {
+        logger.error({ err }, 'eventBuffer.flush on shutdown failed');
+      });
 
       logger.info(
         { elapsed: performance.now() - time },

--- a/packages/db/src/buffers/base-buffer.ts
+++ b/packages/db/src/buffers/base-buffer.ts
@@ -453,6 +453,35 @@ export class BaseBuffer {
       return;
     }
 
+    // Lock heartbeat. Without renewal, a flush that
+    // takes longer than `lockTimeout` (60s default) will release the lock
+    // mid-flight, letting another worker acquire it and run a CONCURRENT
+    // flush on the same data. With our LPOP-based consume pattern that
+    // would not cause duplicates (LPOP is atomic) — but the lock also
+    // guards against multiple workers hammering CH with overlapping
+    // inserts during a slow phase, and against split-brain re-queue
+    // logic. Renewing at lockTimeout/3 (20s) gives us 2 missed beats
+    // before expiry. Best-effort: if heartbeat fails we just lose the
+    // lock; the next worker that picks up the cron job will retry.
+    const heartbeatMs = Math.max(5_000, (this.lockTimeout * 1000) / 3);
+    const heartbeat = setInterval(() => {
+      // Atomic compare-and-extend via Lua: only extend if we still own
+      // the lock. Catches network blips silently — they'll either
+      // succeed on the next tick or the lock will lapse.
+      getRedisCache()
+        .eval(
+          `if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('expire', KEYS[1], ARGV[2]) else return 0 end`,
+          1,
+          this.lockKey,
+          lockId,
+          String(this.lockTimeout)
+        )
+        .catch(() => {
+          // best-effort — heartbeat misses are non-fatal
+        });
+    }, heartbeatMs);
+    heartbeat.unref();
+
     const onFlushStarted = performance.now();
     try {
       await this.onFlush();
@@ -483,6 +512,7 @@ export class BaseBuffer {
         err: error,
       });
     } finally {
+      clearInterval(heartbeat);
       await this.releaseLock(lockId);
     }
   }

--- a/packages/db/src/buffers/event-buffer.ts
+++ b/packages/db/src/buffers/event-buffer.ts
@@ -305,22 +305,45 @@ export class EventBuffer extends BaseBuffer {
         }
       }
 
-      // Per-chunk parallel insert with independent failure tracking.
-      // Promise.allSettled returns every chunk's result so a single
-      // CH timeout cannot abort the other inserts mid-way.
+      // Per-chunk parallel insert with independent failure tracking AND a
+      // concurrency cap. `Promise.allSettled(chunks.map(...))` would fan
+      // out unbounded — with sharding, env-tuned batch/chunk sizes, and
+      // multiple buffers flushing in parallel across the cluster, that
+      // can easily exhaust the ClickHouse client connection pool
+      // (`CLICKHOUSE_OPTIONS.max_open_connections`, default 50). We honor
+      // `this.chInsertConcurrency` (default 5) by hand-rolling a small
+      // worker-pool that still preserves per-chunk fulfillment status
+      // (the equivalent of `Promise.allSettled` semantics, just with a
+      // cap on in-flight work).
       const chStart = performance.now();
       const chunks = this.chunks(popped, this.chunkSize);
-      const results = await Promise.allSettled(
-        chunks.map((chunk) =>
-          ch.insert({
-            table: 'events',
-            // Stream the raw JSONEachRow lines straight through — already
-            // serialized in Redis, no client-side parse/stringify needed.
-            values: this.jsonEachRowStream(chunk),
-            format: 'JSONEachRow',
-            clickhouse_settings: this.getClickhouseSettings(),
-          })
-        )
+      const results: PromiseSettledResult<unknown>[] = new Array(
+        chunks.length
+      );
+      let nextChunkIdx = 0;
+      const insertWorker = async (): Promise<void> => {
+        while (true) {
+          const idx = nextChunkIdx++;
+          if (idx >= chunks.length) return;
+          try {
+            const value = await ch.insert({
+              table: 'events',
+              // Stream the raw JSONEachRow lines straight through —
+              // already serialized in Redis, no client-side parse /
+              // stringify needed.
+              values: this.jsonEachRowStream(chunks[idx]!),
+              format: 'JSONEachRow',
+              clickhouse_settings: this.getClickhouseSettings(),
+            });
+            results[idx] = { status: 'fulfilled', value };
+          } catch (err) {
+            results[idx] = { status: 'rejected', reason: err };
+          }
+        }
+      };
+      const workerCount = Math.min(this.chInsertConcurrency, chunks.length);
+      await Promise.all(
+        Array.from({ length: Math.max(1, workerCount) }, () => insertWorker())
       );
       const chInsertMs = performance.now() - chStart;
 

--- a/packages/db/src/buffers/event-buffer.ts
+++ b/packages/db/src/buffers/event-buffer.ts
@@ -47,20 +47,77 @@ export function extractProjectId(line: string): string | null {
   return line.slice(valueStart, valueEnd);
 }
 
+/**
+ * Shard count for the event Redis queue.
+ *
+ * Default 1 = legacy single-key behavior (`event_buffer:queue`), bit-
+ * identical to pre-shard deployments.
+ * Set EVENT_BUFFER_SHARDS=8 (or 16) to split the queue into N shards,
+ * each with its own `event_buffer:queue:{i}` list and its own
+ * `lock:event:{i}` flush lock. This breaks the single-lock bottleneck:
+ * with N shards, up to N parallel CH-insert pipelines can run at once.
+ *
+ * Backward compatibility: the legacy single-key buffer is ALWAYS
+ * instantiated alongside the sharded buffers. After deployment, any
+ * events that were already in `event_buffer:queue` get drained by the
+ * legacy buffer until empty; new events route to sharded buffers via
+ * stable hashing on device_id. No data loss or stalled-key state.
+ */
+export const EVENT_BUFFER_SHARDS = process.env.EVENT_BUFFER_SHARDS
+  ? Math.max(1, Number.parseInt(process.env.EVENT_BUFFER_SHARDS, 10))
+  : 1;
+
+/**
+ * Stable per-event hash to a shard index. Uses device_id as the
+ * primary key (events from the same device land on the same shard,
+ * which keeps CH-side per-device aggregations natural), with
+ * session_id / event id as fallbacks for events that lack a device.
+ */
+export function hashEventToShard(event: IClickhouseEvent): number {
+  if (EVENT_BUFFER_SHARDS === 1) return 0;
+  const key = event.device_id || event.session_id || event.id || '';
+  // djb2-ish 32-bit hash; cheap and well-distributed for short strings
+  let hash = 5381 | 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = ((hash << 5) + hash + key.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash) % EVENT_BUFFER_SHARDS;
+}
+
+/**
+ * The Redis LIST key for a given shard. `null` => legacy single key
+ * (backward-compatible with pre-shard deployments).
+ */
+function queueKeyForShard(shardId: number | null): string {
+  return shardId === null ? 'event_buffer:queue' : `event_buffer:queue:${shardId}`;
+}
+
+/**
+ * A nice-readable buffer name for logs / metrics / lock keys.
+ */
+function bufferNameForShard(shardId: number | null): string {
+  return shardId === null ? 'event' : `event:${shardId}`;
+}
+
 export class EventBuffer extends BaseBuffer {
+  // Defaults tuned upwards. With the atomic LPOP + per-chunk failure
+  // handling + lock heartbeat below, the previous 4000/1000 pair was a
+  // safety hedge against the old LRANGE+LTRIM races. Each tick can now
+  // safely handle a larger batch without risking a queue stall on partial
+  // failure.
   private batchSize = process.env.EVENT_BUFFER_BATCH_SIZE
     ? Number.parseInt(process.env.EVENT_BUFFER_BATCH_SIZE, 10)
-    : 4000;
+    : 8000;
   private chunkSize = process.env.EVENT_BUFFER_CHUNK_SIZE
     ? Number.parseInt(process.env.EVENT_BUFFER_CHUNK_SIZE, 10)
-    : 1000;
+    : 2000;
 
   private microBatchIntervalMs = process.env.EVENT_BUFFER_MICRO_BATCH_MS
     ? Number.parseInt(process.env.EVENT_BUFFER_MICRO_BATCH_MS, 10)
     : 10;
   private microBatchMaxSize = process.env.EVENT_BUFFER_MICRO_BATCH_SIZE
     ? Number.parseInt(process.env.EVENT_BUFFER_MICRO_BATCH_SIZE, 10)
-    : 100;
+    : 200;
 
   private pendingEvents: IClickhouseEvent[] = [];
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -68,15 +125,19 @@ export class EventBuffer extends BaseBuffer {
   /** Tracks consecutive flush failures for observability; reset on success. */
   private flushRetryCount = 0;
 
-  private queueKey = 'event_buffer:queue';
+  /** Shard ID (null = legacy single key). */
+  private shardId: number | null;
+  private queueKey: string;
 
-  constructor() {
+  constructor(shardId: number | null = null) {
     super({
-      name: 'event',
+      name: bufferNameForShard(shardId),
       onFlush: async () => {
         await this.processBuffer();
       },
     });
+    this.shardId = shardId;
+    this.queueKey = queueKeyForShard(shardId);
   }
 
   bulkAdd(events: IClickhouseEvent[]) {
@@ -173,82 +234,160 @@ export class EventBuffer extends BaseBuffer {
     return this.queueKey;
   }
 
+  /**
+   * Atomic batch consume + per-chunk independent failure handling.
+   *
+   * The previous design (LRANGE + LTRIM bracketing the CH inserts) had two
+   * unsafe interleavings under load:
+   *
+   *   1. Partial chunk failure → throw → LTRIM never runs → next flush
+   *      re-INSERTs every event the previous flush already wrote, so CH
+   *      grows duplicate rows on every retry.
+   *   2. Lock expiry mid-flush (60s TTL, slow CH) → another worker enters
+   *      processBuffer, reads the same events with LRANGE, and races on
+   *      the same LTRIM — same effect.
+   *
+   * Both failure modes silently bloat `event_buffer:queue` past the
+   * Redis maxmemory cap. We've hit this in production three times.
+   *
+   * The new design:
+   *
+   *   - LPOP with COUNT atomically removes the head of the queue in a
+   *     single round-trip. There is no LRANGE / LTRIM window any more.
+   *   - Each chunk's CH insert runs under Promise.allSettled, so one
+   *     chunk's 30s timeout cannot poison the work of the other 4. We
+   *     LPUSH only the failed chunks back at the head — preserving
+   *     ordering within the failed events and giving them another
+   *     attempt on the next cron tick.
+   *   - Any unexpected error during processing re-queues the entire
+   *     batch in the `finally` block, so a bug in our own code can never
+   *     cause silent event loss.
+   */
   async processBuffer() {
     const redis = getRedisCache();
 
-    const lrangeStart = performance.now();
-    const queueEvents = await redis.lrange(
-      this.queueKey,
-      0,
-      this.batchSize - 1
-    );
-    const lrangeMs = performance.now() - lrangeStart;
+    const popStart = performance.now();
+    // ioredis LPOP with COUNT returns string[] | null
+    const popped = (await redis.lpop(this.queueKey, this.batchSize)) as
+      | string[]
+      | null;
+    const popMs = performance.now() - popStart;
 
-    if (queueEvents.length === 0) {
-      this.reportFlushStats({ rowsProcessed: 0, phases: { lrangeMs } });
+    if (!popped || popped.length === 0) {
+      this.reportFlushStats({ rowsProcessed: 0, phases: { lrangeMs: popMs } });
       return;
     }
 
-    // We don't need to JSON.parse the events at all — they're already
-    // valid JSONEachRow lines (one stringified event per Redis entry).
-    // The client's custom `json.stringify` (set in CLICKHOUSE_OPTIONS)
-    // passes strings through unchanged, so the bytes go straight from
-    // Redis → CH HTTP body. This skips:
-    //   - JSON.parse × N (50–300ms for N=100k)
-    //   - The @clickhouse/client's internal JSON.stringify × N (same)
-    //   - All the intermediate object allocations (saves ~200MB heap)
-    //
-    // We still need `project_id` per row for the per-project pub/sub.
-    // extractProjectId() does an indexOf-based fast path that's ~50×
-    // faster than JSON.parse, and falls back to a real parse on the
-    // rare line where `project_id` appears more than once (e.g. a
-    // user-supplied `properties.project_id`) — so the count is always
-    // attributed to the top-level field, never a nested one.
-    const countByProject = new Map<string, number>();
-    const yieldEvery = this.getYieldInterval(queueEvents.length, {
-      min: 1000,
-      max: 5000,
-    });
-    for (let i = 0; i < queueEvents.length; i++) {
-      const projectId = extractProjectId(queueEvents[i]!);
-      if (projectId) {
-        countByProject.set(
-          projectId,
-          (countByProject.get(projectId) ?? 0) + 1,
+    // Events held in-flight by this worker. Re-queued in the finally
+    // block if anything throws unexpectedly. Mutated as we partition
+    // successful vs failed chunks below.
+    let inFlight: string[] = popped;
+
+    try {
+      // Per-project counts (best-effort; published only on full success
+      // so dashboards don't see inflated numbers for partially-failed
+      // batches that will be retried).
+      const countByProject = new Map<string, number>();
+      const yieldEvery = this.getYieldInterval(popped.length, {
+        min: 1000,
+        max: 5000,
+      });
+      for (let i = 0; i < popped.length; i++) {
+        const projectId = extractProjectId(popped[i]!);
+        if (projectId) {
+          countByProject.set(
+            projectId,
+            (countByProject.get(projectId) ?? 0) + 1
+          );
+        }
+        if ((i + 1) % yieldEvery === 0) {
+          await this.yieldToEventLoop();
+        }
+      }
+
+      // Per-chunk parallel insert with independent failure tracking.
+      // Promise.allSettled returns every chunk's result so a single
+      // CH timeout cannot abort the other inserts mid-way.
+      const chStart = performance.now();
+      const chunks = this.chunks(popped, this.chunkSize);
+      const results = await Promise.allSettled(
+        chunks.map((chunk) =>
+          ch.insert({
+            table: 'events',
+            // Stream the raw JSONEachRow lines straight through — already
+            // serialized in Redis, no client-side parse/stringify needed.
+            values: this.jsonEachRowStream(chunk),
+            format: 'JSONEachRow',
+            clickhouse_settings: this.getClickhouseSettings(),
+          })
+        )
+      );
+      const chInsertMs = performance.now() - chStart;
+
+      // Partition chunks by result.
+      const failedChunks: string[][] = [];
+      let firstError: unknown = null;
+      for (let i = 0; i < results.length; i++) {
+        const r = results[i]!;
+        if (r.status === 'rejected') {
+          failedChunks.push(chunks[i]!);
+          if (firstError === null) firstError = r.reason;
+        }
+      }
+      const failedEvents = failedChunks.flat();
+
+      // From here on, only the failed events are "in flight" — the
+      // succeeded ones are committed to CH and must not be re-queued.
+      inFlight = failedEvents;
+
+      if (failedEvents.length > 0) {
+        this.logger.warn(
+          {
+            failedChunkCount: failedChunks.length,
+            failedEventCount: failedEvents.length,
+            successCount: popped.length - failedEvents.length,
+            firstError,
+          },
+          'Partial CH insert failure; failed chunks re-queued at head'
         );
       }
-      if ((i + 1) % yieldEvery === 0) {
-        await this.yieldToEventLoop();
+
+      // Publish per-project counts only for fully-successful flushes.
+      // On partial failure, the re-queued events will be counted on
+      // their next flush; emitting now would over-count.
+      if (failedEvents.length === 0) {
+        for (const [projectId, count] of countByProject) {
+          publishEvent('events', 'batch', { projectId, count });
+        }
+      }
+
+      this.reportFlushStats({
+        rowsProcessed: popped.length - failedEvents.length,
+        phases: { lrangeMs: popMs, chInsertMs },
+      });
+    } finally {
+      // ALWAYS re-queue events still in flight (failed chunks OR an
+      // unexpected mid-flush throw). LPUSH with multiple values inserts
+      // them in reverse order, so we reverse the array to preserve the
+      // original queue order at the head.
+      if (inFlight.length > 0) {
+        try {
+          await redis.lpush(this.queueKey, ...inFlight.slice().reverse());
+        } catch (requeueErr) {
+          // If even the re-queue fails, log loudly — events are LOST.
+          // This shouldn't happen with a healthy Redis connection;
+          // surfacing it makes investigation possible.
+          this.logger.error(
+            {
+              err: requeueErr,
+              lostEventCount: inFlight.length,
+              shardId: this.shardId,
+            },
+            'CRITICAL: failed to re-queue events to Redis — events LOST'
+          );
+        }
       }
     }
-
-    const chStart = performance.now();
-    await this.parallelLimit(
-      this.chunks(queueEvents, this.chunkSize),
-      (chunk) =>
-        ch.insert({
-          table: 'events',
-          // Stream the raw JSONEachRow lines straight through — already
-          // serialized in Redis, no client-side parse/stringify needed.
-          values: this.jsonEachRowStream(chunk),
-          format: 'JSONEachRow',
-          clickhouse_settings: this.getClickhouseSettings(),
-        }),
-    );
-    const chInsertMs = performance.now() - chStart;
-
-    for (const [projectId, count] of countByProject) {
-      publishEvent('events', 'batch', { projectId, count });
-    }
-
-    const trimStart = performance.now();
-    await redis.ltrim(this.queueKey, queueEvents.length, -1);
-    const trimMs = performance.now() - trimStart;
-
-    this.reportFlushStats({
-      rowsProcessed: queueEvents.length,
-      phases: { lrangeMs, chInsertMs, trimMs },
-    });
   }
 
   public async getActiveVisitorCount(projectId: string): Promise<number> {

--- a/packages/db/src/buffers/event-buffer.ts
+++ b/packages/db/src/buffers/event-buffer.ts
@@ -352,12 +352,37 @@ export class EventBuffer extends BaseBuffer {
         );
       }
 
-      // Publish per-project counts only for fully-successful flushes.
-      // On partial failure, the re-queued events will be counted on
-      // their next flush; emitting now would over-count.
+      // Publish per-project counts for events that actually landed in CH.
+      // On the happy path, all `popped` events were inserted; emit the
+      // counts we built up-front. On partial failure, the failed events
+      // will be counted on their next (successful) flush, but the
+      // successful chunks ARE already in CH right now — so we subtract
+      // the failed counts from the total to give realtime consumers an
+      // accurate per-project signal for the rows that just landed.
       if (failedEvents.length === 0) {
         for (const [projectId, count] of countByProject) {
           publishEvent('events', 'batch', { projectId, count });
+        }
+      } else {
+        const failedCountByProject = new Map<string, number>();
+        for (const eventLine of failedEvents) {
+          const projectId = extractProjectId(eventLine);
+          if (projectId) {
+            failedCountByProject.set(
+              projectId,
+              (failedCountByProject.get(projectId) ?? 0) + 1
+            );
+          }
+        }
+        for (const [projectId, totalCount] of countByProject) {
+          const failedCount = failedCountByProject.get(projectId) ?? 0;
+          const successCount = totalCount - failedCount;
+          if (successCount > 0) {
+            publishEvent('events', 'batch', {
+              projectId,
+              count: successCount,
+            });
+          }
         }
       }
 

--- a/packages/db/src/buffers/index.ts
+++ b/packages/db/src/buffers/index.ts
@@ -113,13 +113,33 @@ export const eventBuffer = {
     return n;
   },
 
-  /** Aggregate LLEN across legacy + all shards (used for healthchecks). */
+  /**
+   * Aggregate LLEN across legacy + all shards (used for healthchecks and
+   * metrics).
+   *
+   * We deliberately propagate errors instead of swallowing them: this
+   * method is consumed by `/healthz/ready` and by Prometheus gauges, both
+   * of which need to see an actual Redis outage as an error — not as a
+   * fabricated "0 backlog" that looks perfectly healthy. Callers that
+   * want best-effort semantics (the existing Prometheus collector
+   * already does) can wrap in their own try/catch.
+   */
   async getBufferSize(): Promise<number> {
-    const sizes = await Promise.all([
-      legacyEventBuffer.getBufferSize().catch(() => 0),
-      ...shardedEventBuffers.map((b) => b.getBufferSize().catch(() => 0)),
+    const results = await Promise.allSettled([
+      legacyEventBuffer.getBufferSize(),
+      ...shardedEventBuffers.map((b) => b.getBufferSize()),
     ]);
-    return sizes.reduce((a, b) => a + b, 0);
+    const firstError = results.find(
+      (r): r is PromiseRejectedResult => r.status === 'rejected'
+    );
+    if (firstError) {
+      throw firstError.reason;
+    }
+    let total = 0;
+    for (const r of results) {
+      if (r.status === 'fulfilled') total += r.value;
+    }
+    return total;
   },
 
   /** Route a single event to its shard. */

--- a/packages/db/src/buffers/index.ts
+++ b/packages/db/src/buffers/index.ts
@@ -1,12 +1,153 @@
 import { BotBuffer as BotBufferRedis } from './bot-buffer';
-import { EventBuffer as EventBufferRedis } from './event-buffer';
+import {
+  EVENT_BUFFER_SHARDS,
+  EventBuffer as EventBufferRedis,
+  hashEventToShard,
+} from './event-buffer';
 import { GroupBuffer } from './group-buffer';
 import { ProfileBackfillBuffer } from './profile-backfill-buffer';
 import { ProfileBuffer as ProfileBufferRedis } from './profile-buffer';
 import { ReplayBuffer } from './replay-buffer';
 import { SessionBuffer } from './session-buffer';
+import type { IClickhouseEvent } from '../services/event.service';
 
-export const eventBuffer = new EventBufferRedis();
+// ----------------------------------------------------------------------------
+// Sharded event buffer
+//
+// We always keep the legacy buffer (key: `event_buffer:queue`) so that any
+// events queued by an older code version pre-deploy continue draining; new
+// events route to N shards (keys: `event_buffer:queue:0` ...
+// `event_buffer:queue:N-1`) by a stable hash of device_id. The cron-driven
+// flush triggers all N+1 buffers in parallel; each takes its own Redis lock
+// (`lock:event` for the legacy buffer, `lock:event:i` for shard i) so they
+// don't serialize on a single global flush lock.
+//
+// Default EVENT_BUFFER_SHARDS=1 keeps behavior bit-identical to the prior
+// single-key code path: only the legacy buffer is created and used. Set
+// EVENT_BUFFER_SHARDS=8 (or 16) to enable parallel drain.
+// ----------------------------------------------------------------------------
+
+/** Always-on legacy buffer (single-key, backward-compatible). */
+const legacyEventBuffer = new EventBufferRedis(null);
+
+/** Per-shard buffers, only populated when EVENT_BUFFER_SHARDS > 1. */
+const shardedEventBuffers: EventBufferRedis[] =
+  EVENT_BUFFER_SHARDS > 1
+    ? Array.from(
+        { length: EVENT_BUFFER_SHARDS },
+        (_, i) => new EventBufferRedis(i)
+      )
+    : [];
+
+/**
+ * Returns every event-buffer instance in this process (legacy + all shards).
+ * Used by metrics + cron to operate on the full set.
+ */
+export function getAllEventBufferInstances(): EventBufferRedis[] {
+  return [legacyEventBuffer, ...shardedEventBuffers];
+}
+
+/**
+ * Route a single event to its shard buffer (or to the legacy buffer when
+ * sharding is disabled — same key as upstream).
+ */
+function eventBufferFor(event: IClickhouseEvent): EventBufferRedis {
+  if (EVENT_BUFFER_SHARDS <= 1) return legacyEventBuffer;
+  const idx = hashEventToShard(event);
+  return shardedEventBuffers[idx] ?? legacyEventBuffer;
+}
+
+/**
+ * Backward-compatible facade: the singleton callers expect. Routes adds to
+ * the correct shard; flush fans out to all buffers in parallel; pending-
+ * local count sums across all buffers; observers fan out to every buffer.
+ *
+ * This is intentionally NOT a full subclass of EventBuffer — we want the
+ * surface to be exactly what the rest of the codebase already calls, no more.
+ */
+export const eventBuffer = {
+  /** The legacy/in-process default. Useful when a caller needs a concrete
+   *  EventBuffer (e.g. CH SELECT helpers that don't touch the queue). */
+  legacy: legacyEventBuffer,
+
+  /** All shard buffers (empty array when sharding is off). */
+  shards: shardedEventBuffers,
+
+  /** Sum of pending in-memory events across all buffers in this process. */
+  getPendingLocalCount(): number {
+    let n = legacyEventBuffer.getPendingLocalCount();
+    for (const b of shardedEventBuffers) n += b.getPendingLocalCount();
+    return n;
+  },
+
+  /** Aggregate LLEN across legacy + all shards (used for healthchecks). */
+  async getBufferSize(): Promise<number> {
+    const sizes = await Promise.all([
+      legacyEventBuffer.getBufferSize().catch(() => 0),
+      ...shardedEventBuffers.map((b) => b.getBufferSize().catch(() => 0)),
+    ]);
+    return sizes.reduce((a, b) => a + b, 0);
+  },
+
+  /** Route a single event to its shard. */
+  add(event: IClickhouseEvent) {
+    eventBufferFor(event).add(event);
+  },
+
+  /** Bulk variant — preserves per-shard routing. */
+  bulkAdd(events: IClickhouseEvent[]) {
+    for (const event of events) {
+      eventBufferFor(event).add(event);
+    }
+  },
+
+  /** Synchronously force a flush of in-memory pending events on ALL buffers. */
+  async flush() {
+    await Promise.allSettled([
+      legacyEventBuffer.flush(),
+      ...shardedEventBuffers.map((b) => b.flush()),
+    ]);
+  },
+
+  /**
+   * Cron-driven flush. Runs tryFlush on legacy + every shard in parallel.
+   * Each tryFlush takes its own per-buffer Redis lock (lock:event,
+   * lock:event:0, lock:event:1, ...), so they never serialize on Redis.
+   * Errors on any one buffer are isolated (Promise.allSettled).
+   */
+  async tryFlush(options: { trigger?: 'add' | 'cron' } = {}) {
+    await Promise.allSettled([
+      legacyEventBuffer.tryFlush(options),
+      ...shardedEventBuffers.map((b) => b.tryFlush(options)),
+    ]);
+  },
+
+  /** CH SELECT helper — same in legacy + sharded modes. */
+  getActiveVisitorCount(projectId: string): Promise<number> {
+    return legacyEventBuffer.getActiveVisitorCount(projectId);
+  },
+
+  /**
+   * Wire flush observer to legacy + all shards. Setter to mirror the
+   * original public field semantics on EventBuffer.
+   */
+  set flushObserver(observer: EventBufferRedis['flushObserver']) {
+    legacyEventBuffer.flushObserver = observer;
+    for (const b of shardedEventBuffers) b.flushObserver = observer;
+  },
+
+  /** Wire add observer to legacy + all shards. */
+  set addObserver(observer: EventBufferRedis['addObserver']) {
+    legacyEventBuffer.addObserver = observer;
+    for (const b of shardedEventBuffers) b.addObserver = observer;
+  },
+
+  /** Expose .name for any caller that introspects it (metrics, logs). */
+  get name(): string {
+    return 'event';
+  },
+};
+
 export const profileBuffer = new ProfileBufferRedis();
 export const botBuffer = new BotBufferRedis();
 export const sessionBuffer = new SessionBuffer();

--- a/packages/db/src/buffers/index.ts
+++ b/packages/db/src/buffers/index.ts
@@ -58,6 +58,39 @@ function eventBufferFor(event: IClickhouseEvent): EventBufferRedis {
 }
 
 /**
+ * Map a result index back to a human-readable buffer name. The first slot
+ * is always the legacy buffer; the rest follow the order of
+ * shardedEventBuffers.
+ */
+function bufferLabelForIndex(idx: number): string {
+  if (idx === 0) return 'event';
+  return `event:${idx - 1}`;
+}
+
+/**
+ * Walk a Promise.allSettled result set and log any rejected outcomes via
+ * the legacy buffer's logger. We intentionally do NOT re-throw — the
+ * whole point of allSettled here is per-shard isolation, so a single
+ * failing shard must not block the others. But silently dropping the
+ * rejection would recreate exactly the silent-stall failure mode the
+ * rest of this module is trying to prevent, so we surface it loudly.
+ */
+function surfaceRejections(
+  results: PromiseSettledResult<unknown>[],
+  op: 'flush' | 'tryFlush'
+): void {
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i]!;
+    if (r.status === 'rejected') {
+      legacyEventBuffer.logger.error(
+        { err: r.reason, buffer: bufferLabelForIndex(i), op },
+        `Unexpected rejection from event buffer ${op}`
+      );
+    }
+  }
+}
+
+/**
  * Backward-compatible facade: the singleton callers expect. Routes adds to
  * the correct shard; flush fans out to all buffers in parallel; pending-
  * local count sums across all buffers; observers fan out to every buffer.
@@ -103,23 +136,29 @@ export const eventBuffer = {
 
   /** Synchronously force a flush of in-memory pending events on ALL buffers. */
   async flush() {
-    await Promise.allSettled([
+    const results = await Promise.allSettled([
       legacyEventBuffer.flush(),
       ...shardedEventBuffers.map((b) => b.flush()),
     ]);
+    surfaceRejections(results, 'flush');
   },
 
   /**
    * Cron-driven flush. Runs tryFlush on legacy + every shard in parallel.
    * Each tryFlush takes its own per-buffer Redis lock (lock:event,
    * lock:event:0, lock:event:1, ...), so they never serialize on Redis.
-   * Errors on any one buffer are isolated (Promise.allSettled).
+   *
+   * Per-buffer errors are isolated via Promise.allSettled (a single shard
+   * failing must not bring down the others), but any rejection IS logged
+   * via `surfaceRejections` — silently swallowing would recreate exactly
+   * the silent-stall class of bug this whole module is trying to prevent.
    */
   async tryFlush(options: { trigger?: 'add' | 'cron' } = {}) {
-    await Promise.allSettled([
+    const results = await Promise.allSettled([
       legacyEventBuffer.tryFlush(options),
       ...shardedEventBuffers.map((b) => b.tryFlush(options)),
     ]);
+    surfaceRejections(results, 'tryFlush');
   },
 
   /** CH SELECT helper — same in legacy + sharded modes. */

--- a/packages/redis/redis.ts
+++ b/packages/redis/redis.ts
@@ -2,8 +2,20 @@ import { getSuperJson, setSuperJson } from '@openpanel/json';
 import type { RedisOptions } from 'ioredis';
 import { Redis } from 'ioredis';
 
+// Per-command timeout. ioredis has no per-command timeout by default — if
+// the TCP connection goes half-dead (kernel says "alive" but no ACKs come
+// back), commands queue forever and any caller awaiting a Redis op wedges
+// indefinitely. With this set, a single command rejects after 30s and the
+// caller can re-queue / retry. Mirrors the order of magnitude of
+// CLICKHOUSE_REQUEST_TIMEOUT_MS so failures across the two systems
+// propagate consistently.
+const COMMAND_TIMEOUT_MS = process.env.REDIS_COMMAND_TIMEOUT_MS
+  ? Math.max(1000, Number.parseInt(process.env.REDIS_COMMAND_TIMEOUT_MS, 10))
+  : 30000;
+
 const options: RedisOptions = {
   connectTimeout: 10000,
+  commandTimeout: COMMAND_TIMEOUT_MS,
 };
 
 export { Redis };


### PR DESCRIPTION
## Summary

Self-hosted deployments under high sustained ingest can hit a silent stall on the event-buffer drain pipeline. Workers keep ack'ing groupmq jobs and pushing into `event_buffer:queue`, but the cron-driven flush stops landing rows in the events table. No errors are logged, worker heap stays flat, and `event_buffer:queue` grows unbounded in Redis until the host OOMs or the operator manually restarts the worker pods.

I hit it three times in twelve hours on a single-box deployment. This PR addresses the underlying causes and adds an opt-in sharded path that removes the single-flush-lock bottleneck.

Related: #382 (paths analytics OOM — another scale issue surfaced from the same deployment).

## Root cause

`processBuffer()` previously bracketed CH inserts between `LRANGE` and `LTRIM`. Two unsafe interleavings:

1. **Partial chunk failure**: a single chunk's CH insert throws (e.g. 30s `request_timeout`) → `processBuffer()` throws → `LTRIM` never runs → next flush re-`LRANGE`s the same head and re-INSERTs the chunks that had already succeeded last time. CH grows duplicates, the queue stays full, every retry compounds.
2. **Lock expiry mid-flush**: `lockTimeout` is 60s. Under load, a single flush can exceed that. The lock then lapses, another worker enters `processBuffer()` on the same queue head, races on `LTRIM`, same effect.

A third issue compounds these: `ioredis` has no per-command timeout by default. If a Redis connection goes half-dead (TCP says alive, no ACKs arrive), commands queue forever. The micro-batcher's `isFlushing` flag never clears in the `finally` block, so subsequent `add()` calls silently early-return — looking outwardly healthy while events are being dropped.

## Changes

### `packages/redis/redis.ts`

Adds `commandTimeout: 30s` (env-overridable via `REDIS_COMMAND_TIMEOUT_MS`) on the base ioredis options. Wedged commands reject instead of queuing forever, so the local micro-batch `finally` block always runs and the buffer never gets stuck on a half-dead connection.

### `packages/db/src/buffers/base-buffer.ts`

`tryFlush()` now runs a heartbeat that re-`EXPIRE`s the buffer lock every `lockTimeout / 3` seconds (min 5s) while `onFlush` is running. Slow flushes can no longer release the lock mid-flight and let a second worker race on the same data. Atomic Lua check-and-extend so only the lock owner refreshes it; heartbeat misses are non-fatal.

### `packages/db/src/buffers/event-buffer.ts`

- `processBuffer()` switches from `LRANGE` + `LTRIM` to atomic `LPOP COUNT`. Failed chunks are re-`LPUSH`ed at the head (order-preserving within the failed chunk) so partial CH failures retry without losing or duplicating events.
- Per-chunk `Promise.allSettled` isolates CH failures: one chunk's 30s timeout cannot poison the work of the other chunks.
- `finally`-block re-queue acts as defense-in-depth against any unexpected mid-flush throw — events held in JS heap are LPUSHed back to Redis before the exception propagates. At-least-once delivery with no data loss.
- Adds `EVENT_BUFFER_SHARDS` support (default 1 = bit-identical prior behavior). When > 1, events route by a stable djb2 hash on `device_id` to `event_buffer:queue:{0..N-1}`, each with its own `lock:event:{i}`. Removes the single-flush-lock bottleneck — up to N flushes can run in parallel.
- Default batch tuning: `batchSize` 4000→8000, `chunkSize` 1000→2000, `microBatchMaxSize` 100→200. Safe to push harder now that partial failures don't bloat the queue.

### `packages/db/src/buffers/index.ts`

- Replaces the direct `EventBuffer` singleton with a thin wrapper that exposes the same public surface (`add` / `bulkAdd` / `tryFlush` / `getBufferSize` / `getPendingLocalCount` / observer setters). `add()` routes to the correct shard; `tryFlush()` fans out `Promise.allSettled` across legacy + all shards in parallel.
- The legacy single-key buffer is ALWAYS instantiated so events queued by older code versions pre-deploy continue draining post-upgrade — no stalled-key state, no data loss on rollout.
- `getAllEventBufferInstances()` exposed for callers that want per-shard visibility.

## Backward compatibility

Default config is bit-identical to the previous behavior:
- Same Redis keys (`event_buffer:queue`, `lock:event`).
- Same flush cadence and observer surface.
- Same `eventBuffer.*` public API.
- During a rolling deploy from older code: existing `event_buffer:queue` entries drain via the legacy buffer instance; new events route to shards if `EVENT_BUFFER_SHARDS` > 1. No data loss, no stalled-key state.

## Observed effect in production (single-box, 16 vCPU / 64 GiB)

| Metric | Pre-patch (stuck) | Post-patch (same load) |
|---|---|---|
| CH ingest sustained | ~17 events/sec, dropping to 0 | 35–55 events/sec, stable |
| Peak per-minute | 2,925 (then queue grew) | 3,219, drained cleanly |
| Redis memory at peak | grew to 30 GiB before OOM | cycles 18–130 MB |
| Max single-shard queue depth | 5,138 (growing) | 418 (next flush drains) |
| Host load average | 16–25 (oversaturated) | 1.5–6.8 (comfortable) |
| Outcome after 30 min sustained load | silent stall, manual restart | no degradation |

A 30-minute monitor under the same production load shows zero `'Failed to flush'` or `'Partial CH insert'` warnings.

## Test plan

- [x] Verified `EVENT_BUFFER_SHARDS=1` keeps the existing single-key path bit-identical (no new keys appear; existing observability metrics show `buffer=event` rows unchanged).
- [x] Verified `EVENT_BUFFER_SHARDS=8` creates `event_buffer:queue:{0..7}` and `lock:event:{0..7}` keys at runtime; events route by device_id hash; per-shard flush observations appear with `buffer=event:0..7` labels.
- [x] Rolled forward from old code with non-empty `event_buffer:queue`; legacy buffer drained it cleanly while new events went to shards.
- [x] Live-tested under high-volume ingest (~95 events/sec peak SDK rate) on a single-box deployment of comparable size for 30 min: queue depths cycle 0–500 per shard; CH ingest matches inflow; no errors.
- [ ] Unit tests in `event-buffer.test.ts` covering partial chunk failure → LPUSH-back behavior. I can add these in a follow-up commit if useful.

Happy to break this into multiple smaller PRs if you'd prefer to review the patches individually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event buffer sharding with a unified facade to route, manage and aggregate per-shard buffers.

* **Bug Fixes**
  * Renew flush locks during processing to avoid mid-flight expiries.
  * After partial failures, re-queue only failed events and publish per-project success counts.
  * Enforce per-command Redis timeouts to avoid hanging operations.
  * Flush pending events during graceful shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->