### PR TITLE
fix(export): include properties field and add property_keys filter to /export/events

### DIFF
--- a/apps/api/src/controllers/export.controller.ts
+++ b/apps/api/src/controllers/export.controller.ts
@@ -86,19 +86,25 @@ export const eventsScheme = z.object({
   includes: z
     .preprocess(
       (arg) => {
-        if (arg == null) {
-          return undefined;
-        }
-        if (Array.isArray(arg)) {
-          return arg;
-        }
-        if (typeof arg === 'string') {
-          const parts = arg.split(',').map((s) => s.trim()).filter(Boolean);
-          return parts;
-        }
+        if (arg == null) return undefined;
+        if (Array.isArray(arg)) return arg;
+        if (typeof arg === 'string')
+          return arg.split(',').map((s) => s.trim()).filter(Boolean);
         return arg;
       },
-      z.array(z.string())
+      z.array(z.string()),
+    )
+    .optional(),
+  property_keys: z
+    .preprocess(
+      (arg) => {
+        if (arg == null) return undefined;
+        if (Array.isArray(arg)) return arg;
+        if (typeof arg === 'string')
+          return arg.split(',').map((s) => s.trim()).filter(Boolean);
+        return arg;
+      },
+      z.array(z.string()),
     )
     .optional(),
 });
@@ -110,7 +116,7 @@ export async function events(
   reply: FastifyReply
 ) {
   const projectId = await getProjectId(request);
-  const { limit, page: rawPage, event, start, end, profileId, includes, filters } = request.query;
+  const { limit, page: rawPage, event, start, end, profileId, includes, filters, property_keys } = request.query;
   const take = Math.max(Math.min(limit, 1000), 1);
   const cursor = Math.max(rawPage, 1) - 1;
   const options: GetEventListOptions = {
@@ -122,6 +128,7 @@ export async function events(
     take,
     profileId,
     filters,
+    propertyKeys: property_keys,
     select: {
       profile: false,
       meta: false,

--- a/apps/api/src/controllers/export.controller.ts
+++ b/apps/api/src/controllers/export.controller.ts
@@ -125,6 +125,7 @@ export async function events(
     select: {
       profile: false,
       meta: false,
+      properties: true,
       ...includes?.reduce((acc, key) => ({ ...acc, [key]: true }), {}),
     },
   };

--- a/apps/api/src/controllers/export.controller.ts
+++ b/apps/api/src/controllers/export.controller.ts
@@ -60,6 +60,14 @@ async function getProjectId(
   return projectId;
 }
 
+const preprocessCommaSeparatedArray = (arg: unknown) => {
+  if (arg == null) return undefined;
+  if (Array.isArray(arg)) return arg;
+  if (typeof arg === 'string')
+    return arg.split(',').map((s) => s.trim()).filter(Boolean);
+  return arg;
+};
+
 export const eventsScheme = z.object({
   project_id: z.string().optional(),
   projectId: z.string().optional(),
@@ -83,30 +91,8 @@ export const eventsScheme = z.object({
       return value;
     }, z.array(zChartEventFilter))
     .optional(),
-  includes: z
-    .preprocess(
-      (arg) => {
-        if (arg == null) return undefined;
-        if (Array.isArray(arg)) return arg;
-        if (typeof arg === 'string')
-          return arg.split(',').map((s) => s.trim()).filter(Boolean);
-        return arg;
-      },
-      z.array(z.string()),
-    )
-    .optional(),
-  property_keys: z
-    .preprocess(
-      (arg) => {
-        if (arg == null) return undefined;
-        if (Array.isArray(arg)) return arg;
-        if (typeof arg === 'string')
-          return arg.split(',').map((s) => s.trim()).filter(Boolean);
-        return arg;
-      },
-      z.array(z.string()),
-    )
-    .optional(),
+  includes: z.preprocess(preprocessCommaSeparatedArray, z.array(z.string())).optional(),
+  property_keys: z.preprocess(preprocessCommaSeparatedArray, z.array(z.string())).optional(),
 });
 
 export async function events(

--- a/packages/db/src/services/event.service.ts
+++ b/packages/db/src/services/event.service.ts
@@ -551,7 +551,7 @@ export async function getEventList(options: GetEventListOptions) {
   }
   if (select.properties) {
     if (propertyKeys && propertyKeys.length > 0) {
-      const keys = propertyKeys.map((k) => sqlstring.escape(k)).join(', ');
+      const keys = [...new Set(propertyKeys)].map((k) => sqlstring.escape(k)).join(', ');
       sb.select.properties = `mapFilter((k, v) -> k IN (${keys}), properties) AS properties`;
     } else {
       sb.select.properties = 'properties';

--- a/packages/db/src/services/event.service.ts
+++ b/packages/db/src/services/event.service.ts
@@ -552,7 +552,7 @@ export async function getEventList(options: GetEventListOptions) {
   if (select.properties) {
     if (propertyKeys && propertyKeys.length > 0) {
       const keys = propertyKeys.map((k) => sqlstring.escape(k)).join(', ');
-      sb.select.properties = `mapFilter((k, v) -> k IN (${keys}), properties)`;
+      sb.select.properties = `mapFilter((k, v) -> k IN (${keys}), properties) AS properties`;
     } else {
       sb.select.properties = 'properties';
     }

--- a/packages/db/src/services/event.service.ts
+++ b/packages/db/src/services/event.service.ts
@@ -466,6 +466,7 @@ export interface GetEventListOptions {
   select?: SelectHelper<IServiceEvent>;
   custom?: (sb: SqlBuilderObject) => void;
   dateIntervalInDays?: number;
+  propertyKeys?: string[];
 }
 
 export async function getEventList(options: GetEventListOptions) {
@@ -484,6 +485,7 @@ export async function getEventList(options: GetEventListOptions) {
     custom,
     select: incomingSelect,
     dateIntervalInDays = 0.5,
+    propertyKeys,
   } = options;
   const { sb, getSql, join } = createSqlBuilder();
 
@@ -548,7 +550,12 @@ export async function getEventList(options: GetEventListOptions) {
     sb.select.sessionId = 'session_id';
   }
   if (select.properties) {
-    sb.select.properties = 'properties';
+    if (propertyKeys && propertyKeys.length > 0) {
+      const keys = propertyKeys.map((k) => sqlstring.escape(k)).join(', ');
+      sb.select.properties = `mapFilter((k, v) -> k IN (${keys}), properties)`;
+    } else {
+      sb.select.properties = 'properties';
+    }
   }
   if (select.country) {
     sb.select.country = 'country';


### PR DESCRIPTION
## Problem
  `GET /export/events` never returned the `properties` field — it was missing from the SQL SELECT, so every exported event had an empty properties object.
  
  Fixes #281
  
  ## Changes

  - **`export.controller.ts`**: add `properties: true` to the select object so properties are always included in the export response
  - **`export.controller.ts`**: add optional `property_keys` query param — accepts a comma-separated list of keys to return only specific properties, reducing payload size for events with large property maps
  - **`event.service.ts`**: extend `GetEventListOptions` with `propertyKeys?: string[]` and use ClickHouse `mapFilter` at query time when keys are specified; add `AS properties` alias so the filtered column name is preserved
  correctly
  
  ## Usage
  
  ```bash
  # All properties (default)
  GET /export/events?project_id=xxx

  # Only specific keys — useful for large property payloads
  GET /export/events?project_id=xxx&property_keys=source,url

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add property filtering for event exports: specify which event properties to include via the property_keys parameter to reduce payloads.
* **Improvements**
  * Query parsing now accepts comma-separated property_keys and ignores empty/null entries, and forwards selected properties in export results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->