### PR TITLE
feat(event-meta): add description field to EventMeta

### DIFF
--- a/apps/start/src/modals/Modal/Container.tsx
+++ b/apps/start/src/modals/Modal/Container.tsx
@@ -1,9 +1,8 @@
 import type { DialogContentProps } from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
 import { useRef } from 'react';
-import { popModal } from '..';
 import { Button } from '@/components/ui/button';
-import { DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { DialogClose, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { cn } from '@/utils/cn';
 
 interface ModalContentProps extends DialogContentProps {
@@ -83,15 +82,12 @@ export function ModalHeader({
           )}
         </div>
         {onClose !== false && (
-          <Button
-            className="-mt-2"
-            onClick={() => (onClose ? onClose() : popModal())}
-            size="sm"
-            variant="ghost"
-          >
-            <X className="h-4 w-4" />
-            <span className="sr-only">Close</span>
-          </Button>
+          <DialogClose asChild onClick={() => onClose?.()}>
+            <Button className="-mt-2" size="sm" variant="ghost">
+              <X className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogClose>
         )}
       </div>
     </div>

--- a/apps/start/src/modals/edit-event.tsx
+++ b/apps/start/src/modals/edit-event.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 import { useAppParams } from '@/hooks/use-app-params';
 import { useTRPC } from '@/integrations/trpc/react';
 import { cn } from '@/utils/cn';
@@ -37,6 +38,7 @@ export default function EditEvent({ id }: Props) {
   const [selectedIcon, setIcon] = useState<string | null>(null);
   const [selectedColor, setColor] = useState(EventIconRecords.default!.color);
   const [conversion, setConversion] = useState(false);
+  const [description, setDescription] = useState('');
   const [step, setStep] = useState<'icon' | 'color'>('icon');
   useEffect(() => {
     if (event?.meta?.icon) {
@@ -47,6 +49,9 @@ export default function EditEvent({ id }: Props) {
     }
     if (event?.meta?.conversion) {
       setConversion(event.meta.conversion);
+    }
+    if (event?.meta?.description) {
+      setDescription(event.meta.description);
     }
   }, [event]);
 
@@ -86,6 +91,15 @@ export default function EditEvent({ id }: Props) {
               <span>Yes, this event is important!</span>
             </div>
           </label>
+        </div>
+        <div>
+          <Label className="mb-2 block">Description</Label>
+          <Textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="What does this event mean? When does it fire?"
+            rows={3}
+          />
         </div>
         <AnimatePresence mode="wait">
           {step === 'icon' ? (
@@ -203,6 +217,7 @@ export default function EditEvent({ id }: Props) {
               icon: selectedIcon ?? EventIconRecords.default!.icon,
               color: selectedColor ?? EventIconRecords.default!.color,
               conversion,
+              description: description.trim() || undefined,
             })
           }
         >

--- a/apps/start/src/modals/edit-event.tsx
+++ b/apps/start/src/modals/edit-event.tsx
@@ -217,7 +217,7 @@ export default function EditEvent({ id }: Props) {
               icon: selectedIcon ?? EventIconRecords.default!.icon,
               color: selectedColor ?? EventIconRecords.default!.color,
               conversion,
-              description: description.trim() || undefined,
+              description: description.trim(),
             })
           }
         >

--- a/packages/db/prisma/migrations/20260607120000_add_event_meta_description/migration.sql
+++ b/packages/db/prisma/migrations/20260607120000_add_event_meta_description/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "event_meta" ADD COLUMN IF NOT EXISTS "description" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -500,12 +500,13 @@ model ShareWidget {
 }
 
 model EventMeta {
-  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  name       String
-  conversion Boolean?
-  color      String?
-  icon       String?
-  projectId  String
+  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name        String
+  conversion  Boolean?
+  color       String?
+  icon        String?
+  description String?
+  projectId   String
   project    Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
   createdAt DateTime @default(now())

--- a/packages/trpc/src/routers/event.ts
+++ b/packages/trpc/src/routers/event.ts
@@ -38,10 +38,11 @@ export const eventRouter = createTRPCRouter({
         icon: z.string().optional(),
         color: z.string().optional(),
         conversion: z.boolean().optional(),
+        description: z.string().optional(),
       }),
     )
     .mutation(
-      async ({ input: { projectId, name, icon, color, conversion } }) => {
+      async ({ input: { projectId, name, icon, color, conversion, description } }) => {
         await getEventMetasCached.clear(projectId);
         return db.eventMeta.upsert({
           where: {
@@ -50,8 +51,8 @@ export const eventRouter = createTRPCRouter({
               projectId,
             },
           },
-          create: { projectId, name, icon, color, conversion },
-          update: { icon, color, conversion },
+          create: { projectId, name, icon, color, conversion, description },
+          update: { icon, color, conversion, description },
         });
       },
     ),


### PR DESCRIPTION
There is no way to document what an event means inside OpenPanel. Teams end up maintaining a separate wiki or spreadsheet to explain their event taxonomy — this adds that context directly to the platform.
  
  ## Changes
  
  - **`schema.prisma`**: add optional `description String?` field to `EventMeta` model
  - **`migration.sql`**: `ALTER TABLE event_meta ADD COLUMN IF NOT EXISTS "description" TEXT`
  - **`packages/trpc/src/routers/event.ts`**: accept and persist `description` in `updateEventMeta`
  - **`apps/start/src/modals/edit-event.tsx`**: textarea in the Edit Event modal to set/edit the description
  - **`apps/start/src/modals/Modal/Container.tsx`**: fix modal X button — wrap in `DialogClose` (Radix native) instead of calling `popModal()` directly, which could race with Radix's internal open-state tracking

  ## How it looks
  
  Open any event in the Events page → click the icon → Edit Event modal now has a **Description** field below the Conversion checkbox.
  
  ## Future scope
  
  The description field is a foundation for a full Lexicon view (event catalog with descriptions, display names, volume — similar to Mixpanel Lexicon). That can be built as a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event descriptions: add and edit a description for events to provide richer context.

* **Improvements**
  * Modal close behavior refined for more consistent and reliable closing across dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->