### PR TITLE
fix: enable organization creation from project selector

### DIFF
--- a/apps/start/src/components/project-selector.tsx
+++ b/apps/start/src/components/project-selector.tsx
@@ -151,7 +151,10 @@ export default function ProjectSelector({
               ))}
               <DropdownMenuSeparator />
               <DropdownMenuItem asChild>
-                <Link to={'/onboarding/project'}>
+                <Link
+                  search={{ createNewOrg: true }}
+                  to={'/onboarding/project'}
+                >
                   New organization
                   <DropdownMenuShortcut>
                     <PlusIcon size={16} />

--- a/apps/start/src/routes/_steps.onboarding.project.tsx
+++ b/apps/start/src/routes/_steps.onboarding.project.tsx
@@ -30,6 +30,9 @@ import { cn } from '@/utils/cn';
 
 const validateSearch = z.object({
   inviteId: z.string().optional(),
+  createNewOrg: z
+    .preprocess((value) => value === true || value === 'true', z.boolean())
+    .optional(),
 });
 export const Route = createFileRoute('/_steps/onboarding/project')({
   component: Component,
@@ -63,6 +66,7 @@ export const Route = createFileRoute('/_steps/onboarding/project')({
 type IForm = z.infer<typeof zOnboardingProject>;
 
 function Component() {
+  const search = Route.useSearch();
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const { data: organizations } = useQuery(
@@ -121,7 +125,9 @@ function Component() {
   });
 
   const [showCorsInput, setShowCorsInput] = useState(false);
-  const [createNewOrg, setCreateNewOrg] = useState(false);
+  const [createNewOrg, setCreateNewOrg] = useState(
+    () => search.createNewOrg ?? false
+  );
   const canUseExistingWorkspace = organizations.length > 0;
   const showCreateForm = createNewOrg || organizations.length === 0;
 


### PR DESCRIPTION
## Summary

Fixed a dashboard issue preventing self-hosted users from creating additional organizations.

Multi-organization support is already available in self-hosted deployments and does not require any extra environment flags beyond the standard self-hosted configuration (`SELF_HOSTED=true`, `DASHBOARD_URL`, `API_URL`). The backend onboarding flow already supports creating new organizations and automatically assigns the creator the `org:admin` role.

The issue was in the UI flow. The **"New organization"** option in the organization selector redirected users to the onboarding page, which defaulted to **"Use existing workspace"** when an organization already existed. This change updates the flow to open the workspace creation mode directly.

### Changes

* Updated organization selector navigation

  * `project-selector.tsx`
* Updated onboarding page initialization

  * `_steps.onboarding.project.tsx`

### Notes

The `POST https://api.openpanel.dev/track` `401` error is unrelated to organization creation. It comes from the dashboard telemetry client attempting to send analytics to hosted OpenPanel when `VITE_OP_CLIENT_ID` is present or misconfigured.

Fixes #388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the organization creation flow to properly preserve the intent to create a new organization when navigating to the project onboarding step, ensuring the correct initial state is maintained throughout the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->