### PR TITLE
fix(start): handle clipboard copy failures

### DIFF
--- a/apps/start/src/utils/clipboard.ts
+++ b/apps/start/src/utils/clipboard.ts
@@ -1,13 +1,65 @@
 import { toast } from 'sonner';
 
-export function clipboard(value: string | number, description?: null | string) {
-  navigator.clipboard.writeText(value.toString());
+function copyWithTextarea(value: string) {
+  if (typeof document === 'undefined' || !document.execCommand) {
+    return false;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = value;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-9999px';
+  textarea.style.left = '-9999px';
+
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  try {
+    return document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+export async function clipboard(
+  value: string | number,
+  description?: null | string
+) {
+  const text = value.toString();
+  const clipboardApi =
+    typeof navigator === 'undefined' ? undefined : navigator.clipboard;
+  let copied = false;
+
+  if (clipboardApi?.writeText) {
+    try {
+      await clipboardApi.writeText(text);
+      copied = true;
+    } catch {
+      copied = false;
+    }
+  }
+
+  if (!copied) {
+    copied = copyWithTextarea(text);
+  }
+
+  if (!copied) {
+    toast.error('Failed to copy to clipboard', {
+      description: 'Please copy it manually.',
+    });
+    return;
+  }
+
   toast(
     'Copied to clipboard',
     description !== null
       ? {
-          description: description ?? value.toString(),
+          description: description ?? text,
         }
-      : {},
+      : {}
   );
 }


### PR DESCRIPTION
## Summary

- Add a fallback clipboard copy path for browsers/environments where `navigator.clipboard.writeText` is unavailable or rejects.
- Show an error toast instead of a success toast when all copy methods fail.

## Why

The shared clipboard helper previously called `navigator.clipboard.writeText(...)` directly and showed a success toast immediately. In insecure contexts, permission-restricted browser shells, or other unsupported environments, that can fail silently and leave actions like **Copy invite link** without actually updating the clipboard.

Closes #400.

## Validation

- `pnpm exec biome check apps/start/src/utils/clipboard.ts` passed.

## Note

I intentionally left the existing Vitest workspace setup unchanged because `apps/start` is currently excluded from the root Vitest workspace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved copy-to-clipboard behavior with broader browser/environment support.
* **Bug Fixes**
  * Clipboard writes are now attempted asynchronously and safely.
  * Added a fallback copy method when the standard clipboard API isn’t available.
  * Copy failures now show an explicit error toast with manual-copy guidance.
  * Success feedback remains available, with improved toast message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->