### PR TITLE
fix(db): qualify event-level properties access in funnel & conversion queries

### DIFF
--- a/packages/db/src/services/conversion.service.ts
+++ b/packages/db/src/services/conversion.service.ts
@@ -118,11 +118,17 @@ export class ConversionService {
 
     const eventA = events[0]!;
     const eventB = events[1]!;
+    // Qualify with 'events' so event-level `properties[...]` becomes
+    // `events.properties[...]` — required when the conversion query also
+    // joins the profiles table (which exposes a `properties` column).
+    // Without the qualifier ClickHouse fails with "ambiguous identifier
+    // 'properties'" whenever a step filters on properties.X while a
+    // breakdown is on profile.properties.Y.
     const whereA = Object.values(
-      getEventFiltersWhereClause(eventA.filters, projectId),
+      getEventFiltersWhereClause(eventA.filters, projectId, 'events'),
     ).join(' AND ');
     const whereB = Object.values(
-      getEventFiltersWhereClause(eventB.filters, projectId),
+      getEventFiltersWhereClause(eventB.filters, projectId, 'events'),
     ).join(' AND ');
 
     const funnelWindowSeconds = funnelWindow * 3600;

--- a/packages/db/src/services/funnel.service.ts
+++ b/packages/db/src/services/funnel.service.ts
@@ -42,7 +42,13 @@ export class FunnelService {
   getFunnelConditions(events: IChartEvent[] = [], projectId?: string): string[] {
     return events.map((event) => {
       const { sb, getWhere } = createSqlBuilder();
-      sb.where = getEventFiltersWhereClause(event.filters, projectId);
+      // Qualify with 'events' so event-level `properties[...]` becomes
+      // `events.properties[...]` — required because the funnel CTE may join
+      // the profiles table (which also exposes a `properties` column).
+      // Without the qualifier ClickHouse fails with "ambiguous identifier
+      // 'properties'" whenever a step filters on properties.X while another
+      // step filters on profile.properties.Y.
+      sb.where = getEventFiltersWhereClause(event.filters, projectId, 'events');
       sb.where.name = `events.name = ${sqlstring.escape(event.name)}`;
       return getWhere().replace('WHERE ', '');
     });


### PR DESCRIPTION
## Summary

Fixes a 500 error when a funnel mixes `profile.*` filters with event-level `properties.*` filters on different steps (and the equivalent for conversion charts).

## Repro (funnel)

A funnel with 4 steps:
1. `$identify` filtered by `profile.properties.quotaPlan = 'FRAMEO_BASIC'`
2. `homePageViewed` (no filter)
3. `pricingModalViewed` filtered by `properties.$current_url contains 'canvas'`
4. `paymentSuccess`

Produces:

```
JOIN ... ambiguous identifier 'properties'. In scope funnel AS (SELECT ... 
windowFunnel(...)(..., 
  ((profile.properties['quotaPlan']) = 'FRAMEO_BASIC') AND (name = '$identify'), 
  name = 'homePageViewed', 
  ((properties['$current_url']) LIKE '%canvas%') AND (name = 'pricingModalViewed'),  ← unqualified
  name = 'paymentSuccess') AS level 
FROM events 
LEFT JOIN (SELECT id, properties FROM profiles FINAL WHERE project_id = 'X') AS profile
  ON profile.id = events.profile_id ...)
```

Removing either the `$current_url` filter OR the `profile.properties.quotaPlan` filter makes the query work.

## Root cause

The funnel CTE adds a profile JOIN that selects `properties` (the whole Map) whenever any step references `profile.properties.X`. ClickHouse then has TWO `properties` columns in scope — `events.properties` and `profile.properties` — and any unqualified `properties['key']` in a step condition is ambiguous.

The conversion service has the equivalent issue when a `profile.properties.X` breakdown is combined with event-level `properties.X` filters.

## Fix

`getEventFiltersWhereClause` already accepts an `eventsAlias` parameter (line 1125, documented to handle exactly this case). It's used at `chart.service.ts:448` and `:866` with `'e'` for the regular chart paths. The funnel and conversion services just weren't passing it.

Pass `eventsAlias='events'` (matching the unaliased table name used in those services):

- `funnel.service.ts:getFunnelConditions` → propagates to `windowFunnel` step conditions
- `conversion.service.ts` → propagates to the two `whereA` / `whereB` step conditions

After the fix, the SQL becomes:

```
windowFunnel(...)(..., 
  ((profile.properties['quotaPlan']) = 'FRAMEO_BASIC') AND (events.name = '$identify'), 
  events.name = 'homePageViewed', 
  ((events.properties['$current_url']) LIKE '%canvas%') AND (events.name = 'pricingModalViewed'),
  ...
)
```

`events.properties[...]` is explicitly bound to the events table — no ambiguity with `profile.properties[...]`.

## Why this approach

The codebase already has the `eventsAlias` plumbing for exactly this purpose. Other chart paths (regular `chart` and `chart breakdown`) already use it. Funnel + conversion were the two paths still missing it — likely an oversight from when `eventsAlias` was added.

This keeps the patch minimal (15 lines, 2 files) and consistent with the existing pattern instead of introducing a different mechanism.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of event filter conditions in conversion and funnel queries.
  * Prevented ambiguous `properties` references when filters are used alongside profile-related data.
  * Made funnel and conversion results more reliable in cases with mixed event and profile attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->