### PR TITLE
fix(worker): await GroupMQ worker.run() to prevent silent shard-stuck

### DIFF
--- a/apps/worker/src/boot-workers.ts
+++ b/apps/worker/src/boot-workers.ts
@@ -167,7 +167,17 @@ export function bootWorkers() {
     worker.on('completed', markEventsActivity);
     worker.on('drained', markEventsActivity);
 
-    worker.run();
+    // Fail loud on startup — silent stuck shard otherwise.
+    // Runtime errors are handled by the shared workers.forEach listener below.
+    worker.run().catch((err) => {
+      logger.error(
+        { shard: index, queueName, err },
+        'Worker startup failed — exiting',
+      );
+      // setTimeout+unref to let the logger flush before exit (matches the
+      // pattern used by uncaughtException/unhandledRejection handlers below).
+      setTimeout(() => process.exit(1), 1000).unref();
+    });
     workers.push(worker);
     logger.info({ concurrency }, `Started worker for ${queueName}`);
   }


### PR DESCRIPTION
Fixes #412.

`worker.run()` was fire-and-forget in the GroupMQ event-worker loop. If the underlying `redis.duplicate()` blocking-client setup silently fails for a specific shard, the promise rejects with no handler and the worker enters GroupMQ's exponential backoff sleep forever — pod appears healthy, `"Started worker for events_N"` is logged, but that shard never consumes.

Real incident: 3 of 24 event shards silently stopped consuming after a rolling deploy; 570K jobs accumulated in Redis over ~2h before it was noticed. Zero error logs. Manual restart of the StatefulSet resolved it (fresh `redis.duplicate()` succeeded on retry).

The fix mirrors what's already done for the Kafka consumer startup right below (which `.catches` errors from `startKafkaEventsConsumer`).

Also adds a `worker.on('error', ...)` listener so runtime errors on the blocking client (BZPOPMIN etc.) after startup are visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker startup behavior: startup failures now fail fast, log the shard index and queue name, and then terminate the process to prevent partial/unstable operation.
  * Runtime worker error logging continues to include shard and queue details (no change to that existing behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->