### PR TITLE
fix: dashboard esm-env runtime alias

### DIFF
--- a/apps/start/Dockerfile
+++ b/apps/start/Dockerfile
@@ -139,7 +139,7 @@ RUN set -eux; \
             > "${node_modules}/esm-env/package.json"; \
     fi; \
     cd /app/apps/start/.output/server; \
-    node --input-type=module -e 'import("esm-env").then((env) => { if (env.BROWSER !== false || env.NODE !== true) process.exit(1); })'
+    node --input-type=module -e 'const assert = await import("node:assert/strict"); const env = await import("esm-env"); assert.equal(env.BROWSER, false, "esm-env BROWSER should be false in the Node SSR runtime"); assert.equal(env.NODE, true, "esm-env NODE should be true in the Node SSR runtime"); assert.equal(env.DEV, false, "esm-env DEV should be false in the production runtime");'
 
 # Copy necessary packages
 COPY --from=build /app/packages/db ./packages/db

--- a/apps/start/Dockerfile
+++ b/apps/start/Dockerfile
@@ -120,6 +120,27 @@ COPY --from=build /app/apps/start/.output ./apps/start/.output
 COPY --from=build /app/apps/start/dist ./apps/start/dist
 COPY --from=build /app/apps/start/package.json ./apps/start/
 
+# The standalone Nitro output preserves the target package name for the pnpm
+# esm-env -> esm-env-runtime override. @number-flow/react imports "esm-env"
+# at runtime, so keep that package name resolvable inside the SSR bundle.
+RUN set -eux; \
+    node_modules="/app/apps/start/.output/server/node_modules"; \
+    test -d "${node_modules}/esm-env-runtime"; \
+    if [ ! -d "${node_modules}/esm-env" ]; then \
+        mkdir -p "${node_modules}/esm-env"; \
+        cp "${node_modules}/esm-env-runtime/node.js" "${node_modules}/esm-env/index.js"; \
+        printf '%s\n' \
+            '{' \
+            '  "name": "esm-env",' \
+            '  "version": "1.1.4",' \
+            '  "type": "module",' \
+            '  "exports": "./index.js"' \
+            '}' \
+            > "${node_modules}/esm-env/package.json"; \
+    fi; \
+    cd /app/apps/start/.output/server; \
+    node --input-type=module -e 'import("esm-env").then((env) => { if (env.BROWSER !== false || env.NODE !== true) process.exit(1); })'
+
 # Copy necessary packages
 COPY --from=build /app/packages/db ./packages/db
 COPY --from=build /app/packages/trpc ./packages/trpc


### PR DESCRIPTION
## Summary
- add an `esm-env` package alias inside the self-hosted dashboard SSR bundle when pnpm emits only `esm-env-runtime`
- verify during the dashboard image build that `import("esm-env")` resolves with the expected Node runtime flags

## Root cause
`@number-flow/react` imports `esm-env` at runtime. The workspace override resolves that dependency to `esm-env-runtime`, and the standalone Nitro output copies the target package directory into `.output/server/node_modules` without preserving the `esm-env` alias. In the published self-hosted dashboard image this causes SSR routes using NumberFlow to fail with `ERR_MODULE_NOT_FOUND`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production runtime compatibility for server deployments to better handle environment-specific ESM behavior.
  * Added a build-time validation check to detect mismatches in module behavior before shipping, reducing the chance of runtime failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->