### PR TITLE
fix: display session revenue in currency units

### DIFF
--- a/apps/start/src/components/chat/tool-results/chat-profile-result.tsx
+++ b/apps/start/src/components/chat/tool-results/chat-profile-result.tsx
@@ -11,6 +11,7 @@ import {
   ToolStateGuard,
 } from './shared';
 import type { ToolResultProps } from './types';
+import { useNumber } from '@/hooks/use-numer-formatter';
 
 /**
  * Renders the result of `get_profile_full` — profile + metrics + recent
@@ -54,6 +55,7 @@ function Inner({ output }: { output: unknown }) {
 }
 
 function SuccessCard({ value }: { value: ProfileFullSuccess }) {
+  const number = useNumber();
   const { profile, metrics, dashboard_url } = value;
   const title =
     profile &&
@@ -96,7 +98,7 @@ function SuccessCard({ value }: { value: ProfileFullSuccess }) {
           {typeof metrics.revenue === 'number' && metrics.revenue > 0 && (
             <ResultRow>
               <ResultLabel>Revenue</ResultLabel>
-              <ResultValue>${metrics.revenue.toFixed(2)}</ResultValue>
+              <ResultValue>{number.currency(metrics.revenue / 100)}</ResultValue>
             </ResultRow>
           )}
         </div>

--- a/apps/start/src/components/sessions/table/columns.tsx
+++ b/apps/start/src/components/sessions/table/columns.tsx
@@ -6,6 +6,7 @@ import { ColumnCreatedAt } from '@/components/column-created-at';
 import { ProjectLink } from '@/components/links';
 import { ProfileAvatar } from '@/components/profiles/profile-avatar';
 import { SerieIcon } from '@/components/report-chart/common/serie-icon';
+import { useNumber } from '@/hooks/use-numer-formatter';
 import { getProfileName } from '@/utils/getters';
 
 function formatDuration(milliseconds: number): string {
@@ -26,6 +27,7 @@ function formatDuration(milliseconds: number): string {
 }
 
 export function useColumns() {
+  const number = useNumber();
   const columns: ColumnDef<IServiceSession>[] = [
     {
       accessorKey: 'createdAt',
@@ -258,7 +260,7 @@ export function useColumns() {
         const session = row.original;
         return session.revenue > 0 ? (
           <div className="font-medium text-green-600">
-            ${session.revenue.toFixed(2)}
+            {number.currency(session.revenue / 100)}
           </div>
         ) : (
           <div className="text-muted-foreground">-</div>

--- a/apps/start/src/routes/_app.$organizationId.$projectId.sessions_.$sessionId.tsx
+++ b/apps/start/src/routes/_app.$organizationId.$projectId.sessions_.$sessionId.tsx
@@ -1,5 +1,5 @@
 import type { IServiceEvent, IServiceSession } from '@openpanel/db';
-import { useSuspenseQuery, useQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { EventIcon } from '@/components/events/event-icon';
 import FullPageLoadingState from '@/components/full-page-loading-state';
@@ -279,7 +279,12 @@ function Component() {
                   ? [{ name: 'utmCampaign', value: session.utmCampaign }]
                   : []),
                 ...(session.revenue > 0
-                  ? [{ name: 'revenue', value: `$${session.revenue}` }]
+                  ? [
+                      {
+                        name: 'revenue',
+                        value: number.currency(session.revenue / 100),
+                      },
+                    ]
                   : []),
                 { name: 'country', value: session.country, event: fakeEvent },
                 ...(session.city


### PR DESCRIPTION
## Summary

- convert session revenue from stored cents before rendering
- use the existing locale-aware currency formatter in all three affected views

## Validation

- `pnpm --filter start typecheck`

Fixes #422


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved revenue displays across profile results and session views.
  * Revenue values are now consistently formatted as currency, including correct conversion from stored minor units.
  * Updated session tables and session details to use the same currency formatting for clearer, more accurate financial information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->