### PR TITLE
fix: make truncated KeyValueGrid values readable and copyable

### DIFF
--- a/apps/start/src/components/ui/key-value-grid.tsx
+++ b/apps/start/src/components/ui/key-value-grid.tsx
@@ -109,7 +109,10 @@ export function KeyValueGrid({
     <div
       className={cn('grid card overflow-hidden', gridCols[columns], className)}
     >
-      {data.map((item, index) => (
+      {data.map((item, index) => {
+        const stringValue = toStringValue(item.value);
+
+        return (
         <div
           key={`${item.name}-${index}`}
           className={cn(
@@ -127,11 +130,11 @@ export function KeyValueGrid({
           tabIndex={onItemClick ? 0 : undefined}
           role={onItemClick ? 'button' : undefined}
         >
-          {copyable && (
+          {copyable && stringValue !== undefined && (
             <button
               onClick={(e) => {
                 e.stopPropagation();
-                clipboard(toStringValue(item.value) ?? item.value);
+                clipboard(stringValue);
               }}
               type="button"
               className="absolute left-2 top-1/2 -translate-y-1/2 -translate-x-full opacity-0 group-hover:translate-x-0 group-hover:opacity-100 transition-all duration-200 ease-out bg-background border border-border rounded p-1 shadow-sm z-10"
@@ -147,12 +150,13 @@ export function KeyValueGrid({
               'text-right text-sm font-mono truncate min-w-0 max-w-[60%]',
               valueClassName,
             )}
-            title={toStringValue(item.value)}
+            title={stringValue}
           >
             {renderValue ? renderValue(item) : defaultRenderValue(item)}
           </div>
         </div>
-      ))}
+        );
+      })}
 
       {data.length === 0 && (
         <div className="text-center text-muted-foreground py-8 col-span-full">

--- a/apps/start/src/components/ui/key-value-grid.tsx
+++ b/apps/start/src/components/ui/key-value-grid.tsx
@@ -28,6 +28,35 @@ interface KeyValueGridProps {
   copyable?: boolean;
 }
 
+/**
+ * The value cell truncates, so the full value is only reachable through the native
+ * tooltip and the copy button. Both need a string, and objects render as JSON here,
+ * so stringify them rather than leaving the value unreadable.
+ */
+export function toStringValue(value: unknown): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return undefined;
+    }
+  }
+
+  return String(value);
+}
+
 export function KeyValueGrid({
   data,
   columns = 1,
@@ -102,18 +131,7 @@ export function KeyValueGrid({
             <button
               onClick={(e) => {
                 e.stopPropagation();
-                if (typeof item.value === 'object') {
-                  try {
-                    const value = JSON.stringify(item.value);
-                    clipboard(value);
-                  }
-                  catch {
-                    clipboard(item.value);
-                  }
-                }
-                else {
-                  clipboard(item.value);
-                }
+                clipboard(toStringValue(item.value) ?? item.value);
               }}
               type="button"
               className="absolute left-2 top-1/2 -translate-y-1/2 -translate-x-full opacity-0 group-hover:translate-x-0 group-hover:opacity-100 transition-all duration-200 ease-out bg-background border border-border rounded p-1 shadow-sm z-10"
@@ -129,7 +147,7 @@ export function KeyValueGrid({
               'text-right text-sm font-mono truncate min-w-0 max-w-[60%]',
               valueClassName,
             )}
-            title={typeof item.value === 'string' ? item.value : undefined}
+            title={toStringValue(item.value)}
           >
             {renderValue ? renderValue(item) : defaultRenderValue(item)}
           </div>

--- a/apps/start/src/modals/event-details.tsx
+++ b/apps/start/src/modals/event-details.tsx
@@ -286,6 +286,7 @@ function EventDetailsContent({ id, createdAt, projectId }: Props) {
             {propertiesMode === 'table' && (
             <KeyValueGrid
               columns={1}
+              copyable
               data={properties}
               onItemClick={(item) => {
                 popModal();
@@ -310,6 +311,7 @@ function EventDetailsContent({ id, createdAt, projectId }: Props) {
           </div>
           <KeyValueGrid
             columns={1}
+            copyable
             data={data}
             onItemClick={(item) => {
               const isFilterable = item.value && (filterable as any)[item.name];


### PR DESCRIPTION
Closes #381

## Problem

In the event details popup, long values are truncated with no way to read or copy the remainder. Two separate gaps in `KeyValueGrid`:

1. **The tooltip was string-only.** `title={typeof item.value === 'string' ? item.value : undefined}` — so object values (which render as `JSON.stringify(...)`) and numbers got no tooltip, which is exactly the case in the screenshot on the issue.
2. **No copy affordance in the popup.** `KeyValueGrid` already supports a `copyable` prop, but `event-details.tsx` never passed it, so neither of its two grids rendered the copy button.

## Change

- Adds a shared `toStringValue()` and uses it for both the `title` tooltip and the clipboard, replacing the inline stringify that lived in the copy handler.
- Passes `copyable` on both grids in the event details popup.

Behavioural notes: `0` and `false` now produce tooltips rather than being dropped, and a circular object degrades to no tooltip instead of throwing out of the render path. `null`/`undefined` still yield no tooltip.

The copy button already calls `e.stopPropagation()`, so it doesn't trigger the row's filter-on-click.

## Scope

Deliberately minimal. The `View JSON` toggle added for Properties already covers part of this for that section, but the Information grid has no equivalent, and neither had a copy button. This fixes both without touching the layout.

Happy to go further if you'd prefer a real expand-on-click or a scrollable value cell — I kept it to the tooltip + copy path since row clicks are already bound to setting a filter, so click-to-expand would need a different affordance.

## Verification

Honest caveat on this one: `apps/start` is excluded from the vitest workspace (`'!apps/start'`) and has no test files, so I haven't added tests — happy to if you'd like the helper covered somewhere it would actually run.

What I did check:

- `tsc --noEmit` on `apps/start` produces a byte-identical error list before and after the change (385 pre-existing errors, 0 new).
- `biome check` on both touched files reports the same 25 pre-existing diagnostics before and after. Left alone deliberately, per the "don't format yet" note in the repo.
- `toStringValue` exercised directly across string / long string / number / `0` / `false` / `null` / `undefined` / object / array / `Date` / circular.

I have not been able to verify visually, since that needs the full Postgres + Redis + ClickHouse stack running with event data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added copy functionality for values in the event details modal’s Properties and Information sections.
  * Improved value display and tooltips for dates, objects, and other data types.
  * Added graceful handling for values that cannot be serialized.
  * Values are now consistently formatted for copying and viewing, including ISO-formatted dates and readable object representations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->