### PR TITLE
fix: broken star history chart in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can find the how to [here](https://openpanel.dev/docs/self-hosting/self-host
 
 **Give us a star if you like it!**
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Openpanel-dev/openpanel&type=Date)](https://star-history.com/#Openpanel-dev/openpanel&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Openpanel-dev/openpanel&type=Date)](https://star-history.dera.page/#Openpanel-dev/openpanel&Date)
 
 ## Development
 


### PR DESCRIPTION
The star history chart in our readme is broken, so this change points it to a working mirror that does not rely on the api subdomain anymore. We are switching to it because the current star history chart is broken due to GitHub stargazer API restrictions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History badge to use the new Star History service and link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->