### PR TITLE
fix(auth): don't block existing OAuth users when ALLOW_REGISTRATION=false

### DIFF
--- a/apps/api/src/controllers/oauth-callback.controller.tsx
+++ b/apps/api/src/controllers/oauth-callback.controller.tsx
@@ -8,7 +8,12 @@ import {
   setLastAuthProviderCookie,
   setSessionTokenCookie,
 } from '@openpanel/auth';
-import { type Account, connectUserToOrganization, db } from '@openpanel/db';
+import {
+  type Account,
+  connectUserToOrganization,
+  db,
+  getIsRegistrationAllowed,
+} from '@openpanel/db';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { LogError } from '@/utils/errors';
@@ -130,6 +135,17 @@ async function handleNewUser({
         providerName,
       }
     );
+  }
+
+  // Enforce the self-hosting registration policy here rather than before the
+  // IdP redirect — this is the first point where we know the user is new, so
+  // returning users are never caught by it.
+  if (!(await getIsRegistrationAllowed(inviteId))) {
+    throw new LogError('Registrations are not allowed', {
+      oauthUser,
+      providerName,
+      inviteId,
+    });
   }
 
   const user = await db.user.create({

--- a/apps/api/src/controllers/oauth-callback.controller.tsx
+++ b/apps/api/src/controllers/oauth-callback.controller.tsx
@@ -141,8 +141,11 @@ async function handleNewUser({
   // IdP redirect — this is the first point where we know the user is new, so
   // returning users are never caught by it.
   if (!(await getIsRegistrationAllowed(inviteId))) {
+    // Deliberately no `oauthUser` here — this rejects people who are not users,
+    // so their email and name shouldn't land in application logs. The redirect
+    // carries `correlationId` (the request id), which is what ties a user's
+    // error page back to this log line if an operator needs to investigate.
     throw new LogError('Registrations are not allowed', {
-      oauthUser,
       providerName,
       inviteId,
     });

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -31,6 +31,7 @@ export * from './src/services/profile.service';
 export * from './src/services/project.service';
 export * from './src/services/reference.service';
 export * from './src/services/referrer-spikes.service';
+export * from './src/services/registration.service';
 export * from './src/services/reports.service';
 export * from './src/services/retention.service';
 export * from './src/services/salt.service';

--- a/packages/db/src/services/registration.service.test.ts
+++ b/packages/db/src/services/registration.service.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUserCount = vi.hoisted(() => vi.fn());
+const mockInviteFindUnique = vi.hoisted(() => vi.fn());
+
+vi.mock('../prisma-client', () => ({
+  db: {
+    user: { count: mockUserCount },
+    invite: { findUnique: mockInviteFindUnique },
+  },
+}));
+
+import { getIsRegistrationAllowed } from './registration.service';
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Not the first user unless a test says otherwise
+  mockUserCount.mockResolvedValue(5);
+  mockInviteFindUnique.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('getIsRegistrationAllowed', () => {
+  it('allows everything in cloud (ALLOW_REGISTRATION unset)', async () => {
+    process.env.ALLOW_REGISTRATION = undefined;
+    delete process.env.ALLOW_REGISTRATION;
+
+    await expect(getIsRegistrationAllowed()).resolves.toBe(true);
+    expect(mockUserCount).not.toHaveBeenCalled();
+  });
+
+  it('allows the very first user even when registration is disabled', async () => {
+    process.env.ALLOW_REGISTRATION = 'false';
+    mockUserCount.mockResolvedValue(0);
+
+    await expect(getIsRegistrationAllowed()).resolves.toBe(true);
+  });
+
+  it('blocks a new user with no invite when registration is disabled', async () => {
+    process.env.ALLOW_REGISTRATION = 'false';
+
+    await expect(getIsRegistrationAllowed()).resolves.toBe(false);
+  });
+
+  it('allows a new user holding a valid invite when registration is disabled', async () => {
+    process.env.ALLOW_REGISTRATION = 'false';
+    process.env.ALLOW_INVITATION = 'true';
+    mockInviteFindUnique.mockResolvedValue({ id: 'invite-1' });
+
+    await expect(getIsRegistrationAllowed('invite-1')).resolves.toBe(true);
+  });
+
+  it('blocks an unknown invite id', async () => {
+    process.env.ALLOW_REGISTRATION = 'false';
+    process.env.ALLOW_INVITATION = 'true';
+    mockInviteFindUnique.mockResolvedValue(null);
+
+    await expect(getIsRegistrationAllowed('nope')).resolves.toBe(false);
+  });
+
+  it('blocks a valid invite when invitations are disabled', async () => {
+    process.env.ALLOW_REGISTRATION = 'false';
+    process.env.ALLOW_INVITATION = 'false';
+    mockInviteFindUnique.mockResolvedValue({ id: 'invite-1' });
+
+    await expect(getIsRegistrationAllowed('invite-1')).resolves.toBe(false);
+    expect(mockInviteFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('allows open self-hosted registration', async () => {
+    process.env.ALLOW_REGISTRATION = 'true';
+
+    await expect(getIsRegistrationAllowed()).resolves.toBe(true);
+  });
+});

--- a/packages/db/src/services/registration.service.ts
+++ b/packages/db/src/services/registration.service.ts
@@ -1,0 +1,41 @@
+import { db } from '../prisma-client';
+
+/**
+ * Whether a *new* user may be created right now.
+ *
+ * This must only be consulted at the point where we know the account does not
+ * exist yet. Calling it before an identity is known (e.g. when kicking off an
+ * OAuth redirect) would reject returning users too, since we cannot tell a
+ * sign-in from a sign-up at that stage.
+ */
+export async function getIsRegistrationAllowed(inviteId?: string | null) {
+  // ALLOW_REGISTRATION is always undefined in cloud
+  if (process.env.ALLOW_REGISTRATION === undefined) {
+    return true;
+  }
+
+  // Self-hosting logic
+  // 1. First user is always allowed
+  const count = await db.user.count();
+  if (count === 0) {
+    return true;
+  }
+
+  // 2. If there is an invite, check if it is valid
+  if (inviteId) {
+    if (process.env.ALLOW_INVITATION === 'false') {
+      return false;
+    }
+
+    const invite = await db.invite.findUnique({
+      where: {
+        id: inviteId,
+      },
+    });
+
+    return !!invite;
+  }
+
+  // 3. Otherwise, check if general registration is allowed
+  return process.env.ALLOW_REGISTRATION !== 'false';
+}

--- a/packages/trpc/src/routers/auth.ts
+++ b/packages/trpc/src/routers/auth.ts
@@ -26,6 +26,7 @@ import {
   db,
   decrypt,
   encrypt,
+  getIsRegistrationAllowed,
   getShareOverviewById,
   getUserAccount,
 } from '@openpanel/db';
@@ -75,38 +76,6 @@ async function consumeInviteForUser(
   }
 }
 
-async function getIsRegistrationAllowed(inviteId?: string | null) {
-  // ALLOW_REGISTRATION is always undefined in cloud
-  if (process.env.ALLOW_REGISTRATION === undefined) {
-    return true;
-  }
-
-  // Self-hosting logic
-  // 1. First user is always allowed
-  const count = await db.user.count();
-  if (count === 0) {
-    return true;
-  }
-
-  // 2. If there is an invite, check if it is valid
-  if (inviteId) {
-    if (process.env.ALLOW_INVITATION === 'false') {
-      return false;
-    }
-
-    const invite = await db.invite.findUnique({
-      where: {
-        id: inviteId,
-      },
-    });
-
-    return !!invite;
-  }
-
-  // 3. Otherwise, check if general registration is allowed
-  return process.env.ALLOW_REGISTRATION !== 'false';
-}
-
 export const authRouter = createTRPCRouter({
   signOut: publicProcedure.mutation(async ({ ctx }) => {
     deleteSessionTokenCookie(ctx.setCookie);
@@ -117,14 +86,11 @@ export const authRouter = createTRPCRouter({
   signInOAuth: publicProcedure
     .input(z.object({ provider: zProvider, inviteId: z.string().nullish() }))
     .mutation(async ({ input, ctx }) => {
-      const isRegistrationAllowed = await getIsRegistrationAllowed(
-        input.inviteId
-      );
-
-      if (!isRegistrationAllowed) {
-        throw new TRPCAccessError('Registrations are not allowed');
-      }
-
+      // NOTE: no registration check here. At this point we have no identity for
+      // the caller — the IdP hasn't been hit yet — so we cannot tell a returning
+      // user from a new sign-up. Gating here locks out every existing OAuth user
+      // as soon as their session expires. The check lives in the OAuth callback
+      // (`handleNewUser`), which is the only place we know the user is new.
       const { provider } = input;
 
       if (input.inviteId) {


### PR DESCRIPTION
Fixes #363.

## The problem

`signInOAuth` gated on `getIsRegistrationAllowed()` **before** redirecting to the IdP. At that point the server has no identity for the caller — it can't tell a returning user from a new sign-up — so with `ALLOW_REGISTRATION=false` it rejected *every* OAuth sign-in, including users with a fully populated `User` + `Account` row.

That's a hard lockout, not just "signups are blocked". Those users can't fall back to anything:

- `signInEmail` → `getUserAccount(email, provider: 'email')` → "User does not exist" (OAuth users have no `email` account row).
- `requestResetPassword` → also `provider: 'email'` only → returns `true` without sending anything (anti-enumeration), so the user waits for a link that never arrives.

The only thing keeping them signed in is the session cookie. Once it expires they need operator DB access to get back in.

## The fix

Move the check to the one place where we actually know the user is new — `handleNewUser` in the OAuth callback, just before `db.user.create`.

- `signInOAuth` no longer gates. Comment left explaining why, so it doesn't get "fixed" back.
- `getIsRegistrationAllowed` moves from `packages/trpc/src/routers/auth.ts` into `packages/db/src/services/registration.service.ts`, so the tRPC router and the API controller share one implementation instead of the controller inlining a copy.
- `signUpEmail` keeps its upfront check — that request explicitly declares a sign-up, so gating early is correct there.

**Policy semantics are unchanged.** First-user bootstrap, `ALLOW_INVITATION=false`, and `ALLOW_REGISTRATION` all behave exactly as before; only the enforcement point moved.

## Behaviour with `ALLOW_REGISTRATION=false`, `ALLOW_INVITATION=true`

| Case | Before | After |
|---|---|---|
| Existing OAuth user signs in | ❌ `Registrations are not allowed` before IdP redirect | ✅ signed in |
| Invited user returns after first login (invite consumed) | ❌ locked out | ✅ signed in |
| New user with valid invite | ✅ created | ✅ created, attached to org |
| New user, no invite | ❌ blocked at tRPC | ❌ `/login?error=Registrations+are+not+allowed`, no `User` row |
| First-ever user (0 rows) | ✅ | ✅ |

With `ALLOW_REGISTRATION=true`: unchanged.

## Tests

New `packages/db/src/services/registration.service.test.ts` covers all seven branches of the policy (cloud/unset, first-user bootstrap, no-invite block, valid invite, unknown invite, `ALLOW_INVITATION=false`, open registration). All pass.

`tsc --noEmit` on `@openpanel/db`, `@openpanel/trpc` and `apps/api` reports no new errors — the remaining ones are pre-existing in `notification.service.ts`, `insights/store.ts` and `apps/api/src/utils/auth.ts`, identical on a clean tree.

## Note on #406

PR #406 targets the same issue but only deletes the gate from `signInOAuth` without re-adding it at the callback, so `ALLOW_REGISTRATION=false` would stop blocking OAuth signups entirely. It also drops the `ALLOW_INVITATION === 'false'` branch, which changes policy semantics unrelated to this bug.

## Not included

The issue's adjacent UX nit — OAuth buttons rendering unconditionally on `_login.login.tsx` even when the provider env vars are unset — is left for a separate change, as suggested in the issue.

https://claude.ai/code/session_01ETRr6KYLYATzBVaLRZcwwk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added registration eligibility checks for new OAuth sign-ins.
  - Cloud environments allow registration automatically.
  - Self-hosted environments support first-user registration, invitation validation, and configurable registration settings.
  - Users cannot create accounts when registration is disabled or an invitation is invalid.

- **Bug Fixes**
  - Existing users can continue signing in through OAuth without being affected by registration restrictions.
  - OAuth registration checks now occur during account creation, preventing unnecessary sign-in interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->