### PR TITLE
fix(cohorts): stop non-static cohorts from freezing permanently after first compute

### DIFF
--- a/apps/worker/src/jobs/cron.cohort-refresh.ts
+++ b/apps/worker/src/jobs/cron.cohort-refresh.ts
@@ -1,5 +1,4 @@
-import { db } from '@openpanel/db';
-import { cohortComputeQueue } from '@openpanel/queue';
+import { db, enqueueCohortCompute } from '@openpanel/db';
 
 export async function cohortRefreshCronJob() {
   const cohorts = await db.cohort.findMany({
@@ -7,17 +6,5 @@ export async function cohortRefreshCronJob() {
     select: { id: true },
   });
 
-  await Promise.all(
-    cohorts.map((cohort) =>
-      cohortComputeQueue.add(
-        'cohortCompute',
-        { cohortId: cohort.id },
-        {
-          jobId: `cohort-${cohort.id}`,
-          removeOnComplete: { age: 3600 },
-          removeOnFail: { age: 86400 },
-        },
-      ),
-    ),
-  );
+  await Promise.all(cohorts.map((cohort) => enqueueCohortCompute(cohort.id)));
 }

--- a/packages/db/src/services/cohort.service.ts
+++ b/packages/db/src/services/cohort.service.ts
@@ -599,21 +599,25 @@ export async function getProfilesInCohort(
   return new Set(profileIds);
 }
 
+/**
+ * Enqueue a recompute for a cohort.
+ *
+ * Uses `deduplication` rather than a fixed `jobId`. A fixed jobId makes BullMQ
+ * short-circuit `add` for as long as *any* record for that id exists in Redis —
+ * and `removeOnComplete: { age }` is not a TTL, it only trims on some other
+ * job in the queue finishing. That deadlocks: nothing can be added because the
+ * completed record is still there, and the record is never collected because
+ * nothing gets added. The deduplication key, in contrast, is released by
+ * `moveToFinished` on both completion and terminal failure, so it only collapses
+ * a compute that is genuinely still in flight.
+ */
 export async function enqueueCohortCompute(cohortId: string): Promise<void> {
   await cohortComputeQueue.add(
     'cohortCompute',
     { cohortId },
     {
-      jobId: `cohort-${cohortId}`,
-      removeOnComplete: { age: 3600 },
-      removeOnFail: { age: 86400 },
+      deduplication: { id: `cohort-${cohortId}` },
     },
-  );
-}
-
-export async function removeCohortComputeJob(cohortId: string): Promise<void> {
-  await cohortComputeQueue.remove(
-    `cohort-${cohortId}`,
   );
 }
 

--- a/packages/queue/src/queues.ts
+++ b/packages/queue/src/queues.ts
@@ -320,8 +320,11 @@ export const cohortComputeQueue = new Queue<CohortComputePayload>(
     defaultJobOptions: {
       attempts: 3,
       backoff: { type: 'exponential', delay: 5000 },
-      removeOnComplete: { age: 3600 },
-      removeOnFail: { age: 86400 },
+      // `age` alone only trims when another job in this queue finishes, so pair
+      // it with a count bound to keep the completed/failed sets from growing
+      // unbounded during quiet periods.
+      removeOnComplete: { age: 3600, count: 100 },
+      removeOnFail: { age: 86400, count: 100 },
     },
   },
 );

--- a/packages/trpc/src/routers/cohort.ts
+++ b/packages/trpc/src/routers/cohort.ts
@@ -10,7 +10,6 @@ import {
   getCohortMemberRoutes,
   getCohortMembers,
   listCohortMemberProfiles,
-  removeCohortComputeJob,
 } from '@openpanel/db';
 import {
   type CohortDefinition,
@@ -119,11 +118,7 @@ export const cohortRouter = createTRPCRouter({
         },
       });
 
-      console.log('cohort', cohort);
-
       if (data.definition) {
-        console.log('enqueueing cohort compute');
-        await removeCohortComputeJob(cohort.id);
         await enqueueCohortCompute(cohort.id);
       }
 
@@ -300,7 +295,6 @@ export const cohortRouter = createTRPCRouter({
         );
       }
 
-      await removeCohortComputeJob(input.cohortId);
       await enqueueCohortCompute(input.cohortId);
 
       return { success: true };


### PR DESCRIPTION
Fixes #424.

## The bug

`cohortRefreshCronJob` and `enqueueCohortCompute` both enqueued with a fixed `jobId: cohort-<id>`. BullMQ's `add` short-circuits while *any* Redis record for that id still exists:

```lua
-- addStandardJob-9.lua
if rcall("EXISTS", jobIdKey) == 1 then
    return handleDuplicatedJob(...)   -- never reaches storeJob / LPUSH to wait
end
```

The key detail is that `removeOnComplete: { age }` is **not a TTL**. Nothing expires on a timer — `removeJobsByMaxAge` runs only from inside `moveToFinished`/`removeJobsOnFail`, i.e. as a side effect of some job in that queue finishing, and it collects predecessors only.

So the states form a cycle:

- deleting `cohort-X`'s record requires some job in the queue to finish ≥1h after it,
- a job can only finish if it was added,
- it can only be added if no record exists for its jobId.

`cohortCompute` has only three producers — the cron, cohort create/update, and the UI Refresh — and the first two used the same blocked ids. Once every non-static cohort holds a completed record, nothing can ever be added, so nothing finishes, so nothing is ever collected. **Permanent, not a 1h delay.** The cron keeps firing on schedule and every enqueue is a silent no-op.

This also explains why it looked intermittent: `removeCohortComputeJob` (`remove()` then `add()`) was the only escape, and because `removeJobsByMaxAge` trims the whole target zset by score, one manual Refresh evicted *every other* cohort's hour-old record too — so the next tick worked for everyone, they all completed, all wrote fresh records, and it deadlocked again.

## The fix

Deduplicate on the cohort rather than pinning a jobId:

```ts
await cohortComputeQueue.add(
  'cohortCompute',
  { cohortId },
  { deduplication: { id: `cohort-${cohortId}` } },
);
```

With no `ttl`, the deduplication key is released by `moveToFinished` on completion **or** failure — `removeDeduplicationKeyIfNeededOnFinalization` is called above the completed/failed branching — so it collapses only a compute that is genuinely still in flight, and finished records stop gating anything.

## Verification

Ran against a real Redis on `bullmq@5.63.0`, comparing both enqueue shapes over three ticks with no age-trim opportunity in between:

```
BEFORE (jobId: `cohort-A`)
  processed 1 time(s) over 3 ticks  ->  STUCK
  counts: {"wait":0,"active":0,"completed":1,"failed":0}
AFTER  (deduplication: { id: `cohort-A` })
  processed 3 time(s) over 3 ticks  ->  OK
  counts: {"wait":0,"active":0,"completed":3,"failed":0}

In-flight dedup:
  second add while active started a 2nd run? no (correct)
  dedup key pttl while in flight = -1 (expect -1, no TTL)
  dedup key exists after completion = 0 (expect 0 -> next add lands in wait)

After terminal failure:
  dedup key exists = 0 (expect 0)
  re-enqueue ran again? YES (correct)
  failedReason retained = boom
```

## Also in this PR

Both raised in the issue as worth doing while in here:

- **`cohortRefreshCronJob` now calls `enqueueCohortCompute`** instead of duplicating its options. Fixing only the helper would have missed the cron, which is the producer that actually matters.
- **`removeCohortComputeJob` is deleted**, along with its two call sites in `cohort.ts` (`update` and `refresh`). It only existed to work around the fixed jobId; with dedup a stale record no longer blocks anything, and `remove()` before `add()` would destroy the failure record that dedup deliberately preserves. Behaviour is equivalent — `remove()` never removed *active* jobs anyway, and a waiting deduped job re-reads the cohort definition when it runs.
- **`removeOnComplete`/`removeOnFail` gain a `count` bound** on the queue defaults, since `age` alone only trims when another job finishes.
- Dropped two stray `console.log`s in the cohort router that were sitting on the changed lines.

`removeOnComplete: true` would also have fixed the deadlock (it takes the self-deleting branch) but loses completed-job visibility, so it isn't used here.

## Checks

`tsc --noEmit` reports zero errors in every touched file (`cohort.service.ts`, `queues.ts`, `routers/cohort.ts`, `cron.cohort-refresh.ts`). Remaining repo-wide errors are pre-existing in `notification.service.ts` and `insights/store.ts`.

https://claude.ai/code/session_01ETRr6KYLYATzBVaLRZcwwk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved reliability of automatic and manual cohort refresh processing.
  * Prevented unnecessary duplicate cohort computation jobs.
  * Added limits to retained completed and failed background jobs to help manage queue storage.
  * Simplified cohort updates and refreshes by removing redundant job-removal steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->