### PR TITLE
fix(chart): list all profile property keys instead of sampling 10k unordered rows

### DIFF
--- a/packages/db/src/services/profile.service.ts
+++ b/packages/db/src/services/profile.service.ts
@@ -562,3 +562,14 @@ export async function getProfilePropertyKeys(
   `);
   return rows.map((r) => r.key).sort();
 }
+
+/**
+ * Cached by projectId only. The picker's tRPC-level cache keys on the whole
+ * input, which includes `event` — so without this the full profile scan would
+ * repeat once per event within the same window, even though the profile keys
+ * don't depend on the event at all.
+ */
+export const getProfilePropertyKeysCached = cacheable(
+  getProfilePropertyKeys,
+  60,
+);

--- a/packages/db/src/services/profile.service.ts
+++ b/packages/db/src/services/profile.service.ts
@@ -554,12 +554,12 @@ export async function getProfileMetricsCore(input: {
 export async function getProfilePropertyKeys(
   projectId: string,
 ): Promise<string[]> {
-  const rows = await chQuery<{ key: string }>(`
-    SELECT DISTINCT arrayJoin(mapKeys(properties)) as key
-    FROM ${TABLE_NAMES.profiles}
-    WHERE project_id = ${sqlstring.escape(projectId)}
-      AND is_external = true
-  `);
+  const rows = await clix(ch)
+    .select<{ key: string }>(['DISTINCT arrayJoin(mapKeys(properties)) as key'])
+    .from(TABLE_NAMES.profiles)
+    .where('project_id', '=', projectId)
+    .where('is_external', '=', true)
+    .execute();
   return rows.map((r) => r.key).sort();
 }
 

--- a/packages/db/src/services/profile.service.ts
+++ b/packages/db/src/services/profile.service.ts
@@ -539,3 +539,26 @@ export async function getProfileMetricsCore(input: {
     revenue: raw.revenue,
   };
 }
+
+/**
+ * Every distinct key present in any external profile's `properties` map.
+ *
+ * Aggregated across all profiles rather than sampled — a `LIMIT n` sample with
+ * no `ORDER BY` returns whichever rows ClickHouse's scheduler happens to
+ * produce, so the key set varied between requests and properties set on a small
+ * fraction of profiles were usually missing from the picker entirely.
+ *
+ * `FINAL` isn't needed: older row versions can only contribute keys that
+ * genuinely existed at some point.
+ */
+export async function getProfilePropertyKeys(
+  projectId: string,
+): Promise<string[]> {
+  const rows = await chQuery<{ key: string }>(`
+    SELECT DISTINCT arrayJoin(mapKeys(properties)) as key
+    FROM ${TABLE_NAMES.profiles}
+    WHERE project_id = ${sqlstring.escape(projectId)}
+      AND is_external = true
+  `);
+  return rows.map((r) => r.key).sort();
+}

--- a/packages/trpc/src/routers/chart.ts
+++ b/packages/trpc/src/routers/chart.ts
@@ -13,7 +13,7 @@ import {
   getEventFiltersWhereClause,
   getEventMetasCached,
   getGroupPropertySelect,
-  getProfilePropertyKeys,
+  getProfilePropertyKeysCached,
   getProfilePropertySelect,
   getProfilesCached,
   getReportById,
@@ -243,9 +243,9 @@ export const chartRouter = createTRPCRouter({
       })
     )
     .query(async ({ input: { projectId, event } }) => {
-      const profileProperties = (await getProfilePropertyKeys(projectId)).map(
-        (key) => `profile.properties.${key}`
-      );
+      const profileProperties = (
+        await getProfilePropertyKeysCached(projectId)
+      ).map((key) => `profile.properties.${key}`);
 
       const query = clix(ch)
         .select<{ property_key: string; created_at: string }>([
@@ -257,8 +257,11 @@ export const chartRouter = createTRPCRouter({
         .groupBy(['property_key'])
         // Order by recency, not by key length. The cap has to drop *something*
         // on projects with very many distinct keys, and dropping the longest
-        // keys first meant losing the most descriptive ones.
+        // keys first meant losing the most descriptive ones. `property_key`
+        // breaks ties so the cap can't cut an arbitrary side of a tied group —
+        // an unstable list is the bug this whole change is about.
         .orderBy('created_at', 'DESC')
+        .orderBy('property_key', 'ASC')
         .limit(EVENT_PROPERTY_KEY_LIMIT);
 
       if (event && event !== '*') {

--- a/packages/trpc/src/routers/chart.ts
+++ b/packages/trpc/src/routers/chart.ts
@@ -13,6 +13,7 @@ import {
   getEventFiltersWhereClause,
   getEventMetasCached,
   getGroupPropertySelect,
+  getProfilePropertyKeys,
   getProfilePropertySelect,
   getProfilesCached,
   getReportById,
@@ -50,6 +51,12 @@ import {
 } from '../trpc';
 
 const cacher = cacheMiddleware(60);
+
+/**
+ * Cap on distinct event property keys returned to the picker. Projects in the
+ * 8k range exist, so the previous 10k was reachable in normal use.
+ */
+const EVENT_PROPERTY_KEY_LIMIT = 50_000;
 
 const chartProcedure = publicProcedure.use(
   async ({ ctx, next, getRawInput }) => {
@@ -225,6 +232,10 @@ export const chartRouter = createTRPCRouter({
     }),
 
   properties: protectedProcedure
+    // Aggregating every profile's property keys costs more than the old
+    // 10k-row sample. It's still sub-second on millions of profiles, and this
+    // list barely moves, so a short cache absorbs it.
+    .use(cacheMiddleware(60))
     .input(
       z.object({
         event: z.string().optional(),
@@ -232,21 +243,9 @@ export const chartRouter = createTRPCRouter({
       })
     )
     .query(async ({ input: { projectId, event } }) => {
-      const profiles = await clix(ch, 'UTC')
-        .select<Pick<IServiceProfile, 'properties'>>(['properties'])
-        .from(TABLE_NAMES.profiles)
-        .where('project_id', '=', projectId)
-        .where('is_external', '=', true)
-        .limit(10_000)
-        .execute();
-
-      const profileProperties = [
-        ...new Set(
-          profiles.flatMap((p) =>
-            Object.keys(p.properties).map((k) => `profile.properties.${k}`)
-          )
-        ),
-      ];
+      const profileProperties = (await getProfilePropertyKeys(projectId)).map(
+        (key) => `profile.properties.${key}`
+      );
 
       const query = clix(ch)
         .select<{ property_key: string; created_at: string }>([
@@ -256,9 +255,11 @@ export const chartRouter = createTRPCRouter({
         .from(TABLE_NAMES.event_property_values_mv)
         .where('project_id', '=', projectId)
         .groupBy(['property_key'])
-        .orderBy('length(property_key)', 'ASC')
+        // Order by recency, not by key length. The cap has to drop *something*
+        // on projects with very many distinct keys, and dropping the longest
+        // keys first meant losing the most descriptive ones.
         .orderBy('created_at', 'DESC')
-        .limit(10_000);
+        .limit(EVENT_PROPERTY_KEY_LIMIT);
 
       if (event && event !== '*') {
         query.where('name', '=', event);


### PR DESCRIPTION
Fixes #423.

## The bug

`chart.properties` built the **profile property** half of the breakdown/filter picker from an arbitrary sample:

```ts
const profiles = await clix(ch, 'UTC')
  .select(['properties'])
  .from(TABLE_NAMES.profiles)
  .where('project_id', '=', projectId)
  .where('is_external', '=', true)
  .limit(10_000)          // arbitrary sample, no ORDER BY
  .execute();
```

`LIMIT` with no `ORDER BY` means which rows come back depends on how ClickHouse schedules the read. Per the issue, on a project with a few million identified profiles and ~400 distinct keys:

| `max_threads` | profile keys returned | rare property present? |
|---|---|---|
| 1 | 27 | **no** |
| 2 | 182 | yes |
| 12 | 234 | yes |
| 32 | 166 | yes |

So the picker offered 27–234 of ~400 keys depending on the request, and the list changed between reloads. Any property set on a small fraction of profiles was usually missing outright — and search couldn't help, since `PropertiesCombobox` does a substring match over the array the key was never in.

## The fix

Aggregate over all profiles rather than sampling rows, mirroring what `getGroupPropertyKeys` already does for group properties:

```sql
SELECT DISTINCT arrayJoin(mapKeys(properties)) AS key
FROM profiles
WHERE project_id = {projectId} AND is_external = true
```

Lives in `packages/db/src/services/profile.service.ts` as `getProfilePropertyKeys`, next to the group-property equivalent.

`FINAL` isn't needed — older row versions can only contribute keys that genuinely existed. This also stops shipping 10,000 full `properties` maps into Node just to discard the values.

**Latency:** ~750ms vs ~140ms on a few million profiles (issue's measurement), and stable across `max_threads` 1/4/16. Absorbed by a 60s `cacheMiddleware` on the procedure — this list barely moves, and the middleware only serves from cache in production so dev is unaffected.

Verified the query plan hits the `project_id` primary key (`Parts: 1/7`), and ran the new function against a local ClickHouse end to end.

## Also fixed: the event-property half

Same procedure, flagged in the issue as related:

```ts
.orderBy('length(property_key)', 'ASC')
.orderBy('created_at', 'DESC')
.limit(10_000);
```

Past 10k distinct event property keys this silently dropped the **longest** ones first — which tend to be the most descriptive. Now ordered by recency and the cap raised to 50k. Projects in the 8k range exist, so the old limit was reachable in normal use; dropping the least-recently-seen keys is a defensible tiebreak, dropping the longest is not.

## Checks

`tsc --noEmit` reports zero errors in both touched files. Remaining repo-wide errors are pre-existing in `notification.service.ts` and `insights/store.ts`.

https://claude.ai/code/session_01ETRr6KYLYATzBVaLRZcwwk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved chart property discovery with broader coverage of available profile properties.
  * Added short-term caching to help property lists load more efficiently.
  * Increased the number of event properties available for discovery.
  * Prioritized recently used event properties and applied consistent ordering for easier browsing.
  * Property lists now provide more reliable and predictable results when exploring chart data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->