### PR TITLE
fix(funnel): compute "View Users" from the same query as the chart

### DIFF
--- a/apps/start/src/modals/view-chart-users.tsx
+++ b/apps/start/src/modals/view-chart-users.tsx
@@ -149,6 +149,39 @@ function ProfileList({ profiles }: { profiles: any[] }) {
   );
 }
 
+/**
+ * Renders the query's outcome. A failed request must not look like an empty
+ * result — `data ?? []` used to render backend errors as "No users found",
+ * which hid real failures (e.g. a funnel breakdown whose SQL didn't compile).
+ */
+function ProfileListState({
+  query,
+}: {
+  query: { isLoading: boolean; isError: boolean; data?: any[] };
+}) {
+  if (query.isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <div className="text-muted-foreground">Loading users...</div>
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div className="col items-center justify-center gap-1 py-8 text-center">
+        <div className="font-medium">Could not load users</div>
+        <div className="text-muted-foreground text-sm">
+          Something went wrong running this query. Try again, or adjust the
+          report.
+        </div>
+      </div>
+    );
+  }
+
+  return <ProfileList profiles={query.data ?? []} />;
+}
+
 // Chart-specific props and component
 interface ChartUsersViewProps {
   chartData: IChartData;
@@ -213,8 +246,6 @@ function ChartUsersView({ chartData, report, date }: ChartUsersViewProps) {
     ),
   );
 
-  const profiles = profilesQuery.data ?? [];
-
   return (
     <ScrollableModal
       header={
@@ -273,13 +304,7 @@ function ChartUsersView({ chartData, report, date }: ChartUsersViewProps) {
       }
     >
       <div className="col">
-        {profilesQuery.isLoading ? (
-          <div className="flex items-center justify-center py-8">
-            <div className="text-muted-foreground">Loading users...</div>
-          </div>
-        ) : (
-          <ProfileList profiles={profiles} />
-        )}
+        <ProfileListState query={profilesQuery} />
       </div>
     </ScrollableModal>
   );
@@ -330,7 +355,6 @@ function FunnelUsersView({ report, stepIndex, breakdownValues }: FunnelUsersView
     ),
   );
 
-  const profiles = profilesQuery.data ?? [];
   const isLastStep = stepIndex === report.series.length - 1;
 
   return (
@@ -377,13 +401,7 @@ function FunnelUsersView({ report, stepIndex, breakdownValues }: FunnelUsersView
       }
     >
       <div className="flex flex-col gap-4">
-        {profilesQuery.isLoading ? (
-          <div className="flex items-center justify-center py-8">
-            <div className="text-muted-foreground">Loading users...</div>
-          </div>
-        ) : (
-          <ProfileList profiles={profiles} />
-        )}
+        <ProfileListState query={profilesQuery} />
       </div>
     </ScrollableModal>
   );

--- a/packages/db/src/services/funnel-sql.test.ts
+++ b/packages/db/src/services/funnel-sql.test.ts
@@ -107,13 +107,12 @@ afterAll(() => {
   vi.restoreAllMocks();
 });
 
+// Reports as skipped rather than passed when CH is unreachable — a test that
+// returns before asserting anything should not read as green.
 const itCH = (name: string, fn: () => Promise<void>) =>
-  it(name, async () => {
+  it(name, async (ctx) => {
     if (!chReachable) {
-      console.warn(
-        '[funnel-sql] skipping: ClickHouse not reachable at CLICKHOUSE_URL',
-      );
-      return;
+      ctx.skip('ClickHouse not reachable at CLICKHOUSE_URL');
     }
     await fn();
   });

--- a/packages/db/src/services/funnel-sql.test.ts
+++ b/packages/db/src/services/funnel-sql.test.ts
@@ -1,0 +1,219 @@
+/**
+ * SQL-syntax tests for the shared funnel query builder.
+ *
+ * Same strategy as chart-sql.test.ts: build the SQL string, then run
+ * `EXPLAIN <sql>` against the local ClickHouse instance. EXPLAIN parses and
+ * resolves columns without executing, so a breakdown expression referencing a
+ * join alias that was never added fails here as UNKNOWN_IDENTIFIER — which is
+ * exactly the class of bug that made funnel "View Users" return "No users
+ * found" for profile-property and cohort breakdowns.
+ *
+ * Requires `pnpm dock:up` (or any locally reachable CH at
+ * http://localhost:8123/openpanel). All tests auto-skip if CH is unreachable.
+ */
+import type { IChartBreakdown, IReportInput } from '@openpanel/validation';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const mockCohortFindMany = vi.hoisted(() => vi.fn());
+
+vi.mock('../prisma-client', () => ({
+  db: { cohort: { findMany: mockCohortFindMany } },
+}));
+
+import { ch } from '../clickhouse/client';
+import { funnelService } from './funnel.service';
+
+const PROJECT_ID = 'test-sql-validation';
+const COHORT_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const START = '2026-04-14 00:00:00';
+const END = '2026-05-15 00:00:00';
+
+type ISeriesItem = IReportInput['series'][number];
+
+const event = (overrides: Partial<ISeriesItem> = {}): ISeriesItem =>
+  ({
+    id: 'A',
+    type: 'event',
+    name: 'screen_view',
+    segment: 'event',
+    filters: [],
+    ...overrides,
+  }) as ISeriesItem;
+
+const breakdown = (name: string): IChartBreakdown => ({ id: name, name });
+
+const SERIES = [event({ id: 'A' }), event({ id: 'B', name: 'sign_up' })];
+
+let chReachable = false;
+
+async function explain(sql: string): Promise<void> {
+  await ch.command({ query: `EXPLAIN ${sql}` });
+}
+
+/** Mirrors what getFunnelProfiles builds on top of the shared base. */
+async function buildProfilesSql(breakdowns: IChartBreakdown[]) {
+  const { query } = await funnelService.buildFunnelBase({
+    projectId: PROJECT_ID,
+    startDate: START,
+    endDate: END,
+    series: SERIES,
+    breakdowns,
+    funnelWindow: 24,
+    timezone: 'UTC',
+  });
+  query.with('funnel', 'SELECT * FROM session_funnel WHERE level != 0');
+  query.select(['DISTINCT profile_id']).from('funnel');
+  query.where('level', '>=', 2);
+  return query.toSQL();
+}
+
+/** Mirrors what the funnel chart builds on top of the shared base. */
+async function buildChartSql(breakdowns: IChartBreakdown[]) {
+  const { query, breakdowns: resolved } = await funnelService.buildFunnelBase({
+    projectId: PROJECT_ID,
+    startDate: START,
+    endDate: END,
+    series: SERIES,
+    breakdowns,
+    funnelWindow: 24,
+    timezone: 'UTC',
+  });
+  query.with('funnel', 'SELECT * FROM session_funnel WHERE level != 0');
+  query
+    .select([
+      'level',
+      ...resolved.map((_, index) => `b_${index}`),
+      'count() as count',
+    ])
+    .from('funnel')
+    .groupBy(['level', ...resolved.map((_, index) => `b_${index}`)]);
+  return query.toSQL();
+}
+
+beforeAll(async () => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  mockCohortFindMany.mockResolvedValue([
+    { id: COHORT_ID, name: 'Power users' },
+  ]);
+  try {
+    await ch.command({ query: 'SELECT 1' });
+    chReachable = true;
+  } catch {
+    chReachable = false;
+  }
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+const itCH = (name: string, fn: () => Promise<void>) =>
+  it(name, async () => {
+    if (!chReachable) {
+      console.warn(
+        '[funnel-sql] skipping: ClickHouse not reachable at CLICKHOUSE_URL',
+      );
+      return;
+    }
+    await fn();
+  });
+
+describe('funnel.service / buildFunnelBase — profile breakdowns', () => {
+  itCH('adds the profiles join for a profile.properties breakdown', async () => {
+    const sql = await buildProfilesSql([breakdown('profile.properties.plan')]);
+
+    // The breakdown renders `profile.properties['plan']`, so the alias must exist.
+    expect(sql).toContain("profile.properties['plan']");
+    expect(sql).toMatch(/as profile/);
+    expect(sql).toContain('profile.id = events.profile_id');
+    await explain(sql);
+  });
+
+  itCH('selects the properties column, not a bare `properties` field', async () => {
+    const sql = await buildProfilesSql([breakdown('profile.properties.plan')]);
+    expect(sql).toMatch(/SELECT [^)]*properties[^)]*FROM .*profiles/);
+    await explain(sql);
+  });
+
+  itCH('adds the profiles join for a top-level profile breakdown', async () => {
+    const sql = await buildProfilesSql([breakdown('profile.email')]);
+    expect(sql).toContain('profile.id = events.profile_id');
+    await explain(sql);
+  });
+
+  itCH('adds the join for a profile filter with no profile breakdown', async () => {
+    const { query } = await funnelService.buildFunnelBase({
+      projectId: PROJECT_ID,
+      startDate: START,
+      endDate: END,
+      series: [
+        event({
+          filters: [
+            { id: 'f', name: 'profile.email', operator: 'is', value: ['a@b.c'] },
+          ],
+        }),
+        event({ id: 'B', name: 'sign_up' }),
+      ],
+      funnelWindow: 24,
+      timezone: 'UTC',
+    });
+    query.with('funnel', 'SELECT * FROM session_funnel WHERE level != 0');
+    query.select(['DISTINCT profile_id']).from('funnel');
+    await explain(query.toSQL());
+  });
+});
+
+describe('funnel.service / buildFunnelBase — cohort breakdowns', () => {
+  itCH('adds the cohort join for a cohort breakdown', async () => {
+    const sql = await buildProfilesSql([breakdown(`cohort:${COHORT_ID}`)]);
+
+    // The breakdown renders `cohort_<id>.profile_id`, so its join must exist.
+    const alias = `cohort_${COHORT_ID.replace(/-/g, '_')}`;
+    expect(sql).toContain(`${alias}.profile_id`);
+    expect(sql).toContain(`AS ${alias}`);
+    expect(sql).toContain('Power users');
+    await explain(sql);
+  });
+});
+
+describe('funnel.service / buildFunnelBase — unknown breakdowns', () => {
+  itCH('drops the all-cohorts breakdown, which the funnel cannot render', async () => {
+    // Bare `cohort` is the chart's all-cohorts breakdown. The funnel has no
+    // equivalent, and inlining it produced `cohort as b_0 FROM events` —
+    // UNKNOWN_IDENTIFIER for the chart and the profile list alike.
+    const sql = await buildProfilesSql([breakdown('cohort')]);
+    expect(sql).not.toMatch(/\bcohort as b_0\b/);
+    await explain(sql);
+  });
+
+  itCH('drops an unrecognised breakdown name entirely', async () => {
+    const sql = await buildProfilesSql([breakdown('not_a_real_column')]);
+    expect(sql).not.toContain('not_a_real_column');
+    await explain(sql);
+  });
+
+  itCH('drops unsupported breakdowns identically for chart and profiles', async () => {
+    const breakdowns = [
+      breakdown('cohort'),
+      breakdown('profile.properties.plan'),
+    ];
+    const chartSql = await buildChartSql(breakdowns);
+    const profilesSql = await buildProfilesSql(breakdowns);
+
+    // Both sides must resolve the same breakdown to the same b_N index,
+    // otherwise the breakdownValues filter targets the wrong column.
+    expect(chartSql).toContain("profile.properties['plan'] as b_0");
+    expect(profilesSql).toContain("profile.properties['plan'] as b_0");
+    await explain(chartSql);
+    await explain(profilesSql);
+  });
+});
+
+describe('funnel.service / buildFunnelBase — group breakdowns', () => {
+  itCH('adds the group array join for a group breakdown', async () => {
+    const sql = await buildProfilesSql([breakdown('group.plan')]);
+    expect(sql).toContain('ARRAY JOIN groups AS _group_id');
+    expect(sql).toContain('LEFT ANY JOIN _g ON _g.id = _group_id');
+    await explain(sql);
+  });
+});

--- a/packages/db/src/services/funnel.service.ts
+++ b/packages/db/src/services/funnel.service.ts
@@ -1,5 +1,9 @@
 import { ifNaN } from '@openpanel/common';
-import type { IChartEvent, IReportInput } from '@openpanel/validation';
+import type {
+  IChartBreakdown,
+  IChartEvent,
+  IReportInput,
+} from '@openpanel/validation';
 import { last, reverse, uniq } from 'ramda';
 import sqlstring from 'sqlstring';
 import { ch } from '../clickhouse/client';
@@ -13,6 +17,7 @@ import {
   fetchCohortsMetadata,
   getEventFiltersWhereClause,
   getSelectPropertyKey,
+  isAllCohortsBreakdown,
   isKnownEventField,
 } from './chart.service';
 import { mergeGlobalFilters, onlyReportEvents } from './reports.service';
@@ -209,47 +214,66 @@ export class FunnelService {
     );
   }
 
-  async getFunnel({
+  /**
+   * Builds everything the funnel chart and the funnel profile list share: the
+   * normalized event series and breakdowns, the `session_funnel` CTE with all
+   * of its joins wired up, and the outer query those CTEs are registered on.
+   *
+   * This exists because the two used to be written out twice and drifted. A
+   * breakdown expression only works if the join it references was added, and
+   * the joins depend on the breakdowns — so building the selects in one place
+   * and the joins in another is exactly the bug waiting to happen. Callers add
+   * their own `funnel` CTE and final projection on top.
+   */
+  async buildFunnelBase({
     projectId,
     startDate,
     endDate,
     series,
     globalFilters,
-    options,
-    breakdowns = [],
-    limit,
-    timezone = 'UTC',
-  }: IReportInput & { timezone: string; events?: IChartEvent[] }) {
-    if (!startDate || !endDate) {
-      throw new Error('startDate and endDate are required');
-    }
-
-    series = mergeGlobalFilters(series, globalFilters);
-
-    const funnelOptions = options?.type === 'funnel' ? options : undefined;
-    const funnelWindow = funnelOptions?.funnelWindow ?? 24;
-    const funnelGroup = funnelOptions?.funnelGroup;
-
+    breakdowns: initialBreakdowns = [],
+    funnelWindow = 24,
+    funnelGroup,
+    timezone,
+  }: {
+    projectId: string;
+    startDate: string;
+    endDate: string;
+    series: IReportInput['series'];
+    globalFilters?: IReportInput['globalFilters'];
+    breakdowns?: IChartBreakdown[];
+    funnelWindow?: number;
+    funnelGroup?: string;
+    timezone: string;
+  }) {
     // Drop breakdowns that don't resolve to a known events column, properties
-    // path, profile path, group path, or cohort. The funnel CTE inlines each
-    // breakdown's name directly via getSelectPropertyKey — a saved report with
-    // breakdown `cohort` (intended for the chart's all-cohorts feature; the
-    // funnel doesn't support it) used to produce `cohort as b_0 FROM events
-    // GROUP BY b_0`, failing parse.
-    breakdowns = breakdowns.filter((b) => isKnownEventField(b.name));
+    // path, profile path, group path, or specific cohort. The funnel CTE
+    // inlines each breakdown's name directly via getSelectPropertyKey, so
+    // anything that doesn't resolve leaks into the SQL verbatim.
+    //
+    // `isKnownEventField` accepts the bare `cohort` breakdown because the
+    // chart's all-cohorts feature uses it, but the funnel has no equivalent —
+    // it renders as `cohort as b_0 FROM events`, which fails with
+    // UNKNOWN_IDENTIFIER for the chart and the profile list alike. Exclude it
+    // explicitly rather than relying on the generic check.
+    const breakdowns = initialBreakdowns.filter(
+      (b) => isKnownEventField(b.name) && !isAllCohortsBreakdown(b.name),
+    );
 
-    const eventSeries = onlyReportEvents(series);
+    const eventSeries = onlyReportEvents(
+      mergeGlobalFilters(series, globalFilters),
+    );
 
     if (eventSeries.length === 0) {
       throw new Error('events are required');
     }
 
-    const funnelWindowSeconds = funnelWindow * 3600;
-    const funnelWindowMilliseconds = funnelWindowSeconds * 1000;
+    const funnelWindowMilliseconds = funnelWindow * 3600 * 1000;
     const group = this.getFunnelGroup(funnelGroup);
+
     const profileFilters = this.getProfileFilters(eventSeries);
     const anyFilterOnProfile = profileFilters.length > 0;
-    const anyBreakdownOnProfile = breakdowns.some((b) =>
+    const profileBreakdowns = breakdowns.filter((b) =>
       b.name.startsWith('profile.'),
     );
     const anyFilterOnGroup = eventSeries.some((e) =>
@@ -264,13 +288,12 @@ export class FunnelService {
     const cohortIds = collectBreakdownCohortIds(breakdowns);
     const cohortMetadata = await fetchCohortsMetadata(cohortIds);
 
-    // Create the funnel CTE (session-level)
     const breakdownSelects = breakdowns.map((b, index) => {
       const bId = extractCohortId(b.name);
       const bName = bId ? cohortMetadata.get(bId)?.name : undefined;
       return `${getSelectPropertyKey(b.name, projectId, bId ?? undefined, bName)} as b_${index}`;
     });
-    const breakdownGroupBy = breakdowns.map((b, index) => `b_${index}`);
+    const breakdownGroupBy = breakdowns.map((_, index) => `b_${index}`);
 
     const funnelCte = this.buildFunnelCte({
       projectId,
@@ -284,13 +307,15 @@ export class FunnelService {
       group,
     });
 
-    if (anyFilterOnProfile || anyBreakdownOnProfile) {
-      // Collect profile columns needed for filters and breakdowns (same as conversion.service)
+    // The profile join has to cover breakdowns as well as filters — a
+    // `profile.*` breakdown renders `profile.properties[...]` into the select,
+    // so the alias must exist in scope even when no filter touches profiles.
+    if (anyFilterOnProfile || profileBreakdowns.length > 0) {
       const profileFields = new Set<string>(['id']);
       for (const f of profileFilters) {
         profileFields.add(f.split('.')[0]!);
       }
-      for (const b of breakdowns.filter((x) => x.name.startsWith('profile.'))) {
+      for (const b of profileBreakdowns) {
         const fieldName = b.name.replace('profile.', '').split('.')[0];
         if (fieldName === 'properties') {
           profileFields.add('properties');
@@ -319,21 +344,58 @@ export class FunnelService {
       funnelCte.rawJoin('LEFT ANY JOIN _g ON _g.id = _group_id');
     }
 
+    // A cohort breakdown renders `cohort_<id>.profile_id`, so every cohort
+    // referenced by a breakdown needs its join.
     for (const cohortId of cohortIds) {
       funnelCte.rawJoin(buildInlineCohortJoin(cohortId, projectId, 'events'));
     }
 
-    // Base funnel query with CTEs
-    const funnelQuery = clix(this.client, timezone);
+    const query = clix(this.client, timezone);
 
     if (needsGroupArrayJoin) {
-      funnelQuery.with(
+      query.with(
         '_g',
         `SELECT id, name, type, properties FROM ${TABLE_NAMES.groups} FINAL WHERE project_id = ${sqlstring.escape(projectId)}`,
       );
     }
 
-    funnelQuery.with('session_funnel', funnelCte);
+    query.with('session_funnel', funnelCte);
+
+    return { query, eventSeries, breakdowns, group };
+  }
+
+  async getFunnel({
+    projectId,
+    startDate,
+    endDate,
+    series,
+    globalFilters,
+    options,
+    breakdowns: initialBreakdowns = [],
+    limit,
+    timezone = 'UTC',
+  }: IReportInput & { timezone: string; events?: IChartEvent[] }) {
+    if (!startDate || !endDate) {
+      throw new Error('startDate and endDate are required');
+    }
+
+    const funnelOptions = options?.type === 'funnel' ? options : undefined;
+
+    const {
+      query: funnelQuery,
+      eventSeries,
+      breakdowns,
+    } = await this.buildFunnelBase({
+      projectId,
+      startDate,
+      endDate,
+      series,
+      globalFilters,
+      breakdowns: initialBreakdowns,
+      funnelWindow: funnelOptions?.funnelWindow,
+      funnelGroup: funnelOptions?.funnelGroup,
+      timezone,
+    });
 
     // windowFunnel is computed per the primary key (profile_id or session_id),
     // so we just filter out level=0 rows — no re-aggregation needed.

--- a/packages/trpc/src/routers/chart.ts
+++ b/packages/trpc/src/routers/chart.ts
@@ -823,7 +823,7 @@ export const chartRouter = createTRPCRouter({
         showDropoffs = false,
         funnelWindow,
         funnelGroup,
-        breakdowns = [],
+        breakdowns: inputBreakdowns = [],
         breakdownValues = [],
       } = input;
 
@@ -832,94 +832,27 @@ export const chartRouter = createTRPCRouter({
       // stepIndex is 0-based, but level is 1-based, so we need level >= stepIndex + 1
       const targetLevel = stepIndex + 1;
 
-      const eventSeries = onlyReportEvents(series);
-
-      if (eventSeries.length === 0) {
-        throw new Error('At least one event series is required');
-      }
-
-      const funnelWindowSeconds = (funnelWindow || 24) * 3600;
-      const funnelWindowMilliseconds = funnelWindowSeconds * 1000;
-
-      // Get the grouping strategy (profile_id or session_id)
-      const group = funnelService.getFunnelGroup(funnelGroup);
-
-      const anyFilterOnGroup = (eventSeries as IChartEvent[]).some((e) =>
-        e.filters?.some((f) => f.name.startsWith('group.'))
-      );
-      const anyBreakdownOnGroup = breakdowns.some((b) =>
-        b.name.startsWith('group.')
-      );
-      const needsGroupArrayJoin = anyFilterOnGroup || anyBreakdownOnGroup;
-
-      // Breakdown selects/groupBy so we can filter by specific breakdown values
-      const breakdownSelects = breakdowns.map(
-        (b, index) => `${getSelectPropertyKey(b.name, projectId)} as b_${index}`
-      );
-      const breakdownGroupBy = breakdowns.map((_, index) => `b_${index}`);
-
-      // Create funnel CTE using funnel service
-      const funnelCte = funnelService.buildFunnelCte({
+      // Reuse the chart's own funnel builder rather than re-deriving the CTE
+      // here. The two copies used to drift — breakdown expressions referencing
+      // a `profile` or `cohort_<id>` alias whose join this side never added,
+      // which failed with UNKNOWN_IDENTIFIER and surfaced as "No users found".
+      const { query, breakdowns } = await funnelService.buildFunnelBase({
         projectId,
         startDate,
         endDate,
-        eventSeries: eventSeries as IChartEvent[],
-        funnelWindowMilliseconds,
+        series,
+        breakdowns: inputBreakdowns,
+        funnelWindow,
+        funnelGroup,
         timezone,
-        additionalSelects: breakdownSelects,
-        additionalGroupBy: breakdownGroupBy,
-        group,
       });
 
-      // Profile JOIN must cover both profile filters AND profile breakdowns —
-      // breakdownSelects reference `profile.properties[...]` etc. via
-      // getSelectPropertyKey, so the alias has to exist in scope even when
-      // no filter touches the profiles table. Mirrors the same guard in
-      // funnelService.getFunnel.
-      const profileFilters = funnelService.getProfileFilters(
-        eventSeries as IChartEvent[]
-      );
-      const profileBreakdownNames = breakdowns
-        .filter((b) => b.name.startsWith('profile.'))
-        .map((b) => b.name.replace('profile.', ''));
-      if (profileFilters.length > 0 || profileBreakdownNames.length > 0) {
-        const fieldsToSelect = uniq([
-          ...profileFilters.map((f) => f.split('.')[0]!),
-          ...profileBreakdownNames.map((f) => f.split('.')[0]!),
-        ]).join(', ');
-        funnelCte.leftJoin(
-          `(SELECT id, ${fieldsToSelect} FROM ${TABLE_NAMES.profiles} FINAL WHERE project_id = ${sqlstring.escape(projectId)}) as profile`,
-          'profile.id = events.profile_id'
-        );
-      }
-
-      if (needsGroupArrayJoin) {
-        funnelCte.rawJoin('ARRAY JOIN groups AS _group_id');
-        funnelCte.rawJoin('LEFT ANY JOIN _g ON _g.id = _group_id');
-      }
-
-      // Build main query
-      const query = clix(ch, timezone);
-      if (needsGroupArrayJoin) {
-        query.with(
-          '_g',
-          `SELECT id, name, type, properties FROM ${TABLE_NAMES.groups} FINAL WHERE project_id = ${sqlstring.escape(projectId)}`
-        );
-      }
-      query.with('session_funnel', funnelCte);
-
-      if (group === 'profile_id') {
-        const breakdownAggregates =
-          breakdowns.length > 0
-            ? `, ${breakdowns.map((_, index) => `any(b_${index}) AS b_${index}`).join(', ')}`
-            : '';
-        query.with(
-          'funnel',
-          `SELECT profile_id, max(level) AS level${breakdownAggregates} FROM (SELECT * FROM session_funnel WHERE level != 0) GROUP BY profile_id`
-        );
-      } else {
-        query.with('funnel', 'SELECT * FROM session_funnel WHERE level != 0');
-      }
+      // Same shape as the chart's `funnel` CTE: windowFunnel is already
+      // computed per primary key, so drop level=0 and select distinct
+      // profiles. Re-aggregating with max(level)/any(b_0) here would collapse
+      // the breakdown column and make the breakdownValues filter pick an
+      // arbitrary value for profiles that appear under more than one.
+      query.with('funnel', 'SELECT * FROM session_funnel WHERE level != 0');
 
       query.select(['DISTINCT profile_id']).from('funnel');
 


### PR DESCRIPTION
Fixes #427.

## Status of the original report

The issue was filed against `b467a6ce` (Mar 23). The **profile-breakdown** half was already fixed on `main` in `604a5698` (May 19, "fix: cohort filters and view funnel profiles with breakdowns"), which added the `anyBreakdownOnProfile` guard to `getFunnelProfiles`.

What was still broken, and what this PR fixes:

1. **Cohort breakdowns** — still no join in `getFunnelProfiles`, exactly as the issue predicted.
2. **The root cause itself** — the duplicated funnel SQL. `604a5698` fixed one symptom by copying the guard across; the two copies were still free to drift.
3. **The modal** — still `data ?? []`, so any failure reads as "No users found".

Plus one bug found while unifying them (below).

## The fix

Extract the shared construction into `FunnelService.buildFunnelBase`. It normalizes the series and breakdowns, builds the `session_funnel` CTE, and wires up every join the breakdowns and filters imply — profiles, groups, and cohorts. `getFunnel` and `getFunnelProfiles` each add only their own outer projection.

This is the issue's "Better" option. The minimal fix (copy the join logic across again) would leave the same failure mode one breakdown type away: the breakdown *selects* and the *joins they require* have to be decided in one place, or they drift.

### Three real fixes fall out of the unification

- **Cohort breakdowns** get their `cohort_<id>` join in the profile list.
- **Breakdowns are filtered identically on both sides.** The profile list previously used the raw input list while the chart filtered via `isKnownEventField`, so when the chart dropped a breakdown, the UI's `breakdownValues` indices — derived from the chart's series — pointed at the wrong `b_N` column.
- **The profile list no longer re-aggregates** with `max(level)` / `any(b_0)` per profile. With a breakdown, `session_funnel` groups by (key, `b_0`), so `any()` collapsed a profile appearing under several breakdown values down to an arbitrary one and *then* filtered on it. Selecting distinct profiles from the same `funnel` CTE the chart uses makes the list match the chart exactly — the chart's step count is rows with `level >= i` and its dropoff count is rows with `level == i` (via `fillFunnel`'s accumulation), which is precisely what this queries.

### Bonus: the all-cohorts breakdown broke the funnel chart too

`getFunnel`'s comment says unknown breakdowns are dropped so a saved report with breakdown `cohort` can't produce `cohort as b_0 FROM events`. It doesn't — `isKnownEventField('cohort')` returns `true` via `isAllCohortsBreakdown`, so it survives the filter and renders verbatim.

Reproduced against `getFunnel` on unmodified `main`:

```
MAIN getFunnel(cohort breakdown) >>> FAILED: 47 Unknown expression identifier `cohort` in scope session_funnel.
```

So this broke the funnel **chart**, not just View Users. The funnel has no all-cohorts equivalent, so it's now excluded explicitly — which is what the comment already claimed.

### Modal error state

`view-chart-users.tsx` now distinguishes a failed query from an empty result, so a backend error can't masquerade as "No users found" again. Applied to both the chart and funnel views.

## Tests

New `packages/db/src/services/funnel-sql.test.ts`, following the strategy already used by `chart-sql.test.ts`: build the SQL, then `EXPLAIN` it against local ClickHouse. EXPLAIN parses and resolves columns without executing, so a breakdown referencing a join alias that was never added fails as `UNKNOWN_IDENTIFIER` — exactly this bug class. Auto-skips if CH is unreachable.

9 tests: profile-property and top-level-profile breakdowns, profile filters with no breakdown, cohort breakdowns, the all-cohorts breakdown, an unrecognised breakdown name, group breakdowns, and chart/profiles `b_N` index agreement.

```
✓ src/services/funnel-sql.test.ts (9 tests)
```

Full `@openpanel/db` suite: **149 passed**. `tsc --noEmit` clean in every touched file.

https://claude.ai/code/session_01ETRr6KYLYATzBVaLRZcwwk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Chart and funnel user views now display a clear error state when profile data cannot be loaded, instead of appearing as an empty list.
  - Loading states are presented consistently across chart and funnel user views.
  - Funnel profile results now use more consistent filtering and breakdown handling, improving result accuracy across supported views.
  - Profile and cohort breakdowns are handled more reliably in funnel results, including unsupported or all-cohort selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->