### PR TITLE
fix(funnel): attribute breakdowns at the entry step instead of grouping by them

### DIFF
--- a/packages/db/src/services/funnel-sql.test.ts
+++ b/packages/db/src/services/funnel-sql.test.ts
@@ -232,12 +232,16 @@ describe('funnel.service / buildFunnelBase — breakdown attribution', () => {
     await explain(sql);
   });
 
-  itCH('keeps per-row grouping for group breakdowns (fan-out is intended)', async () => {
+  it('keeps per-row grouping for group breakdowns (fan-out is intended)', async () => {
     // A user in three groups should appear in all three funnels, so group.*
     // breakdowns keep the ARRAY JOIN fan-out and per-row GROUP BY.
     const sql = await buildChartSql([breakdown('group.plan')]);
     expect(sql).not.toContain('argMinIf');
     expect(sql).toMatch(/GROUP BY session_id, b_0/);
+  });
+
+  itCH('group-breakdown SQL parses and resolves', async () => {
+    const sql = await buildChartSql([breakdown('group.plan')]);
     await explain(sql);
   });
 });

--- a/packages/db/src/services/funnel-sql.test.ts
+++ b/packages/db/src/services/funnel-sql.test.ts
@@ -201,10 +201,44 @@ describe('funnel.service / buildFunnelBase — unknown breakdowns', () => {
 
     // Both sides must resolve the same breakdown to the same b_N index,
     // otherwise the breakdownValues filter targets the wrong column.
-    expect(chartSql).toContain("profile.properties['plan'] as b_0");
-    expect(profilesSql).toContain("profile.properties['plan'] as b_0");
+    expect(chartSql).toContain(
+      "argMinIf(profile.properties['plan'], created_at,",
+    );
+    expect(profilesSql).toContain(
+      "argMinIf(profile.properties['plan'], created_at,",
+    );
     await explain(chartSql);
     await explain(profilesSql);
+  });
+});
+
+describe('funnel.service / buildFunnelBase — breakdown attribution', () => {
+  // The breakdown value must be read at the user's FIRST funnel step, not
+  // used as a windowFunnel GROUP BY key. Per-row grouping splits a user's
+  // steps across buckets whenever the property isn't identical on every
+  // step, so the sequence never connects and downstream steps show 0.
+  it('attributes event-property breakdowns at the entry step', async () => {
+    const sql = await buildChartSql([breakdown('properties.experiment')]);
+    expect(sql).toContain("argMinIf(properties['experiment'], created_at,");
+    // The windowFunnel aggregation groups by the primary key only; b_0 is an
+    // aggregate, not a grouping key. (The outer chart GROUP BY level, b_0 is
+    // unaffected.)
+    expect(sql).toMatch(/GROUP BY session_id\b/);
+    expect(sql).not.toMatch(/GROUP BY session_id, b_0/);
+  });
+
+  itCH('entry-step attribution parses and resolves', async () => {
+    const sql = await buildChartSql([breakdown('properties.experiment')]);
+    await explain(sql);
+  });
+
+  itCH('keeps per-row grouping for group breakdowns (fan-out is intended)', async () => {
+    // A user in three groups should appear in all three funnels, so group.*
+    // breakdowns keep the ARRAY JOIN fan-out and per-row GROUP BY.
+    const sql = await buildChartSql([breakdown('group.plan')]);
+    expect(sql).not.toContain('argMinIf');
+    expect(sql).toMatch(/GROUP BY session_id, b_0/);
+    await explain(sql);
   });
 });
 

--- a/packages/db/src/services/funnel.service.ts
+++ b/packages/db/src/services/funnel.service.ts
@@ -288,12 +288,42 @@ export class FunnelService {
     const cohortIds = collectBreakdownCohortIds(breakdowns);
     const cohortMetadata = await fetchCohortsMetadata(cohortIds);
 
+    // Attribute each breakdown to its value at the user's FIRST funnel step,
+    // as a per-group aggregate (argMinIf) — not by adding it to the
+    // windowFunnel GROUP BY. Grouping the sequence by a per-row value splits
+    // a user's steps across buckets whenever the value isn't identical on
+    // every step (e.g. an experiment tag set on the entry event but absent
+    // on the conversion event): the later step lands in a separate bucket,
+    // the windowFunnel sequence never connects, and downstream steps show 0.
+    // Reading the entry-step value keeps each sequence intact in one bucket
+    // and matches standard funnel-breakdown semantics (segment by entry
+    // attribute).
+    //
+    // `group.*` breakdowns are the exception: their ARRAY JOIN fans each
+    // event out per group, and grouping by the group value is intentional —
+    // a user in three groups should appear in all three funnels. Those keep
+    // the per-row GROUP BY.
+    const firstStepCondition = this.getFunnelConditions(
+      eventSeries,
+      projectId,
+    )[0]!;
     const breakdownSelects = breakdowns.map((b, index) => {
       const bId = extractCohortId(b.name);
       const bName = bId ? cohortMetadata.get(bId)?.name : undefined;
-      return `${getSelectPropertyKey(b.name, projectId, bId ?? undefined, bName)} as b_${index}`;
+      const expr = getSelectPropertyKey(
+        b.name,
+        projectId,
+        bId ?? undefined,
+        bName,
+      );
+      if (b.name.startsWith('group.')) {
+        return `${expr} as b_${index}`;
+      }
+      return `argMinIf(${expr}, created_at, ${firstStepCondition}) as b_${index}`;
     });
-    const breakdownGroupBy = breakdowns.map((_, index) => `b_${index}`);
+    const breakdownGroupBy = breakdowns.flatMap((b, index) =>
+      b.name.startsWith('group.') ? [`b_${index}`] : [],
+    );
 
     const funnelCte = this.buildFunnelCte({
       projectId,

--- a/packages/trpc/src/routers/chart.ts
+++ b/packages/trpc/src/routers/chart.ts
@@ -6,6 +6,7 @@ import {
   clix,
   conversionService,
   createSqlBuilder,
+  EMPTY_BREAKDOWN_LABEL,
   formatClickhouseDate,
   funnelService,
   getChartPrevStartEndDate,
@@ -852,10 +853,9 @@ export const chartRouter = createTRPCRouter({
       });
 
       // Same shape as the chart's `funnel` CTE: windowFunnel is already
-      // computed per primary key, so drop level=0 and select distinct
-      // profiles. Re-aggregating with max(level)/any(b_0) here would collapse
-      // the breakdown column and make the breakdownValues filter pick an
-      // arbitrary value for profiles that appear under more than one.
+      // computed per primary key (with breakdowns attributed at the entry
+      // step, so each group carries one deterministic b_N value), so drop
+      // level=0 and select distinct profiles.
       query.with('funnel', 'SELECT * FROM session_funnel WHERE level != 0');
 
       query.select(['DISTINCT profile_id']).from('funnel');
@@ -866,11 +866,22 @@ export const chartRouter = createTRPCRouter({
         query.where('level', '>=', targetLevel);
       }
 
-      // Filter by specific breakdown values when a breakdown row was clicked
+      // Filter by specific breakdown values when a breakdown row was clicked.
+      // The clicked row carries DISPLAY labels — trimmed, with empty/null
+      // shown as EMPTY_BREAKDOWN_LABEL (see toSeries/normalizeBreakdownValue)
+      // — so match against the same normalization, not the raw column, or
+      // "Not set" rows and values with stray whitespace return no users.
       breakdowns.forEach((_, index) => {
         const value = breakdownValues[index];
-        if (value !== undefined) {
-          query.where(`b_${index}`, '=', value);
+        if (value === undefined) {
+          return;
+        }
+        if (value === EMPTY_BREAKDOWN_LABEL) {
+          query.rawWhere(
+            `(trim(b_${index}) = '' OR trim(b_${index}) = ${sqlstring.escape(EMPTY_BREAKDOWN_LABEL)})`
+          );
+        } else {
+          query.rawWhere(`trim(b_${index}) = ${sqlstring.escape(value)}`);
         }
       });
 

--- a/packages/trpc/src/routers/chart.ts
+++ b/packages/trpc/src/routers/chart.ts
@@ -871,17 +871,21 @@ export const chartRouter = createTRPCRouter({
       // shown as EMPTY_BREAKDOWN_LABEL (see toSeries/normalizeBreakdownValue)
       // — so match against the same normalization, not the raw column, or
       // "Not set" rows and values with stray whitespace return no users.
+      // toString/ifNull make the comparison safe for numeric breakdown
+      // columns (trim on a number is a type error) and for Nullable ones
+      // (trim(NULL) = '' is NULL, never true).
       breakdowns.forEach((_, index) => {
         const value = breakdownValues[index];
         if (value === undefined) {
           return;
         }
+        const normalized = `trim(ifNull(toString(b_${index}), ''))`;
         if (value === EMPTY_BREAKDOWN_LABEL) {
           query.rawWhere(
-            `(trim(b_${index}) = '' OR trim(b_${index}) = ${sqlstring.escape(EMPTY_BREAKDOWN_LABEL)})`
+            `(${normalized} = '' OR ${normalized} = ${sqlstring.escape(EMPTY_BREAKDOWN_LABEL)})`
           );
         } else {
-          query.rawWhere(`trim(b_${index}) = ${sqlstring.escape(value)}`);
+          query.rawWhere(`${normalized} = ${sqlstring.escape(value)}`);
         }
       });
 


### PR DESCRIPTION
## Problem

A funnel breakdown is added to the windowFunnel `GROUP BY`, so the sequence is computed per **(session, breakdown value)**. Any property that isn't identical on every step — an experiment tag set on the entry event but absent on the conversion event, a page title that only exists on `screen_view`s — splits a user's steps across buckets. The later step lands in a bucket whose windowFunnel never saw step 1, the sequence never connects, and downstream steps report 0 (or heavily undercount).

Measured on real data (steps `screen_view` → `session_end`, broken down by a property that only `screen_view` carries, 6h window):

| | sessions completing both steps |
|---|---|
| no breakdown (ground truth) | 283 |
| current per-row grouping, summed across named buckets | 235 |
| entry-step attribution (this PR) | 283 |

17% of completed sequences silently vanish the moment a breakdown is added.

## Fix

Read each breakdown as a per-group aggregate of its value at the user's **first funnel step** — `argMinIf(<expr>, created_at, <step-1 condition>)` — instead of grouping the sequence by it. Every sequence stays intact in one bucket, and the bucket is labeled by the entry attribute, which is the standard funnel-breakdown semantic (Mixpanel/Amplitude behave this way).

`group.*` breakdowns are deliberately excluded: their ARRAY JOIN fans each event out per group, and grouping by the group value is intentional — a user in three groups should appear in all three funnels. Those keep the per-row `GROUP BY`.

Because each group now carries one deterministic `b_N`, the "View Users" endpoint's breakdown filter is also aligned with what the user actually clicked: the modal passes back display labels (trimmed, empty shown as "Not set"), so the filter now matches `trim(b_N)` and maps the "Not set" label back to empty. Previously clicking a "Not set" row (or any value with stray whitespace) returned "No users found".

## Tests

- `funnel-sql.test.ts`: entry-step attribution renders `argMinIf(..., created_at, <step-1>)` and keeps `b_N` out of the windowFunnel `GROUP BY`; `group.*` breakdowns keep per-row grouping; existing chart/profiles same-index consistency test updated; all EXPLAIN-validated against ClickHouse.
- `pnpm tsc --noEmit` clean on `@openpanel/db` and `@openpanel/trpc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved funnel breakdown attribution by consistently using values from the first funnel step.
  * Prevented changing event or profile properties from incorrectly splitting funnel sequences.
  * Preserved accurate multi-group attribution for group-based breakdowns.
  * Improved breakdown filtering, including trimmed values and empty or null breakdowns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->