### PR TITLE
perf(project): read project event counts from distinct_event_names_mv

### DIFF
--- a/packages/db/src/services/project.service.ts
+++ b/packages/db/src/services/project.service.ts
@@ -97,7 +97,16 @@ export const getProjectEventsCount = async (projectId: string) => {
   // scans the project's whole events slice — and this runs from the sessions
   // job on every batch. distinct_event_names_mv already accumulates
   // `count() AS event_count` per (project_id, name) insert block, so summing
-  // it returns the same total from a few thousand pre-aggregated rows.
+  // it returns a fast approximate total from a few thousand pre-aggregated
+  // rows instead of billions of raw ones.
+  //
+  // Approximate because event_count is a plain UInt64, not an aggregate
+  // state: MV counter rows whose (project_id, name, created_at) sort key
+  // collides collapse on merge keeping only one block's count. Live
+  // ingestion rarely ties on the ms timestamp; bulk imports with coarse
+  // timestamps are where collisions come from. The error is strictly
+  // downward (measured 0.0011% low on a 1.46B-event project) — acceptable
+  // for this display/onboarding counter.
   const res = await chQuery<{ count: number }>(
     `SELECT sum(event_count) as count FROM ${TABLE_NAMES.event_names_mv} WHERE project_id = ${sqlstring.escape(projectId)} AND name NOT IN ('session_start', 'session_end')`
   );

--- a/packages/db/src/services/project.service.ts
+++ b/packages/db/src/services/project.service.ts
@@ -92,21 +92,27 @@ export async function getProjects({
   return projects;
 }
 
+/**
+ * Fast approximate count of a project's events (excluding session_start /
+ * session_end), read from distinct_event_names_mv instead of the raw events
+ * table.
+ *
+ * Why not count raw events: `name NOT IN (...)` is a negation, so it can't
+ * prune with idx_name and scans the project's whole events slice — and this
+ * runs from the sessions job on every batch. The MV already accumulates
+ * `count() AS event_count` per (project_id, name) insert block, so summing
+ * it reads a few thousand pre-aggregated rows instead of billions of raw
+ * ones.
+ *
+ * Why approximate: event_count is a plain UInt64, not an aggregate state,
+ * so MV counter rows whose (project_id, name, created_at) sort key collides
+ * collapse on merge keeping only one block's count. Live ingestion rarely
+ * ties on the ms timestamp; bulk imports with coarse timestamps are where
+ * collisions come from. The error is strictly downward (measured 0.0011%
+ * low on a 1.46B-event project) — acceptable for this display/onboarding
+ * counter.
+ */
 export const getProjectEventsCount = async (projectId: string) => {
-  // `name NOT IN (...)` is a negation, so it can't prune with idx_name and
-  // scans the project's whole events slice — and this runs from the sessions
-  // job on every batch. distinct_event_names_mv already accumulates
-  // `count() AS event_count` per (project_id, name) insert block, so summing
-  // it returns a fast approximate total from a few thousand pre-aggregated
-  // rows instead of billions of raw ones.
-  //
-  // Approximate because event_count is a plain UInt64, not an aggregate
-  // state: MV counter rows whose (project_id, name, created_at) sort key
-  // collides collapse on merge keeping only one block's count. Live
-  // ingestion rarely ties on the ms timestamp; bulk imports with coarse
-  // timestamps are where collisions come from. The error is strictly
-  // downward (measured 0.0011% low on a 1.46B-event project) — acceptable
-  // for this display/onboarding counter.
   const res = await chQuery<{ count: number }>(
     `SELECT sum(event_count) as count FROM ${TABLE_NAMES.event_names_mv} WHERE project_id = ${sqlstring.escape(projectId)} AND name NOT IN ('session_start', 'session_end')`
   );

--- a/packages/db/src/services/project.service.ts
+++ b/packages/db/src/services/project.service.ts
@@ -93,8 +93,13 @@ export async function getProjects({
 }
 
 export const getProjectEventsCount = async (projectId: string) => {
+  // `name NOT IN (...)` is a negation, so it can't prune with idx_name and
+  // scans the project's whole events slice — and this runs from the sessions
+  // job on every batch. distinct_event_names_mv already accumulates
+  // `count() AS event_count` per (project_id, name) insert block, so summing
+  // it returns the same total from a few thousand pre-aggregated rows.
   const res = await chQuery<{ count: number }>(
-    `SELECT count(*) as count FROM ${TABLE_NAMES.events} WHERE project_id = ${sqlstring.escape(projectId)} AND name NOT IN ('session_start', 'session_end')`
+    `SELECT sum(event_count) as count FROM ${TABLE_NAMES.event_names_mv} WHERE project_id = ${sqlstring.escape(projectId)} AND name NOT IN ('session_start', 'session_end')`
   );
   return res[0]?.count;
 };


### PR DESCRIPTION
## Problem

`getProjectEventsCount` counts raw events with `name NOT IN ('session_start', 'session_end')`. A negated name filter can't prune with `idx_name`, so every call scans the project's entire events slice — and the sessions job calls this on every batch, so the scan re-runs all day long. On our deployment (~1.5B events in one project) it was the most expensive recurring query in the system.

## Fix

`distinct_event_names_mv` already accumulates `count() AS event_count` per `(project_id, name)` insert block. Summing it over the project (minus the two session events) returns the total from a few thousand pre-aggregated rows instead of billions of raw ones.

## Why the sum is approximate (and why that's fine here)

The MV's query runs once per insert block into `events`, so each batch appends one counter row per event name — the total per name is the sum of many small per-batch rows. But `event_count` is a plain `UInt64`, not an `AggregateFunction` state, and for plain columns AggregatingMergeTree behaves like ReplacingMergeTree: two counter rows whose `(project_id, name, created_at)` sort key is **identical** collapse on merge, keeping only one block's count. The other block's count silently drops out of the sum.

Key collisions are rare under live ingestion (different batches seldom tie on a millisecond `max(created_at)`), but common for bulk-imported data with coarse timestamps — which is exactly our case: on our deployment, a 1.46B-event project that includes a large historical import with second-granularity timestamps measures **0.0011% low** (1,458,634,820 via the MV vs 1,458,651,382 via the full scan). The error is strictly downward — collapse can only drop counter rows, never double them — and duplicate *events* don't cause disagreement at all (they increment both sides identically).

The value feeds the project's `eventsCount` stat and the onboarding has-data checks; org-level billing counts come from `getOrganizationBillingEventsCount`, which is untouched. For an exact MV the column would need to become `SimpleAggregateFunction(sum, UInt64)` so merges add instead of replace, but that's a rebuild of an existing table — disproportionate for a display counter. Happy to do it that way instead if you'd prefer exactness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
