### PR TITLE
feat(cohorts): make the materialize limit configurable via env

### DIFF
--- a/packages/db/src/services/cohort.service.ts
+++ b/packages/db/src/services/cohort.service.ts
@@ -28,15 +28,21 @@ import {
 // than this are silently truncated to an arbitrary subset, so deployments
 // with bigger cohorts need to raise it — env-tunable to avoid an image
 // rebuild for what is really a sizing knob.
-const COHORT_MATERIALIZE_LIMIT_RAW = Number.parseInt(
-  process.env.COHORT_MATERIALIZE_LIMIT ?? '',
-  10,
-);
-export const COHORT_MATERIALIZE_LIMIT = Number.isNaN(
-  COHORT_MATERIALIZE_LIMIT_RAW,
-)
-  ? 10000
-  : COHORT_MATERIALIZE_LIMIT_RAW;
+//
+// Strictly a positive safe integer: anything else falls back to the
+// default. Number.parseInt would accept '5000junk' or '-1' (LIMIT -1 is a
+// query error), and 0 is falsy at the `limit ? LIMIT ... : ''` call sites,
+// which would silently remove the cap entirely.
+const COHORT_MATERIALIZE_LIMIT_RAW = process.env.COHORT_MATERIALIZE_LIMIT;
+const COHORT_MATERIALIZE_LIMIT_PARSED =
+  COHORT_MATERIALIZE_LIMIT_RAW && /^\d+$/.test(COHORT_MATERIALIZE_LIMIT_RAW)
+    ? Number(COHORT_MATERIALIZE_LIMIT_RAW)
+    : Number.NaN;
+export const COHORT_MATERIALIZE_LIMIT =
+  Number.isSafeInteger(COHORT_MATERIALIZE_LIMIT_PARSED) &&
+  COHORT_MATERIALIZE_LIMIT_PARSED > 0
+    ? COHORT_MATERIALIZE_LIMIT_PARSED
+    : 10000;
 
 function buildTimeConstraint(timeframe: Timeframe): string {
   if (timeframe.type === 'relative') {

--- a/packages/db/src/services/cohort.service.ts
+++ b/packages/db/src/services/cohort.service.ts
@@ -24,7 +24,19 @@ import {
   type IServiceProfile,
 } from './profile.service';
 
-export const COHORT_MATERIALIZE_LIMIT = 10000;
+// Max members materialized into cohort_members per compute. Cohorts larger
+// than this are silently truncated to an arbitrary subset, so deployments
+// with bigger cohorts need to raise it — env-tunable to avoid an image
+// rebuild for what is really a sizing knob.
+const COHORT_MATERIALIZE_LIMIT_RAW = Number.parseInt(
+  process.env.COHORT_MATERIALIZE_LIMIT ?? '',
+  10,
+);
+export const COHORT_MATERIALIZE_LIMIT = Number.isNaN(
+  COHORT_MATERIALIZE_LIMIT_RAW,
+)
+  ? 10000
+  : COHORT_MATERIALIZE_LIMIT_RAW;
 
 function buildTimeConstraint(timeframe: Timeframe): string {
   if (timeframe.type === 'relative') {


### PR DESCRIPTION
## Problem

`COHORT_MATERIALIZE_LIMIT` is hardcoded to 10000. Cohorts larger than that are silently truncated to an arbitrary 10k-member subset at compute time — member counts, cohort-filtered charts, and cohort event feeds all quietly report on a fraction of the real cohort, with no signal that truncation happened. We run cohorts with 77k and 227k genuine members, and the numbers were simply wrong until we found this.

## Fix

Keep 10000 as the default and read an optional `COHORT_MATERIALIZE_LIMIT` env var (any non-numeric value falls back to the default), so deployments with larger cohorts can raise the cap without patching the image. No behavior change unless the variable is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration support for controlling the cohort materialization limit through an environment variable.
  - Uses a default limit of 10,000 when the setting is missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->