### PR TITLE
feat(funnel): opt-in non-strict windowFunnel ordering

### DIFF
--- a/apps/public/content/docs/self-hosting/environment-variables.mdx
+++ b/apps/public/content/docs/self-hosting/environment-variables.mdx
@@ -984,6 +984,21 @@ Batch size for bot detection buffer operations.
 BOT_BUFFER_BATCH_SIZE=1000
 ```
 
+## Analytics Behavior
+
+### FUNNEL_NON_STRICT_ORDERING
+
+**Type**: `boolean` (`1` or `true`)  
+**Required**: No  
+**Default**: unset (strict ordering)
+
+Funnels use ClickHouse's `windowFunnel` in `strict_increase` mode by default: every step's timestamp must be strictly greater than the previous step's. Setting this variable switches funnels to non-strict ordering (`>=`), where steps sharing the same timestamp still count as an ordered sequence — matching how Mixpanel and Amplitude evaluate funnels. Useful for server-side senders, batched SDKs, or imported data with coarse timestamps.
+
+**Example**:
+```bash
+FUNNEL_NON_STRICT_ORDERING=1
+```
+
 ## Performance & Tuning
 
 ### IMPORT_BATCH_SIZE

--- a/packages/db/src/services/funnel-sql.test.ts
+++ b/packages/db/src/services/funnel-sql.test.ts
@@ -315,7 +315,9 @@ describe('funnel.service / buildFunnelCte — windowFunnel ordering', () => {
   });
 
   it('defaults to strict_increase (unchanged behavior)', async () => {
-    vi.unstubAllEnvs();
+    // Stub to '' rather than unstubbing: unstubAllEnvs restores the HOST
+    // environment, so a dev shell with the variable set would flip this test.
+    vi.stubEnv('FUNNEL_NON_STRICT_ORDERING', '');
     const sql = await buildChartSql([]);
     expect(sql).toContain("'strict_increase'");
   });

--- a/packages/db/src/services/funnel-sql.test.ts
+++ b/packages/db/src/services/funnel-sql.test.ts
@@ -309,6 +309,32 @@ describe('funnel.service / buildFunnelBase — breakdown attribution', () => {
   });
 });
 
+describe('funnel.service / buildFunnelCte — windowFunnel ordering', () => {
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('defaults to strict_increase (unchanged behavior)', async () => {
+    vi.unstubAllEnvs();
+    const sql = await buildChartSql([]);
+    expect(sql).toContain("'strict_increase'");
+  });
+
+  it('drops strict_increase when FUNNEL_NON_STRICT_ORDERING is set', async () => {
+    vi.stubEnv('FUNNEL_NON_STRICT_ORDERING', '1');
+    const sql = await buildChartSql([]);
+    expect(sql).not.toContain('strict_increase');
+    expect(sql).toMatch(/windowFunnel\(\d+\)\(/);
+  });
+
+  itCH('non-strict funnel SQL parses and resolves', async () => {
+    vi.stubEnv('FUNNEL_NON_STRICT_ORDERING', 'true');
+    const sql = await buildChartSql([]);
+    expect(sql).not.toContain('strict_increase');
+    await explain(sql);
+  });
+});
+
 describe('funnel.service / buildFunnelBase — group breakdowns', () => {
   itCH('adds the group array join for a group breakdown', async () => {
     const sql = await buildProfilesSql([breakdown('group.plan')]);

--- a/packages/db/src/services/funnel.service.ts
+++ b/packages/db/src/services/funnel.service.ts
@@ -84,10 +84,21 @@ export class FunnelService {
     const funnels = this.getFunnelConditions(eventSeries, projectId);
     const primaryKey = group === 'profile_id' ? 'profile_id' : 'session_id';
 
+    // windowFunnel's 'strict_increase' mode requires every step's timestamp
+    // to be strictly greater than the previous step's, so same-timestamp
+    // sequences (server-side senders, batched SDKs, imported data with
+    // coarse timestamps) never connect. Mixpanel/Amplitude count those as
+    // ordered, so deployments migrating from them can opt into the default
+    // (>=) mode; strict stays the default here.
+    const nonStrictOrdering =
+      process.env.FUNNEL_NON_STRICT_ORDERING === '1' ||
+      process.env.FUNNEL_NON_STRICT_ORDERING === 'true';
+    const windowFunnelMode = nonStrictOrdering ? '' : ", 'strict_increase'";
+
     return clix(this.client, timezone)
       .select([
         primaryKey,
-        `windowFunnel(${funnelWindowMilliseconds}, 'strict_increase')(toUInt64(toUnixTimestamp64Milli(created_at)), ${funnels.join(', ')}) AS level`,
+        `windowFunnel(${funnelWindowMilliseconds}${windowFunnelMode})(toUInt64(toUnixTimestamp64Milli(created_at)), ${funnels.join(', ')}) AS level`,
         ...(group === 'session_id'
           ? ['argMax(profile_id, created_at) AS profile_id']
           : []),


### PR DESCRIPTION
## Problem

Funnels hardcode `windowFunnel(..., 'strict_increase')`: every step's timestamp must be **strictly greater** than the previous step's. Any same-timestamp sequence — server-side senders that batch a user's actions, SDKs that flush several events in one tick, imported data with second-granularity timestamps — never connects, and those conversions silently vanish from the funnel. Mixpanel and Amplitude both count same-timestamp steps as ordered, so anyone comparing OpenPanel funnels against a previous tool sees unexplained shortfalls.

## Fix

An opt-in env var, `FUNNEL_NON_STRICT_ORDERING` (`1`/`true`), that switches funnels to windowFunnel's default (`>=`) ordering. **Strict remains the default — zero behavior change unless the variable is set.** Documented in the self-hosting environment-variables reference.

Kept deliberately as a deployment-level toggle rather than a per-report option to stay minimal; happy to build the per-report picker instead if you'd rather expose it in the UI.

## Tests

`funnel-sql.test.ts`: default SQL still contains `'strict_increase'`; with the env set the mode argument is dropped (`windowFunnel(<window>)(...)`); non-strict SQL EXPLAIN-validated against ClickHouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `FUNNEL_NON_STRICT_ORDERING` setting for funnel analytics.
  * When enabled with `1` or `true`, funnel steps may share the same timestamp.

* **Documentation**
  * Documented the new setting and its behavior.

* **Bug Fixes**
  * Preserved strict timestamp ordering by default for consistent funnel results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->