### PR TITLE
feat(lists): per-list ceilings for the empty-result lookback

### DIFF
--- a/apps/public/content/docs/self-hosting/environment-variables.mdx
+++ b/apps/public/content/docs/self-hosting/environment-variables.mdx
@@ -986,17 +986,30 @@ BOT_BUFFER_BATCH_SIZE=1000
 
 ## Performance & Tuning
 
-### MAX_LOOKBACK_DAYS
+### EVENT_LIST_MAX_LOOKBACK_DAYS
 
-**Type**: `number` (days)  
+**Type**: `number` (whole days, positive integer)  
 **Required**: No  
-**Default**: unset (event list: 1825, session list: 365)
+**Default**: `1825` (5 years)
 
-Ceiling for the empty-result lookback on the event and session lists. When a page's cursor window matches nothing, the window doubles and retries until it reaches this many days. With filters that no index can prune (e.g. a properties value) each retry is a full scan of its window, so large deployments can bound the worst case with a small, human-sized value.
+Ceiling for the empty-result lookback on the event list. When a page's cursor window matches nothing, the window doubles and retries until it reaches this many days. With filters that no index can prune (e.g. a properties value) each retry is a full scan of its window, so large deployments can bound the worst case with a small, human-sized value. Invalid values (non-integer, zero, negative) keep the default.
 
 **Example**:
 ```bash
-MAX_LOOKBACK_DAYS=7
+EVENT_LIST_MAX_LOOKBACK_DAYS=7
+```
+
+### SESSION_LIST_MAX_LOOKBACK_DAYS
+
+**Type**: `number` (whole days, positive integer)  
+**Required**: No  
+**Default**: `365`
+
+Same ceiling for the session list, which has its own default. Invalid values keep the default.
+
+**Example**:
+```bash
+SESSION_LIST_MAX_LOOKBACK_DAYS=7
 ```
 
 ### IMPORT_BATCH_SIZE

--- a/apps/public/content/docs/self-hosting/environment-variables.mdx
+++ b/apps/public/content/docs/self-hosting/environment-variables.mdx
@@ -986,6 +986,19 @@ BOT_BUFFER_BATCH_SIZE=1000
 
 ## Performance & Tuning
 
+### MAX_LOOKBACK_DAYS
+
+**Type**: `number` (days)  
+**Required**: No  
+**Default**: unset (event list: 1825, session list: 365)
+
+Ceiling for the empty-result lookback on the event and session lists. When a page's cursor window matches nothing, the window doubles and retries until it reaches this many days. With filters that no index can prune (e.g. a properties value) each retry is a full scan of its window, so large deployments can bound the worst case with a small, human-sized value.
+
+**Example**:
+```bash
+MAX_LOOKBACK_DAYS=7
+```
+
 ### IMPORT_BATCH_SIZE
 
 **Type**: `number`  

--- a/packages/db/src/services/event.service.ts
+++ b/packages/db/src/services/event.service.ts
@@ -501,7 +501,10 @@ export async function getEventList(options: GetEventListOptions) {
   const { sb, getSql, join } = createSqlBuilder();
 
   // Deployment-tunable ceiling for the empty-result lookback (see lookback.ts).
-  const MAX_DATE_INTERVAL_IN_DAYS = resolveMaxLookbackDays(365 * 5);
+  const MAX_DATE_INTERVAL_IN_DAYS = resolveMaxLookbackDays(
+    'EVENT_LIST_MAX_LOOKBACK_DAYS',
+    365 * 5,
+  );
   // Cap the date interval to prevent infinity
   const safeDateIntervalInDays = Math.min(
     dateIntervalInDays,

--- a/packages/db/src/services/event.service.ts
+++ b/packages/db/src/services/event.service.ts
@@ -16,6 +16,7 @@ import { clix, type Query } from '../clickhouse/query-builder';
 import type { EventMeta, Prisma } from '../prisma-client';
 import { db } from '../prisma-client';
 import { createSqlBuilder, type SqlBuilderObject } from '../sql-builder';
+import { resolveMaxLookbackDays } from './lookback';
 import { getEventFiltersWhereClause } from './chart.service';
 import { buildFilterWhere } from './filter-where.service';
 import type { IServiceProfile, IServiceUpsertProfile } from './profile.service';
@@ -499,7 +500,8 @@ export async function getEventList(options: GetEventListOptions) {
   } = options;
   const { sb, getSql, join } = createSqlBuilder();
 
-  const MAX_DATE_INTERVAL_IN_DAYS = 365 * 5;
+  // Deployment-tunable ceiling for the empty-result lookback (see lookback.ts).
+  const MAX_DATE_INTERVAL_IN_DAYS = resolveMaxLookbackDays(365 * 5);
   // Cap the date interval to prevent infinity
   const safeDateIntervalInDays = Math.min(
     dateIntervalInDays,

--- a/packages/db/src/services/lookback.test.ts
+++ b/packages/db/src/services/lookback.test.ts
@@ -7,23 +7,40 @@ describe('resolveMaxLookbackDays', () => {
   });
 
   it('returns the caller default when unset', () => {
-    vi.stubEnv('MAX_LOOKBACK_DAYS', '');
-    expect(resolveMaxLookbackDays(365)).toBe(365);
-    expect(resolveMaxLookbackDays(365 * 5)).toBe(365 * 5);
+    vi.stubEnv('EVENT_LIST_MAX_LOOKBACK_DAYS', '');
+    expect(resolveMaxLookbackDays('EVENT_LIST_MAX_LOOKBACK_DAYS', 365 * 5)).toBe(
+      365 * 5,
+    );
+    expect(resolveMaxLookbackDays('SESSION_LIST_MAX_LOOKBACK_DAYS', 365)).toBe(
+      365,
+    );
   });
 
   it('replaces the ceiling when set to a positive integer', () => {
-    vi.stubEnv('MAX_LOOKBACK_DAYS', '7');
-    expect(resolveMaxLookbackDays(365 * 5)).toBe(7);
+    vi.stubEnv('EVENT_LIST_MAX_LOOKBACK_DAYS', '7');
+    expect(resolveMaxLookbackDays('EVENT_LIST_MAX_LOOKBACK_DAYS', 365 * 5)).toBe(
+      7,
+    );
     // Raising past the default is allowed too — it's a ceiling, not a min.
-    vi.stubEnv('MAX_LOOKBACK_DAYS', '3650');
-    expect(resolveMaxLookbackDays(365)).toBe(3650);
+    vi.stubEnv('SESSION_LIST_MAX_LOOKBACK_DAYS', '3650');
+    expect(resolveMaxLookbackDays('SESSION_LIST_MAX_LOOKBACK_DAYS', 365)).toBe(
+      3650,
+    );
+  });
+
+  it('reads each list its own variable — no cross-talk', () => {
+    vi.stubEnv('EVENT_LIST_MAX_LOOKBACK_DAYS', '7');
+    expect(resolveMaxLookbackDays('SESSION_LIST_MAX_LOOKBACK_DAYS', 365)).toBe(
+      365,
+    );
   });
 
   it('falls back to the default for malformed values', () => {
     for (const bad of ['0', '-1', '7.5', '7days', 'junk']) {
-      vi.stubEnv('MAX_LOOKBACK_DAYS', bad);
-      expect(resolveMaxLookbackDays(365)).toBe(365);
+      vi.stubEnv('EVENT_LIST_MAX_LOOKBACK_DAYS', bad);
+      expect(
+        resolveMaxLookbackDays('EVENT_LIST_MAX_LOOKBACK_DAYS', 365),
+      ).toBe(365);
     }
   });
 });

--- a/packages/db/src/services/lookback.test.ts
+++ b/packages/db/src/services/lookback.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveMaxLookbackDays } from './lookback';
+
+describe('resolveMaxLookbackDays', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns the caller default when unset', () => {
+    vi.stubEnv('MAX_LOOKBACK_DAYS', '');
+    expect(resolveMaxLookbackDays(365)).toBe(365);
+    expect(resolveMaxLookbackDays(365 * 5)).toBe(365 * 5);
+  });
+
+  it('replaces the ceiling when set to a positive integer', () => {
+    vi.stubEnv('MAX_LOOKBACK_DAYS', '7');
+    expect(resolveMaxLookbackDays(365 * 5)).toBe(7);
+    // Raising past the default is allowed too — it's a ceiling, not a min.
+    vi.stubEnv('MAX_LOOKBACK_DAYS', '3650');
+    expect(resolveMaxLookbackDays(365)).toBe(3650);
+  });
+
+  it('falls back to the default for malformed values', () => {
+    for (const bad of ['0', '-1', '7.5', '7days', 'junk']) {
+      vi.stubEnv('MAX_LOOKBACK_DAYS', bad);
+      expect(resolveMaxLookbackDays(365)).toBe(365);
+    }
+  });
+});

--- a/packages/db/src/services/lookback.ts
+++ b/packages/db/src/services/lookback.ts
@@ -10,13 +10,18 @@
  * of its window, and a multi-year ceiling turns one page view into minutes
  * of scanning.
  *
- * MAX_LOOKBACK_DAYS replaces the callers' built-in ceilings with a single
- * human-sized value (1 / 7 / 365 / ...). Unset or invalid (non-numeric,
- * zero, negative) keeps each caller's own default — behavior is unchanged
- * unless the variable is set.
+ * Each list has its own variable (EVENT_LIST_MAX_LOOKBACK_DAYS,
+ * SESSION_LIST_MAX_LOOKBACK_DAYS) because their built-in ceilings differ —
+ * the surfaces have different cost profiles and a shared knob would couple
+ * them. Values are human-sized day counts (1 / 7 / 365 / ...); unset or
+ * invalid (non-integer, zero, negative) keeps the caller's default, so
+ * behavior is unchanged unless a variable is set.
  */
-export function resolveMaxLookbackDays(defaultDays: number): number {
-  const raw = process.env.MAX_LOOKBACK_DAYS;
+export function resolveMaxLookbackDays(
+  envName: string,
+  defaultDays: number
+): number {
+  const raw = process.env[envName];
   if (!raw || !/^\d+$/.test(raw)) {
     return defaultDays;
   }

--- a/packages/db/src/services/lookback.ts
+++ b/packages/db/src/services/lookback.ts
@@ -1,0 +1,25 @@
+/**
+ * Ceiling (in days) for the empty-result lookback expansion on the event and
+ * session lists.
+ *
+ * When a cursor window matches nothing, those lists double the window and
+ * retry until the ceiling is reached. The doubling geometry keeps the total
+ * cost at roughly 2x the final window, so the ceiling is what actually
+ * bounds the worst case: with a filter no index can prune (e.g. a
+ * properties value) that matches nothing at all, every step is a full scan
+ * of its window, and a multi-year ceiling turns one page view into minutes
+ * of scanning.
+ *
+ * MAX_LOOKBACK_DAYS replaces the callers' built-in ceilings with a single
+ * human-sized value (1 / 7 / 365 / ...). Unset or invalid (non-numeric,
+ * zero, negative) keeps each caller's own default — behavior is unchanged
+ * unless the variable is set.
+ */
+export function resolveMaxLookbackDays(defaultDays: number): number {
+  const raw = process.env.MAX_LOOKBACK_DAYS;
+  if (!raw || !/^\d+$/.test(raw)) {
+    return defaultDays;
+  }
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : defaultDays;
+}

--- a/packages/db/src/services/session.service.ts
+++ b/packages/db/src/services/session.service.ts
@@ -174,7 +174,10 @@ export async function getSessionList(options: GetSessionListOptions) {
   sb.where.projectId = `project_id = ${sqlstring.escape(projectId)}`;
 
   // Deployment-tunable ceiling for the empty-result lookback (see lookback.ts).
-  const MAX_DATE_INTERVAL_IN_DAYS = resolveMaxLookbackDays(365);
+  const MAX_DATE_INTERVAL_IN_DAYS = resolveMaxLookbackDays(
+    'SESSION_LIST_MAX_LOOKBACK_DAYS',
+    365,
+  );
   // Cap the date interval to prevent infinity
   const safeDateIntervalInDays = Math.min(
     dateIntervalInDays,

--- a/packages/db/src/services/session.service.ts
+++ b/packages/db/src/services/session.service.ts
@@ -248,7 +248,7 @@ export async function getSessionList(options: GetSessionListOptions) {
   });
 
   sb.select.has_replay = `toBool(src.session_id != '') as hasReplay`;
-  sb.joins.has_replay = `LEFT JOIN (SELECT DISTINCT session_id FROM ${TABLE_NAMES.session_replay_chunks} WHERE project_id = ${sqlstring.escape(projectId)} AND started_at > now() - INTERVAL ${dateIntervalInDays} DAY) AS src ON src.session_id = id`;
+  sb.joins.has_replay = `LEFT JOIN (SELECT DISTINCT session_id FROM ${TABLE_NAMES.session_replay_chunks} WHERE project_id = ${sqlstring.escape(projectId)} AND started_at > now() - INTERVAL ${safeDateIntervalInDays} DAY) AS src ON src.session_id = id`;
 
   const sql = getSql();
   const data = await chQuery<

--- a/packages/db/src/services/session.service.ts
+++ b/packages/db/src/services/session.service.ts
@@ -11,6 +11,7 @@ import {
 } from '../clickhouse/client';
 import { clix } from '../clickhouse/query-builder';
 import { createSqlBuilder } from '../sql-builder';
+import { resolveMaxLookbackDays } from './lookback';
 import { buildFilterWhere } from './filter-where.service';
 import { getProfilesCached, type IServiceProfile } from './profile.service';
 
@@ -172,7 +173,8 @@ export async function getSessionList(options: GetSessionListOptions) {
   sb.limit = take;
   sb.where.projectId = `project_id = ${sqlstring.escape(projectId)}`;
 
-  const MAX_DATE_INTERVAL_IN_DAYS = 365;
+  // Deployment-tunable ceiling for the empty-result lookback (see lookback.ts).
+  const MAX_DATE_INTERVAL_IN_DAYS = resolveMaxLookbackDays(365);
   // Cap the date interval to prevent infinity
   const safeDateIntervalInDays = Math.min(
     dateIntervalInDays,


### PR DESCRIPTION
## Problem

When an event- or session-list page matches nothing, the cursor window doubles and retries until it reaches a hardcoded ceiling — 5 years for the event list, 1 year for sessions. The doubling itself is fine (the geometric sum keeps total cost at ~2× the final window); the problem is the **unbounded ceiling**: with a filter no index can prune — a `properties` value being the classic case — each retry is a full scan of its window, and a filter that matches *nothing* always runs the ladder to the top. On our deployment (~1.5B events in one project) a single zero-match properties filter cost minutes of ClickHouse time per page view.

## Fix

Two deployment-tunable ceilings, one per list — they have different built-in defaults (1825 vs 365 days), so they're different knobs, and the names follow the codebase's domain-prefixed env convention (`COHORT_*`, `IMPORT_*`, `API_*`):

- `EVENT_LIST_MAX_LOOKBACK_DAYS` (default `1825`)
- `SESSION_LIST_MAX_LOOKBACK_DAYS` (default `365`)

Values are human-sized whole-day counts (1 / 7 / 365 / …). The doubling ladder is untouched — data found at moderate distance is still found by cheap small-window steps — only the worst case gets bounded. Unset or invalid values (non-integer, zero, negative) keep each list's existing default, so **behavior is unchanged unless a variable is set**. Documented in the self-hosting environment-variables reference, value format included.

## Tests

`lookback.test.ts`: default fall-through, positive-integer replacement (including raising past the default — it's a ceiling, not a min), per-list isolation (setting the event var doesn't touch sessions), and malformed-value fallback (`0`, `-1`, `7.5`, `7days`, `junk`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate settings for controlling event and session list lookback limits.
  * Supports independent positive whole-number limits with safe fallback behavior for invalid or unset values.
  * Session lookback limits now apply consistently to date ranges, empty-result retries, and related data retrieval.
* **Documentation**
  * Documented both settings, including defaults, validation behavior, and example configurations.
* **Bug Fixes**
  * Event and session lookback limits can now be adjusted independently without code changes while preserving existing safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->