### PR TITLE
perf(ch): data-skipping index on events.profile_id (migration 18)

### DIFF
--- a/packages/db/code-migrations/18-events-profile-id-index.ts
+++ b/packages/db/code-migrations/18-events-profile-id-index.ts
@@ -1,4 +1,7 @@
-import { runClickhouseMigrationCommands } from '../src/clickhouse/migration';
+import {
+  chMigrationClient,
+  runClickhouseMigrationCommands,
+} from '../src/clickhouse/migration';
 import { getIsCluster } from './helpers';
 
 /**
@@ -13,32 +16,60 @@ import { getIsCluster } from './helpers';
  * profile; on our deployment (~1.5B events) profile pages went from
  * tens-of-seconds full scans to sub-second reads.
  *
- * This migration only ADDs the index — a cheap, metadata-level, idempotent
- * operation that applies to newly written parts. For a deployment whose
- * events table already holds data, existing parts must also be built —
- * targeting the same table this migration alters:
+ * ADD INDEX is metadata-only and covers newly written parts; existing parts
+ * are backfilled by MATERIALIZE INDEX, which this migration submits by
+ * default. The mutation is asynchronous (the migration doesn't block on it)
+ * and idempotent, reads only the profile_id column, and writes small .idx
+ * files — unlike a projection it does not rewrite table data. Progress:
+ *
+ *   SELECT * FROM system.mutations WHERE command LIKE '%idx_profile_id%';
+ *
+ * Deployments with very large events tables that want to control WHEN the
+ * backfill runs can apply both statements manually before upgrading
+ * (off-peak), targeting the same table this migration alters:
  *
  * Non-clustered:
+ *   ALTER TABLE events ADD INDEX IF NOT EXISTS idx_profile_id profile_id TYPE bloom_filter(0.01) GRANULARITY 1;
  *   ALTER TABLE events MATERIALIZE INDEX idx_profile_id;
  *
  * Clustered:
- *   ALTER TABLE events_replicated ON CLUSTER '{cluster}' MATERIALIZE INDEX idx_profile_id;
+ *   ... events_replicated ON CLUSTER '{cluster}' ...
  *
- * which is a heavy one-time mutation (it reads the whole profile_id column,
- * though it only writes small .idx files — unlike a projection it does not
- * rewrite table data). It is deliberately NOT part of the migration so it
- * can't re-run on every deploy; run it once, off-peak, and watch
- * system.mutations until is_done = 1. Fresh installs need nothing.
+ * The migration detects the pre-applied index and skips re-materializing.
+ * Fresh installs have no existing parts, so the mutation is a no-op.
  */
+
+const INDEX_NAME = 'idx_profile_id';
+
+async function hasIndex(table: string): Promise<boolean> {
+  const res = await chMigrationClient.query({
+    query: `SHOW CREATE TABLE ${table}`,
+    format: 'JSONEachRow',
+  });
+  const [row] = await res.json<{ statement: string }>();
+  return !!row?.statement.includes(INDEX_NAME);
+}
 
 export async function up() {
   const isClustered = getIsCluster();
   const table = isClustered ? 'events_replicated' : 'events';
   const onCluster = isClustered ? " ON CLUSTER '{cluster}'" : '';
 
-  await runClickhouseMigrationCommands([
-    `ALTER TABLE ${table}${onCluster} ADD INDEX IF NOT EXISTS idx_profile_id profile_id TYPE bloom_filter(0.01) GRANULARITY 1`,
-  ]);
+  // A pre-existing index means the deployment ran ADD + MATERIALIZE manually
+  // ahead of the upgrade (see header) — don't submit a redundant rebuild of
+  // every part's index files.
+  const preApplied = await hasIndex(table);
+
+  const sqls = [
+    `ALTER TABLE ${table}${onCluster} ADD INDEX IF NOT EXISTS ${INDEX_NAME} profile_id TYPE bloom_filter(0.01) GRANULARITY 1`,
+  ];
+  if (!preApplied) {
+    sqls.push(
+      `ALTER TABLE ${table}${onCluster} MATERIALIZE INDEX ${INDEX_NAME}`,
+    );
+  }
+
+  await runClickhouseMigrationCommands(sqls);
 }
 
 export async function down() {
@@ -47,6 +78,6 @@ export async function down() {
   const onCluster = isClustered ? " ON CLUSTER '{cluster}'" : '';
 
   await runClickhouseMigrationCommands([
-    `ALTER TABLE ${table}${onCluster} DROP INDEX IF EXISTS idx_profile_id`,
+    `ALTER TABLE ${table}${onCluster} DROP INDEX IF EXISTS ${INDEX_NAME}`,
   ]);
 }

--- a/packages/db/code-migrations/18-events-profile-id-index.ts
+++ b/packages/db/code-migrations/18-events-profile-id-index.ts
@@ -35,8 +35,13 @@ import { getIsCluster } from './helpers';
  * Clustered:
  *   ... events_replicated ON CLUSTER '{cluster}' ...
  *
- * The migration detects the pre-applied index and skips re-materializing.
- * Fresh installs have no existing parts, so the mutation is a no-op.
+ * The migration skips re-materializing only when BOTH hold: the index
+ * already exists AND system.mutations records a completed MATERIALIZE for
+ * it. Index presence alone doesn't prove the backfill happened (a crashed
+ * earlier attempt may have run ADD without MATERIALIZE), and if mutation
+ * state can't be read the migration materializes anyway — the mutation is
+ * idempotent, so the failure direction is redundant work, never silently
+ * missing index files. Fresh installs have no existing parts; no-op.
  */
 
 const INDEX_NAME = 'idx_profile_id';
@@ -50,20 +55,39 @@ async function hasIndex(table: string): Promise<boolean> {
   return !!row?.statement.includes(INDEX_NAME);
 }
 
+async function hasCompletedMaterialization(table: string): Promise<boolean> {
+  try {
+    const res = await chMigrationClient.query({
+      query: `SELECT count() AS c FROM system.mutations
+              WHERE database = currentDatabase() AND table = '${table}'
+                AND command LIKE '%MATERIALIZE INDEX%${INDEX_NAME}%'
+                AND is_done = 1`,
+      format: 'JSONEachRow',
+    });
+    const [row] = await res.json<{ c: string | number }>();
+    return Number(row?.c ?? 0) > 0;
+  } catch {
+    // Can't verify (e.g. no grant on system.mutations) — materialize; the
+    // mutation is idempotent and redundant work beats a silent skip.
+    return false;
+  }
+}
+
 export async function up() {
   const isClustered = getIsCluster();
   const table = isClustered ? 'events_replicated' : 'events';
   const onCluster = isClustered ? " ON CLUSTER '{cluster}'" : '';
 
-  // A pre-existing index means the deployment ran ADD + MATERIALIZE manually
-  // ahead of the upgrade (see header) — don't submit a redundant rebuild of
-  // every part's index files.
-  const preApplied = await hasIndex(table);
+  // Skip the backfill only when the index exists AND a completed
+  // MATERIALIZE mutation is on record (a manual pre-apply, see header).
+  // Index presence alone could be a crashed earlier attempt's ADD.
+  const backfilled =
+    (await hasIndex(table)) && (await hasCompletedMaterialization(table));
 
   const sqls = [
     `ALTER TABLE ${table}${onCluster} ADD INDEX IF NOT EXISTS ${INDEX_NAME} profile_id TYPE bloom_filter(0.01) GRANULARITY 1`,
   ];
-  if (!preApplied) {
+  if (!backfilled) {
     sqls.push(
       `ALTER TABLE ${table}${onCluster} MATERIALIZE INDEX ${INDEX_NAME}`,
     );

--- a/packages/db/code-migrations/18-events-profile-id-index.ts
+++ b/packages/db/code-migrations/18-events-profile-id-index.ts
@@ -15,9 +15,14 @@ import { getIsCluster } from './helpers';
  *
  * This migration only ADDs the index — a cheap, metadata-level, idempotent
  * operation that applies to newly written parts. For a deployment whose
- * events table already holds data, existing parts must also be built with
+ * events table already holds data, existing parts must also be built —
+ * targeting the same table this migration alters:
  *
+ * Non-clustered:
  *   ALTER TABLE events MATERIALIZE INDEX idx_profile_id;
+ *
+ * Clustered:
+ *   ALTER TABLE events_replicated ON CLUSTER '{cluster}' MATERIALIZE INDEX idx_profile_id;
  *
  * which is a heavy one-time mutation (it reads the whole profile_id column,
  * though it only writes small .idx files — unlike a projection it does not

--- a/packages/db/code-migrations/18-events-profile-id-index.ts
+++ b/packages/db/code-migrations/18-events-profile-id-index.ts
@@ -1,0 +1,47 @@
+import { runClickhouseMigrationCommands } from '../src/clickhouse/migration';
+import { getIsCluster } from './helpers';
+
+/**
+ * Data-skipping index on events.profile_id.
+ *
+ * The events table sorts by (project_id, toDate(created_at), created_at,
+ * name) and has no index on profile_id, so every profile-scoped query — the
+ * profile panel, per-profile event lists and counts, profile-filtered
+ * charts — scans the project's entire events slice to find one profile's
+ * rows. A bloom_filter index lets both `profile_id = X` and
+ * `profile_id IN (...)` prune to the few granules that can contain that
+ * profile; on our deployment (~1.5B events) profile pages went from
+ * tens-of-seconds full scans to sub-second reads.
+ *
+ * This migration only ADDs the index — a cheap, metadata-level, idempotent
+ * operation that applies to newly written parts. For a deployment whose
+ * events table already holds data, existing parts must also be built with
+ *
+ *   ALTER TABLE events MATERIALIZE INDEX idx_profile_id;
+ *
+ * which is a heavy one-time mutation (it reads the whole profile_id column,
+ * though it only writes small .idx files — unlike a projection it does not
+ * rewrite table data). It is deliberately NOT part of the migration so it
+ * can't re-run on every deploy; run it once, off-peak, and watch
+ * system.mutations until is_done = 1. Fresh installs need nothing.
+ */
+
+export async function up() {
+  const isClustered = getIsCluster();
+  const table = isClustered ? 'events_replicated' : 'events';
+  const onCluster = isClustered ? " ON CLUSTER '{cluster}'" : '';
+
+  await runClickhouseMigrationCommands([
+    `ALTER TABLE ${table}${onCluster} ADD INDEX IF NOT EXISTS idx_profile_id profile_id TYPE bloom_filter(0.01) GRANULARITY 1`,
+  ]);
+}
+
+export async function down() {
+  const isClustered = getIsCluster();
+  const table = isClustered ? 'events_replicated' : 'events';
+  const onCluster = isClustered ? " ON CLUSTER '{cluster}'" : '';
+
+  await runClickhouseMigrationCommands([
+    `ALTER TABLE ${table}${onCluster} DROP INDEX IF EXISTS idx_profile_id`,
+  ]);
+}

--- a/packages/db/code-migrations/18-events-profile-id-index.ts
+++ b/packages/db/code-migrations/18-events-profile-id-index.ts
@@ -81,10 +81,13 @@ async function hasCompletedMaterialization(
     // Clustered: a completed mutation on the connected host doesn't prove
     // the other hosts finished (or even received) theirs — require every
     // host in the cluster to report one.
+    // (hostName(), tcpPort()) rather than hostName() alone: multiple
+    // replicas on one machine share a hostname, and collapsing them could
+    // count an incomplete replica as done.
     const res = await chMigrationClient.query({
       query: `SELECT
-                (SELECT countDistinct(hostName()) FROM clusterAllReplicas('{cluster}', system.one)) AS total,
-                countDistinct(hostName()) AS done
+                (SELECT countDistinct((hostName(), tcpPort())) FROM clusterAllReplicas('{cluster}', system.one)) AS total,
+                countDistinct((hostName(), tcpPort())) AS done
               FROM clusterAllReplicas('{cluster}', system.mutations)
               WHERE database = currentDatabase() AND table = '${table}'
                 AND ${matchExpr}`,

--- a/packages/db/code-migrations/18-events-profile-id-index.ts
+++ b/packages/db/code-migrations/18-events-profile-id-index.ts
@@ -46,29 +46,56 @@ import { getIsCluster } from './helpers';
 
 const INDEX_NAME = 'idx_profile_id';
 
+// Token-boundary match so a similarly named index (idx_profile_id_v2) can
+// never satisfy the check — LIKE's % and _ wildcards would.
+const NAME_BOUNDARY = '($|[^A-Za-z0-9_])';
+
 async function hasIndex(table: string): Promise<boolean> {
   const res = await chMigrationClient.query({
     query: `SHOW CREATE TABLE ${table}`,
     format: 'JSONEachRow',
   });
   const [row] = await res.json<{ statement: string }>();
-  return !!row?.statement.includes(INDEX_NAME);
+  return new RegExp(`INDEX ${INDEX_NAME}([^A-Za-z0-9_]|$)`).test(
+    row?.statement ?? '',
+  );
 }
 
-async function hasCompletedMaterialization(table: string): Promise<boolean> {
+async function hasCompletedMaterialization(
+  table: string,
+  isClustered: boolean,
+): Promise<boolean> {
+  const matchExpr = `match(command, 'MATERIALIZE INDEX ${INDEX_NAME}${NAME_BOUNDARY}') AND is_done = 1`;
   try {
+    if (!isClustered) {
+      const res = await chMigrationClient.query({
+        query: `SELECT count() AS c FROM system.mutations
+                WHERE database = currentDatabase() AND table = '${table}'
+                  AND ${matchExpr}`,
+        format: 'JSONEachRow',
+      });
+      const [row] = await res.json<{ c: string | number }>();
+      return Number(row?.c ?? 0) > 0;
+    }
+
+    // Clustered: a completed mutation on the connected host doesn't prove
+    // the other hosts finished (or even received) theirs — require every
+    // host in the cluster to report one.
     const res = await chMigrationClient.query({
-      query: `SELECT count() AS c FROM system.mutations
+      query: `SELECT
+                (SELECT countDistinct(hostName()) FROM clusterAllReplicas('{cluster}', system.one)) AS total,
+                countDistinct(hostName()) AS done
+              FROM clusterAllReplicas('{cluster}', system.mutations)
               WHERE database = currentDatabase() AND table = '${table}'
-                AND command LIKE '%MATERIALIZE INDEX%${INDEX_NAME}%'
-                AND is_done = 1`,
+                AND ${matchExpr}`,
       format: 'JSONEachRow',
     });
-    const [row] = await res.json<{ c: string | number }>();
-    return Number(row?.c ?? 0) > 0;
+    const [row] = await res.json<{ total: string | number; done: string | number }>();
+    return Number(row?.total ?? 0) > 0 && Number(row?.done ?? 0) >= Number(row?.total ?? 0);
   } catch {
-    // Can't verify (e.g. no grant on system.mutations) — materialize; the
-    // mutation is idempotent and redundant work beats a silent skip.
+    // Can't verify (e.g. no grant on system.mutations / cluster functions) —
+    // materialize; the mutation is idempotent and redundant work beats a
+    // silent skip.
     return false;
   }
 }
@@ -82,7 +109,8 @@ export async function up() {
   // MATERIALIZE mutation is on record (a manual pre-apply, see header).
   // Index presence alone could be a crashed earlier attempt's ADD.
   const backfilled =
-    (await hasIndex(table)) && (await hasCompletedMaterialization(table));
+    (await hasIndex(table)) &&
+    (await hasCompletedMaterialization(table, isClustered));
 
   const sqls = [
     `ALTER TABLE ${table}${onCluster} ADD INDEX IF NOT EXISTS ${INDEX_NAME} profile_id TYPE bloom_filter(0.01) GRANULARITY 1`,


### PR DESCRIPTION
## Problem

The events table sorts by `(project_id, toDate(created_at), created_at, name)` and has **no index on `profile_id`**. Every profile-scoped query — the profile panel, per-profile event lists and counts, profile-filtered charts — scans the project's entire events slice to find one profile's rows. On our deployment (~1.5B events in one project) profile pages took tens of seconds of full scanning per widget.

## Fix

Migration 18: a `bloom_filter(0.01)` data-skipping index on `profile_id`, GRANULARITY 1. It prunes both `profile_id = X` and `profile_id IN (...)` to the few granules that can contain the profile. After adding and materializing it, our profile pages went sub-second.

## Backfill of existing parts

`ADD INDEX` is metadata-only, so the migration also submits `MATERIALIZE INDEX` **by default** — migrations are self-contained for self-hosters. The mutation is asynchronous (the migration doesn't block on it), idempotent, reads only the `profile_id` column, and writes small `.idx` files without rewriting table data; fresh installs no-op. Progress is visible in `system.mutations`.

**Escape hatch for very large deployments** that want to control *when* the backfill runs: apply `ADD INDEX` + `MATERIALIZE INDEX` manually before upgrading (off-peak; the exact statements for non-clustered and clustered are in the migration header). The migration detects the pre-applied index via `SHOW CREATE TABLE` and skips the redundant rebuild. Both paths were validated against a live ClickHouse (detection flips correctly; the mutation completes `is_done = 1`). Might be worth a line in the self-hosting changelog whenever this ships in a release — happy to draft it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved index setup reliability by verifying that index materialization completed successfully.
  * Automatically retries materialization when the index is missing, incomplete, or completion status cannot be confirmed.
  * In clustered deployments, confirms completion across all hosts before skipping setup.
  * Improved detection of existing indexes to prevent setup from being incorrectly skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->