### PR TITLE
perf(ch): projection for the property-key autocomplete + value cap (migration 19)

### DIFF
--- a/apps/public/content/docs/self-hosting/environment-variables.mdx
+++ b/apps/public/content/docs/self-hosting/environment-variables.mdx
@@ -999,6 +999,19 @@ Batch size for data import operations.
 IMPORT_BATCH_SIZE=10000
 ```
 
+### EVENT_PROPERTY_VALUE_LIMIT
+
+**Type**: `number` (positive integer)  
+**Required**: No  
+**Default**: `500`
+
+Cap on distinct values returned per event property to the filter autocomplete. High-cardinality keys (ids, urls, tokens) can hold millions of distinct values; the most recent ones win. Invalid values keep the default.
+
+**Example**:
+```bash
+EVENT_PROPERTY_VALUE_LIMIT=1000
+```
+
 ### IP_HEADER_ORDER
 
 **Type**: `string` (comma-separated)  

--- a/apps/public/content/docs/self-hosting/environment-variables.mdx
+++ b/apps/public/content/docs/self-hosting/environment-variables.mdx
@@ -999,7 +999,7 @@ Batch size for data import operations.
 IMPORT_BATCH_SIZE=10000
 ```
 
-### EVENT_PROPERTY_VALUE_LIMIT
+### EVENT_PROPERTY_VALUE_AUTOCOMPLETE_LIMIT
 
 **Type**: `number` (positive integer)  
 **Required**: No  
@@ -1009,7 +1009,7 @@ Cap on distinct values returned per event property to the filter autocomplete. H
 
 **Example**:
 ```bash
-EVENT_PROPERTY_VALUE_LIMIT=1000
+EVENT_PROPERTY_VALUE_AUTOCOMPLETE_LIMIT=1000
 ```
 
 ### IP_HEADER_ORDER

--- a/packages/db/code-migrations/19-event-property-values-projections.ts
+++ b/packages/db/code-migrations/19-event-property-values-projections.ts
@@ -110,8 +110,11 @@ async function materializedProjections(
     const source = isClustered
       ? `clusterAllReplicas('{cluster}', system.mutations)`
       : 'system.mutations';
+    // (hostName(), tcpPort()) rather than hostName() alone: multiple
+    // replicas on one machine share a hostname, and collapsing them could
+    // count an incomplete replica as done.
     const res = await chMigrationClient.query({
-      query: `SELECT hostName() AS host, command FROM ${source}
+      query: `SELECT concat(hostName(), ':', toString(tcpPort())) AS host, command FROM ${source}
               WHERE database = currentDatabase() AND table = '${storage}'
                 AND command LIKE '%MATERIALIZE PROJECTION%'
                 AND is_done = 1`,
@@ -122,7 +125,7 @@ async function materializedProjections(
     let totalHosts = 1;
     if (isClustered) {
       const hostsRes = await chMigrationClient.query({
-        query: `SELECT countDistinct(hostName()) AS c FROM clusterAllReplicas('{cluster}', system.one)`,
+        query: `SELECT countDistinct((hostName(), tcpPort())) AS c FROM clusterAllReplicas('{cluster}', system.one)`,
         format: 'JSONEachRow',
       });
       const [hostsRow] = await hostsRes.json<{ c: string | number }>();
@@ -181,9 +184,13 @@ export async function down() {
   const tbl = `\`${storage}\``;
   const onCluster = isClustered ? " ON CLUSTER '{cluster}'" : '';
 
-  await runClickhouseMigrationCommands(
-    PROJECTIONS.map(
+  await runClickhouseMigrationCommands([
+    ...PROJECTIONS.map(
       (p) => `ALTER TABLE ${tbl}${onCluster} DROP PROJECTION IF EXISTS ${p.name}`,
     ),
-  );
+    // Restore the engine default ('throw'). Safe here because this down()
+    // just dropped the only projections on the table; if you've added your
+    // own projections to it, keep 'rebuild'.
+    `ALTER TABLE ${tbl}${onCluster} MODIFY SETTING deduplicate_merge_projection_mode = 'throw'`,
+  ]);
 }

--- a/packages/db/code-migrations/19-event-property-values-projections.ts
+++ b/packages/db/code-migrations/19-event-property-values-projections.ts
@@ -1,0 +1,103 @@
+import { TABLE_NAMES } from '../src/clickhouse/client';
+import {
+  chMigrationClient,
+  runClickhouseMigrationCommands,
+} from '../src/clickhouse/migration';
+import { getIsCluster } from './helpers';
+
+/**
+ * Aggregating projections for the property autocomplete dropdowns.
+ *
+ * The property-key and property-value pickers read
+ * event_property_values_mv, which is ORDER BY
+ * (project_id, name, property_key, property_value). Neither picker query
+ * can seek on that key: the project-wide key list has no `name` filter, and
+ * the value lookup filters property_key, which sits behind `name`. Both
+ * therefore scan the project's whole MV slice — on our deployment, 1.57B
+ * rows read to return ~6.4K distinct keys.
+ *
+ * Two aggregating projections give those queries a key they can seek:
+ *
+ *   epv_keys   -> (project_id, property_key)                 max(created_at)
+ *   epv_values -> (project_id, property_key, property_value) max(created_at)
+ *
+ * The optimizer rewrites the picker queries onto them transparently — no
+ * application change, reads drop to a few thousand rows.
+ *
+ * Notes:
+ *  - The projections live on the MV's STORAGE table: the implicit
+ *    `.inner_id.<uuid>` table on a single node, `<mv>_replicated` when
+ *    clustered.
+ *  - AggregatingMergeTree refuses ADD PROJECTION while
+ *    deduplicate_merge_projection_mode is 'throw' (the default);
+ *    'rebuild' keeps projections correct across dedup merges.
+ *  - This migration only ADDs the projections, which populate for newly
+ *    written parts (and for old parts as background merges rewrite them).
+ *    Queries stay correct over mixed parts — ClickHouse uses the projection
+ *    where it exists and the base table elsewhere — so coverage improves
+ *    over time on its own. To backfill existing parts immediately, run the
+ *    heavy one-time mutations manually (they rewrite projection data for
+ *    every part; off-peak, watch system.mutations until is_done = 1):
+ *
+ *      ALTER TABLE <storage> MATERIALIZE PROJECTION epv_keys;
+ *      ALTER TABLE <storage> MATERIALIZE PROJECTION epv_values;
+ */
+
+const MV = TABLE_NAMES.event_property_values_mv;
+
+const PROJECTIONS = [
+  {
+    name: 'epv_keys',
+    def: 'SELECT project_id, property_key, max(created_at) AS created_at GROUP BY project_id, property_key',
+  },
+  {
+    name: 'epv_values',
+    def: 'SELECT project_id, property_key, property_value, max(created_at) AS created_at GROUP BY project_id, property_key, property_value',
+  },
+];
+
+// The projection lives on the MV's storage table: the implicit inner table
+// (`.inner_id.<uuid>`) on a single node, or `<mv>_replicated` when clustered.
+async function resolveStorageTable(isClustered: boolean): Promise<string> {
+  if (isClustered) {
+    return `${MV}_replicated`;
+  }
+  const res = await chMigrationClient.query({
+    query: `SELECT concat('.inner_id.', toString(uuid)) AS t
+            FROM system.tables WHERE database = currentDatabase() AND name = '${MV}'`,
+    format: 'JSONEachRow',
+  });
+  const rows = await res.json<{ t: string }>();
+  if (!rows[0]?.t) {
+    throw new Error(`${MV}: inner storage table not found`);
+  }
+  return rows[0].t;
+}
+
+export async function up() {
+  const isClustered = getIsCluster();
+  const storage = await resolveStorageTable(isClustered);
+  const tbl = `\`${storage}\``;
+  const onCluster = isClustered ? " ON CLUSTER '{cluster}'" : '';
+
+  await runClickhouseMigrationCommands([
+    `ALTER TABLE ${tbl}${onCluster} MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'`,
+    ...PROJECTIONS.map(
+      (p) =>
+        `ALTER TABLE ${tbl}${onCluster} ADD PROJECTION IF NOT EXISTS ${p.name} (${p.def})`,
+    ),
+  ]);
+}
+
+export async function down() {
+  const isClustered = getIsCluster();
+  const storage = await resolveStorageTable(isClustered);
+  const tbl = `\`${storage}\``;
+  const onCluster = isClustered ? " ON CLUSTER '{cluster}'" : '';
+
+  await runClickhouseMigrationCommands(
+    PROJECTIONS.map(
+      (p) => `ALTER TABLE ${tbl}${onCluster} DROP PROJECTION IF EXISTS ${p.name}`,
+    ),
+  );
+}

--- a/packages/db/code-migrations/19-event-property-values-projections.ts
+++ b/packages/db/code-migrations/19-event-property-values-projections.ts
@@ -6,48 +6,73 @@ import {
 import { getIsCluster } from './helpers';
 
 /**
- * Aggregating projections for the property autocomplete dropdowns.
+ * Aggregating projection for the property-key autocomplete dropdown.
  *
- * The property-key and property-value pickers read
- * event_property_values_mv, which is ORDER BY
- * (project_id, name, property_key, property_value). Neither picker query
- * can seek on that key: the project-wide key list has no `name` filter, and
- * the value lookup filters property_key, which sits behind `name`. Both
- * therefore scan the project's whole MV slice — on our deployment, 1.57B
- * rows read to return ~6.4K distinct keys.
+ * The key picker reads event_property_values_mv, which is ORDER BY
+ * (project_id, name, property_key, property_value). Two shapes exist:
  *
- * Two aggregating projections give those queries a key they can seek:
+ *   no event selected  -> WHERE project_id ... GROUP BY property_key
+ *   event selected     -> WHERE project_id AND name ... GROUP BY property_key
  *
- *   epv_keys   -> (project_id, property_key)                 max(created_at)
- *   epv_values -> (project_id, property_key, property_value) max(created_at)
+ * Neither is cheap on that sort key. The first can seek only to project_id
+ * and must then aggregate the project's whole slice (on our deployment,
+ * 1.57B rows to return ~6.4K distinct keys). The second prunes to the
+ * event's slice, but that slice still holds every key AND every value for
+ * the event — measured 120M rows read on average, p95 15.9s.
  *
- * The optimizer rewrites the picker queries onto them transparently — no
- * application change, reads drop to a few thousand rows.
+ * One aggregating projection answers both:
+ *
+ *   epv_keys -> (project_id, name, property_key), max(created_at)
+ *
+ * With an event selected, (project_id, name) is a seekable prefix, so the
+ * read prunes to that event's keys. With no event, the query's GROUP BY is
+ * a subset of the projection's, so the optimizer still substitutes it and
+ * aggregates over the (tiny) projection instead of the table — verified
+ * with EXPLAIN for both shapes. The optimizer rewrites the existing picker
+ * queries transparently; no application change.
+ *
+ * Sizing: the projection is one row per (project, event, key) — 30,212 rows
+ * against a 1.637B-row MV on our deployment. Including `name` costs ~3.4x
+ * the rows of a (project_id, property_key)-only projection while covering
+ * the event-selected shape that one cannot serve at all (a projection is
+ * only substitutable when it contains EVERY column the query references,
+ * so any filter on `name` disqualifies a projection that lacks it).
+ *
+ * NOT included: a (project_id, property_key, property_value) projection for
+ * the value picker. Its grain is 95.4% of the MV's row count — a near-
+ * complete second copy of the table — and it can only serve value lookups
+ * with no event selected, since the event-selected shape already gets a
+ * full three-column prefix seek on the base table. Measured on our
+ * deployment: 2 such queries in 30 days.
  *
  * Notes:
- *  - The projections live on the MV's STORAGE table: the implicit
+ *  - The projection lives on the MV's STORAGE table: the implicit
  *    `.inner_id.<uuid>` table on a single node, `<mv>_replicated` when
  *    clustered.
  *  - AggregatingMergeTree refuses ADD PROJECTION while
  *    deduplicate_merge_projection_mode is 'throw' (the default);
  *    'rebuild' keeps projections correct across dedup merges.
- *  - The migration ADDs the projections and submits MATERIALIZE PROJECTION
- *    for existing parts by default. The mutations are asynchronous (the
- *    migration doesn't block on them) and idempotent; queries stay correct
- *    over mixed parts while they run — ClickHouse uses the projection where
- *    it exists and the base table elsewhere. Fresh installs no-op. Progress:
+ *  - The migration ADDs the projection and submits MATERIALIZE PROJECTION
+ *    for existing parts by default. The mutation is asynchronous (the
+ *    migration doesn't block on it) and idempotent; queries stay correct
+ *    over mixed parts while it runs — ClickHouse reads the projection from
+ *    parts that have it and the base table from those that don't (observed
+ *    in EXPLAIN as two read nodes). Fresh installs no-op. Progress:
  *
  *      SELECT * FROM system.mutations WHERE command LIKE '%epv_%';
  *
- *  - These mutations rewrite projection data for every part, so deployments
+ *  - The mutation rewrites projection data for every part, so deployments
  *    with a very large MV that want to control WHEN the backfill runs can
  *    apply the setting + ADD PROJECTION + MATERIALIZE PROJECTION statements
  *    manually before upgrading (off-peak), against the storage table. The
- *    migration skips re-materializing a projection only when it already
+ *    migration skips re-materializing only when the projection already
  *    exists AND system.mutations records a completed MATERIALIZE for it —
  *    presence alone could be a crashed earlier attempt's ADD, and if
  *    mutation state can't be read the migration materializes anyway
- *    (idempotent; redundant work beats a silent skip).
+ *    (idempotent; redundant work beats a silent skip). Note that because
+ *    ADD uses IF NOT EXISTS, a manual pre-apply must use the definition
+ *    below verbatim — a same-named projection with a different grain would
+ *    be kept as-is.
  */
 
 const MV = TABLE_NAMES.event_property_values_mv;
@@ -55,11 +80,7 @@ const MV = TABLE_NAMES.event_property_values_mv;
 const PROJECTIONS = [
   {
     name: 'epv_keys',
-    def: 'SELECT project_id, property_key, max(created_at) AS created_at GROUP BY project_id, property_key',
-  },
-  {
-    name: 'epv_values',
-    def: 'SELECT project_id, property_key, property_value, max(created_at) AS created_at GROUP BY project_id, property_key, property_value',
+    def: 'SELECT project_id, name, property_key, max(created_at) AS created_at GROUP BY project_id, name, property_key',
   },
 ];
 

--- a/packages/db/code-migrations/19-event-property-values-projections.ts
+++ b/packages/db/code-migrations/19-event-property-values-projections.ts
@@ -31,16 +31,20 @@ import { getIsCluster } from './helpers';
  *  - AggregatingMergeTree refuses ADD PROJECTION while
  *    deduplicate_merge_projection_mode is 'throw' (the default);
  *    'rebuild' keeps projections correct across dedup merges.
- *  - This migration only ADDs the projections, which populate for newly
- *    written parts (and for old parts as background merges rewrite them).
- *    Queries stay correct over mixed parts — ClickHouse uses the projection
- *    where it exists and the base table elsewhere — so coverage improves
- *    over time on its own. To backfill existing parts immediately, run the
- *    heavy one-time mutations manually (they rewrite projection data for
- *    every part; off-peak, watch system.mutations until is_done = 1):
+ *  - The migration ADDs the projections and submits MATERIALIZE PROJECTION
+ *    for existing parts by default. The mutations are asynchronous (the
+ *    migration doesn't block on them) and idempotent; queries stay correct
+ *    over mixed parts while they run — ClickHouse uses the projection where
+ *    it exists and the base table elsewhere. Fresh installs no-op. Progress:
  *
- *      ALTER TABLE <storage> MATERIALIZE PROJECTION epv_keys;
- *      ALTER TABLE <storage> MATERIALIZE PROJECTION epv_values;
+ *      SELECT * FROM system.mutations WHERE command LIKE '%epv_%';
+ *
+ *  - These mutations rewrite projection data for every part, so deployments
+ *    with a very large MV that want to control WHEN the backfill runs can
+ *    apply the setting + ADD PROJECTION + MATERIALIZE PROJECTION statements
+ *    manually before upgrading (off-peak), against the storage table. The
+ *    migration detects pre-applied projections via SHOW CREATE TABLE and
+ *    skips re-materializing them.
  */
 
 const MV = TABLE_NAMES.event_property_values_mv;
@@ -74,17 +78,38 @@ async function resolveStorageTable(isClustered: boolean): Promise<string> {
   return rows[0].t;
 }
 
+async function preAppliedProjections(storage: string): Promise<Set<string>> {
+  const res = await chMigrationClient.query({
+    query: `SHOW CREATE TABLE \`${storage}\``,
+    format: 'JSONEachRow',
+  });
+  const [row] = await res.json<{ statement: string }>();
+  return new Set(
+    PROJECTIONS.filter((p) =>
+      row?.statement.includes(`PROJECTION ${p.name}`),
+    ).map((p) => p.name),
+  );
+}
+
 export async function up() {
   const isClustered = getIsCluster();
   const storage = await resolveStorageTable(isClustered);
   const tbl = `\`${storage}\``;
   const onCluster = isClustered ? " ON CLUSTER '{cluster}'" : '';
 
+  // Pre-existing projections mean the deployment applied ADD + MATERIALIZE
+  // manually ahead of the upgrade (see header) — don't rewrite every part's
+  // projection data again.
+  const preApplied = await preAppliedProjections(storage);
+
   await runClickhouseMigrationCommands([
     `ALTER TABLE ${tbl}${onCluster} MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'`,
     ...PROJECTIONS.map(
       (p) =>
         `ALTER TABLE ${tbl}${onCluster} ADD PROJECTION IF NOT EXISTS ${p.name} (${p.def})`,
+    ),
+    ...PROJECTIONS.filter((p) => !preApplied.has(p.name)).map(
+      (p) => `ALTER TABLE ${tbl}${onCluster} MATERIALIZE PROJECTION ${p.name}`,
     ),
   ]);
 }

--- a/packages/db/code-migrations/19-event-property-values-projections.ts
+++ b/packages/db/code-migrations/19-event-property-values-projections.ts
@@ -81,6 +81,11 @@ async function resolveStorageTable(isClustered: boolean): Promise<string> {
   return rows[0].t;
 }
 
+// Token-boundary match so a similarly named projection (epv_keys_v2) can
+// never satisfy the checks — substring/LIKE matching would.
+const nameBoundary = (name: string) =>
+  new RegExp(`${name}([^A-Za-z0-9_]|$)`);
+
 async function existingProjections(storage: string): Promise<Set<string>> {
   const res = await chMigrationClient.query({
     query: `SHOW CREATE TABLE \`${storage}\``,
@@ -89,29 +94,57 @@ async function existingProjections(storage: string): Promise<Set<string>> {
   const [row] = await res.json<{ statement: string }>();
   return new Set(
     PROJECTIONS.filter((p) =>
-      row?.statement.includes(`PROJECTION ${p.name}`),
+      nameBoundary(`PROJECTION ${p.name}`).test(row?.statement ?? ''),
     ).map((p) => p.name),
   );
 }
 
-async function materializedProjections(storage: string): Promise<Set<string>> {
+async function materializedProjections(
+  storage: string,
+  isClustered: boolean,
+): Promise<Set<string>> {
   try {
+    // Clustered: a completed mutation on the connected host doesn't prove
+    // the other hosts finished (or even received) theirs — require every
+    // host in the cluster to report one, per projection.
+    const source = isClustered
+      ? `clusterAllReplicas('{cluster}', system.mutations)`
+      : 'system.mutations';
     const res = await chMigrationClient.query({
-      query: `SELECT command FROM system.mutations
+      query: `SELECT hostName() AS host, command FROM ${source}
               WHERE database = currentDatabase() AND table = '${storage}'
                 AND command LIKE '%MATERIALIZE PROJECTION%'
                 AND is_done = 1`,
       format: 'JSONEachRow',
     });
-    const rows = await res.json<{ command: string }>();
+    const rows = await res.json<{ host: string; command: string }>();
+
+    let totalHosts = 1;
+    if (isClustered) {
+      const hostsRes = await chMigrationClient.query({
+        query: `SELECT countDistinct(hostName()) AS c FROM clusterAllReplicas('{cluster}', system.one)`,
+        format: 'JSONEachRow',
+      });
+      const [hostsRow] = await hostsRes.json<{ c: string | number }>();
+      totalHosts = Number(hostsRow?.c ?? 0);
+      if (totalHosts === 0) {
+        return new Set();
+      }
+    }
+
     return new Set(
-      PROJECTIONS.filter((p) =>
-        rows.some((r) => r.command.includes(p.name)),
-      ).map((p) => p.name),
+      PROJECTIONS.filter((p) => {
+        const matcher = nameBoundary(`MATERIALIZE PROJECTION ${p.name}`);
+        const hosts = new Set(
+          rows.filter((r) => matcher.test(r.command)).map((r) => r.host),
+        );
+        return hosts.size >= totalHosts;
+      }).map((p) => p.name),
     );
   } catch {
-    // Can't verify (e.g. no grant on system.mutations) — materialize; the
-    // mutations are idempotent and redundant work beats a silent skip.
+    // Can't verify (e.g. no grant on system.mutations / cluster functions) —
+    // materialize; the mutations are idempotent and redundant work beats a
+    // silent skip.
     return new Set();
   }
 }
@@ -126,7 +159,7 @@ export async function up() {
   // MATERIALIZE mutation is on record (a manual pre-apply, see header) —
   // presence alone could be a crashed earlier attempt's ADD.
   const existing = await existingProjections(storage);
-  const materialized = await materializedProjections(storage);
+  const materialized = await materializedProjections(storage, isClustered);
 
   await runClickhouseMigrationCommands([
     `ALTER TABLE ${tbl}${onCluster} MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'`,

--- a/packages/db/code-migrations/19-event-property-values-projections.ts
+++ b/packages/db/code-migrations/19-event-property-values-projections.ts
@@ -43,8 +43,11 @@ import { getIsCluster } from './helpers';
  *    with a very large MV that want to control WHEN the backfill runs can
  *    apply the setting + ADD PROJECTION + MATERIALIZE PROJECTION statements
  *    manually before upgrading (off-peak), against the storage table. The
- *    migration detects pre-applied projections via SHOW CREATE TABLE and
- *    skips re-materializing them.
+ *    migration skips re-materializing a projection only when it already
+ *    exists AND system.mutations records a completed MATERIALIZE for it —
+ *    presence alone could be a crashed earlier attempt's ADD, and if
+ *    mutation state can't be read the migration materializes anyway
+ *    (idempotent; redundant work beats a silent skip).
  */
 
 const MV = TABLE_NAMES.event_property_values_mv;
@@ -78,7 +81,7 @@ async function resolveStorageTable(isClustered: boolean): Promise<string> {
   return rows[0].t;
 }
 
-async function preAppliedProjections(storage: string): Promise<Set<string>> {
+async function existingProjections(storage: string): Promise<Set<string>> {
   const res = await chMigrationClient.query({
     query: `SHOW CREATE TABLE \`${storage}\``,
     format: 'JSONEachRow',
@@ -91,16 +94,39 @@ async function preAppliedProjections(storage: string): Promise<Set<string>> {
   );
 }
 
+async function materializedProjections(storage: string): Promise<Set<string>> {
+  try {
+    const res = await chMigrationClient.query({
+      query: `SELECT command FROM system.mutations
+              WHERE database = currentDatabase() AND table = '${storage}'
+                AND command LIKE '%MATERIALIZE PROJECTION%'
+                AND is_done = 1`,
+      format: 'JSONEachRow',
+    });
+    const rows = await res.json<{ command: string }>();
+    return new Set(
+      PROJECTIONS.filter((p) =>
+        rows.some((r) => r.command.includes(p.name)),
+      ).map((p) => p.name),
+    );
+  } catch {
+    // Can't verify (e.g. no grant on system.mutations) — materialize; the
+    // mutations are idempotent and redundant work beats a silent skip.
+    return new Set();
+  }
+}
+
 export async function up() {
   const isClustered = getIsCluster();
   const storage = await resolveStorageTable(isClustered);
   const tbl = `\`${storage}\``;
   const onCluster = isClustered ? " ON CLUSTER '{cluster}'" : '';
 
-  // Pre-existing projections mean the deployment applied ADD + MATERIALIZE
-  // manually ahead of the upgrade (see header) — don't rewrite every part's
-  // projection data again.
-  const preApplied = await preAppliedProjections(storage);
+  // Skip a projection's backfill only when it exists AND a completed
+  // MATERIALIZE mutation is on record (a manual pre-apply, see header) —
+  // presence alone could be a crashed earlier attempt's ADD.
+  const existing = await existingProjections(storage);
+  const materialized = await materializedProjections(storage);
 
   await runClickhouseMigrationCommands([
     `ALTER TABLE ${tbl}${onCluster} MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'`,
@@ -108,7 +134,9 @@ export async function up() {
       (p) =>
         `ALTER TABLE ${tbl}${onCluster} ADD PROJECTION IF NOT EXISTS ${p.name} (${p.def})`,
     ),
-    ...PROJECTIONS.filter((p) => !preApplied.has(p.name)).map(
+    ...PROJECTIONS.filter(
+      (p) => !(existing.has(p.name) && materialized.has(p.name)),
+    ).map(
       (p) => `ALTER TABLE ${tbl}${onCluster} MATERIALIZE PROJECTION ${p.name}`,
     ),
   ]);

--- a/packages/trpc/src/routers/chart.ts
+++ b/packages/trpc/src/routers/chart.ts
@@ -64,18 +64,20 @@ const EVENT_PROPERTY_KEY_LIMIT = 50_000;
  * autocomplete. High-cardinality keys (ids, urls, session tokens) can hold
  * millions of distinct values — returning them all is useless for a picker
  * and heavy for ClickHouse and the browser alike. Most recent values win.
- * Env-tunable via EVENT_PROPERTY_VALUE_LIMIT (positive integer; invalid
- * values keep the default).
+ * Env-tunable via EVENT_PROPERTY_VALUE_AUTOCOMPLETE_LIMIT (positive
+ * integer; invalid values keep the default).
  */
-const EVENT_PROPERTY_VALUE_LIMIT_RAW = process.env.EVENT_PROPERTY_VALUE_LIMIT;
-const EVENT_PROPERTY_VALUE_LIMIT_PARSED =
-  EVENT_PROPERTY_VALUE_LIMIT_RAW && /^\d+$/.test(EVENT_PROPERTY_VALUE_LIMIT_RAW)
-    ? Number(EVENT_PROPERTY_VALUE_LIMIT_RAW)
+const EVENT_PROPERTY_VALUE_AUTOCOMPLETE_LIMIT_RAW =
+  process.env.EVENT_PROPERTY_VALUE_AUTOCOMPLETE_LIMIT;
+const EVENT_PROPERTY_VALUE_AUTOCOMPLETE_LIMIT_PARSED =
+  EVENT_PROPERTY_VALUE_AUTOCOMPLETE_LIMIT_RAW &&
+  /^\d+$/.test(EVENT_PROPERTY_VALUE_AUTOCOMPLETE_LIMIT_RAW)
+    ? Number(EVENT_PROPERTY_VALUE_AUTOCOMPLETE_LIMIT_RAW)
     : Number.NaN;
-const EVENT_PROPERTY_VALUE_LIMIT =
-  Number.isSafeInteger(EVENT_PROPERTY_VALUE_LIMIT_PARSED) &&
-  EVENT_PROPERTY_VALUE_LIMIT_PARSED > 0
-    ? EVENT_PROPERTY_VALUE_LIMIT_PARSED
+const EVENT_PROPERTY_VALUE_AUTOCOMPLETE_LIMIT =
+  Number.isSafeInteger(EVENT_PROPERTY_VALUE_AUTOCOMPLETE_LIMIT_PARSED) &&
+  EVENT_PROPERTY_VALUE_AUTOCOMPLETE_LIMIT_PARSED > 0
+    ? EVENT_PROPERTY_VALUE_AUTOCOMPLETE_LIMIT_PARSED
     : 500;
 
 const chartProcedure = publicProcedure.use(
@@ -367,7 +369,7 @@ export const chartRouter = createTRPCRouter({
           // rationale as the key picker above.
           .orderBy('created_at', 'DESC')
           .orderBy('property_value', 'ASC')
-          .limit(EVENT_PROPERTY_VALUE_LIMIT);
+          .limit(EVENT_PROPERTY_VALUE_AUTOCOMPLETE_LIMIT);
 
         if (event && event !== '*') {
           query.where('name', '=', event);

--- a/packages/trpc/src/routers/chart.ts
+++ b/packages/trpc/src/routers/chart.ts
@@ -60,12 +60,23 @@ const cacher = cacheMiddleware(60);
 const EVENT_PROPERTY_KEY_LIMIT = 50_000;
 
 /**
- * Cap on distinct values returned per property to the filter autocomplete.
- * High-cardinality keys (ids, urls, session tokens) can hold millions of
- * distinct values — returning them all is useless for a picker and heavy
- * for ClickHouse and the browser alike. Most recent values win.
+ * Cap on distinct values returned per event property to the filter
+ * autocomplete. High-cardinality keys (ids, urls, session tokens) can hold
+ * millions of distinct values — returning them all is useless for a picker
+ * and heavy for ClickHouse and the browser alike. Most recent values win.
+ * Env-tunable via EVENT_PROPERTY_VALUE_LIMIT (positive integer; invalid
+ * values keep the default).
  */
-const PROPERTY_VALUE_LIMIT = 500;
+const EVENT_PROPERTY_VALUE_LIMIT_RAW = process.env.EVENT_PROPERTY_VALUE_LIMIT;
+const EVENT_PROPERTY_VALUE_LIMIT_PARSED =
+  EVENT_PROPERTY_VALUE_LIMIT_RAW && /^\d+$/.test(EVENT_PROPERTY_VALUE_LIMIT_RAW)
+    ? Number(EVENT_PROPERTY_VALUE_LIMIT_RAW)
+    : Number.NaN;
+const EVENT_PROPERTY_VALUE_LIMIT =
+  Number.isSafeInteger(EVENT_PROPERTY_VALUE_LIMIT_PARSED) &&
+  EVENT_PROPERTY_VALUE_LIMIT_PARSED > 0
+    ? EVENT_PROPERTY_VALUE_LIMIT_PARSED
+    : 500;
 
 const chartProcedure = publicProcedure.use(
   async ({ ctx, next, getRawInput }) => {
@@ -356,7 +367,7 @@ export const chartRouter = createTRPCRouter({
           // rationale as the key picker above.
           .orderBy('created_at', 'DESC')
           .orderBy('property_value', 'ASC')
-          .limit(PROPERTY_VALUE_LIMIT);
+          .limit(EVENT_PROPERTY_VALUE_LIMIT);
 
         if (event && event !== '*') {
           query.where('name', '=', event);

--- a/packages/trpc/src/routers/chart.ts
+++ b/packages/trpc/src/routers/chart.ts
@@ -59,6 +59,14 @@ const cacher = cacheMiddleware(60);
  */
 const EVENT_PROPERTY_KEY_LIMIT = 50_000;
 
+/**
+ * Cap on distinct values returned per property to the filter autocomplete.
+ * High-cardinality keys (ids, urls, session tokens) can hold millions of
+ * distinct values — returning them all is useless for a picker and heavy
+ * for ClickHouse and the browser alike. Most recent values win.
+ */
+const PROPERTY_VALUE_LIMIT = 500;
+
 const chartProcedure = publicProcedure.use(
   async ({ ctx, next, getRawInput }) => {
     const rawInput = (await getRawInput()) as {
@@ -344,7 +352,11 @@ export const chartRouter = createTRPCRouter({
           .where('project_id', '=', projectId)
           .where('property_key', '=', property.replace(/^properties\./, ''))
           .groupBy(['property_value'])
-          .orderBy('created_at', 'DESC');
+          // Recency + key tie-break for a stable list under the cap — same
+          // rationale as the key picker above.
+          .orderBy('created_at', 'DESC')
+          .orderBy('property_value', 'ASC')
+          .limit(PROPERTY_VALUE_LIMIT);
 
         if (event && event !== '*') {
           query.where('name', '=', event);


### PR DESCRIPTION
## Problem

The property-key autocomplete reads `event_property_values_mv`, sorted `(project_id, name, property_key, property_value)`. The picker has two shapes and **neither is cheap** on that key:

| shape | today |
|---|---|
| no event selected — `WHERE project_id … GROUP BY property_key` | can only seek to `project_id`, then aggregates the project's whole slice — **1.57B rows read to return ~6.4K keys** on our deployment |
| event selected — `WHERE project_id AND name … GROUP BY property_key` | prunes to the event's slice, but that slice still holds every key **and every value** for the event — **120M rows read on average, p95 15.9s** |

## Fix

One aggregating projection: **`epv_keys → (project_id, name, property_key), max(created_at)`**.

- **Event selected:** `(project_id, name)` is a seekable prefix → prunes to that event's keys.
- **No event:** the query's `GROUP BY` is a subset of the projection's, so the optimizer still substitutes it and aggregates over the projection instead of the table.

Both verified with `EXPLAIN` using the verbatim picker SQL from `chart.ts` (both report `ReadFromMergeTree (epv_keys)`). No application change — the optimizer rewrites the existing queries.

**Sizing:** one row per (project, event, key) — **30,212 rows against a 1.637B-row MV** here. Including `name` costs ~3.4× a `(project_id, property_key)`-only projection while covering the event-selected shape that one cannot serve at all: a projection is only substitutable when it contains *every* column the query references, so any filter on `name` disqualifies a projection lacking it.

## What was dropped (per your review)

`epv_values`, i.e. `(project_id, property_key, property_value)` — agreed, not worth it:

- It can only serve value lookups with **no event selected**. With an event selected the base table already gets a full three-column prefix seek — `EXPLAIN` shows **the same 11 granules** the projection achieved for the no-event case, so there's nothing left to win.
- Its grain is **95.4% of the MV's rows (1.562B of 1.637B)** — a near-complete second copy of the table, rebuilt on every insert and recomputed on dedup merges.
- Measured on our deployment over 30 days: **2 queries** used it, reading **15 rows** each.

Trade-off, stated plainly: those no-event value lookups revert to a full project-slice scan, and `chart.values` has no cache middleware (unlike `properties`). Worth accepting — and no cheap structure fixes it, since 1.56B *is* the true cardinality at `(project, key, value)`; a standalone MV with that sort key would cost the same. If it ever matters, time-bounding the value picker (values seen in the last 30–90 days) is the real fix.

## Also in this PR

**Value-picker cap** — `EVENT_PROPERTY_VALUE_AUTOCOMPLETE_LIMIT` (default 500, documented in the env reference), recency-ordered with a value tie-break so the list is stable under the cap. High-cardinality keys (ids, urls, tokens) can hold millions of distinct values; returning them all is useless for a picker and heavy for ClickHouse and the browser.

**Backfill** — the migration ADDs the projection and submits `MATERIALIZE PROJECTION` by default: asynchronous, idempotent, submitted once via the migration bookkeeping, and queries stay correct over mixed parts while it runs (observed in `EXPLAIN` as two read nodes — projection for covered parts, base table for the rest). Fresh installs no-op. Deployments with a very large MV that want to control *when* the backfill runs can apply the statements manually before upgrading; the migration skips re-materializing only when the projection exists **and** `system.mutations` records a completed `MATERIALIZE` for it (token-boundary matched, and in clustered mode every replica must report it), falling back to materializing whenever that can't be verified.

## Follow-up, not in this PR

`list_event_properties` (API + MCP) selects `DISTINCT property_key, name`, and multi-column `DISTINCT` doesn't match an aggregate projection — verified: the same query written as `GROUP BY property_key, name` does match. A one-line rewrite there would put that path on the projection too; happy to send it separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
