### PR TITLE
feat(alerts): usage-limit and data-health notifications

### DIFF
--- a/apps/api/src/controllers/webhook.controller.ts
+++ b/apps/api/src/controllers/webhook.controller.ts
@@ -317,6 +317,12 @@ async function syncSubscriptionToOrg(
       organization.subscriptionPeriodEventsLimit < subscriptionPeriodEventsLimit
         ? null
         : undefined,
+    // A raised limit re-arms the usage alerts for the new headroom.
+    ...(typeof subscriptionPeriodEventsLimit === 'number' &&
+    typeof organization.subscriptionPeriodEventsLimit === 'number' &&
+    organization.subscriptionPeriodEventsLimit < subscriptionPeriodEventsLimit
+      ? { usageWarningSentAt: null, usageExceededSentAt: null }
+      : {}),
   };
 
   const changes = diffOrganizationFields(
@@ -444,6 +450,9 @@ export async function polarWebhook(
           data: {
             subscriptionPeriodEventsCount: 0,
             subscriptionPeriodEventsCountExceededAt: null,
+            // New cycle — the usage alerts may fire again.
+            usageWarningSentAt: null,
+            usageExceededSentAt: null,
           },
         });
 

--- a/apps/start/src/routes/_app.$organizationId.tsx
+++ b/apps/start/src/routes/_app.$organizationId.tsx
@@ -162,12 +162,31 @@ function Component() {
           </LinkButton>
         </Alert>
       )}
+      {organization.isActive &&
+        !organization.isExceeded &&
+        organization.subscriptionPeriodEventsLimit > 0 &&
+        organization.subscriptionPeriodEventsCount >=
+          organization.subscriptionPeriodEventsLimit * 0.8 && (
+          <Alert
+            title="Approaching your events limit"
+            description={`You've used ${Math.round((organization.subscriptionPeriodEventsCount / organization.subscriptionPeriodEventsLimit) * 100)}% of your ${organization.subscriptionPeriodEventsLimit.toLocaleString()} monthly events. If you go over, we keep collecting your events but charts pause until you upgrade.`}
+          >
+            <LinkButton
+              to="/$organizationId/billing"
+              params={{
+                organizationId: organizationId,
+              }}
+            >
+              See plans
+            </LinkButton>
+          </Alert>
+        )}
       {organization.subscriptionPeriodEventsCountExceededAt &&
         organization.isActive &&
         organization.isExceeded && (
           <Alert
             title="Events limit exceeded"
-            description={`Your subscription has exceeded the limit on ${format(organization.subscriptionPeriodEventsCountExceededAt, 'PPP')}`}
+            description={`You hit your monthly events limit on ${format(organization.subscriptionPeriodEventsCountExceededAt, 'PPP')}. We're still collecting your events — nothing is lost — but charts won't show new data until you upgrade or your next cycle starts.`}
           >
             <LinkButton
               to="/$organizationId/billing"

--- a/apps/worker/src/boot-cron.ts
+++ b/apps/worker/src/boot-cron.ts
@@ -113,6 +113,11 @@ export async function bootCron() {
       type: 'weeklyDigest',
       pattern: '0 8 * * 1', // Mondays 08:00 UTC — weekly analytics digest email
     },
+    {
+      name: 'dataHealth',
+      type: 'dataHealth',
+      pattern: '30 7 * * *', // Daily 07:30 UTC — no-data / data-stopped rescue emails
+    },
   ];
 
   if (process.env.SELF_HOSTED && process.env.NODE_ENV === 'production') {

--- a/apps/worker/src/boot-debug.ts
+++ b/apps/worker/src/boot-debug.ts
@@ -30,6 +30,7 @@ const CRON_TYPES = [
   'sessionVacuum',
   'insightCleanup',
   'weeklyDigest',
+  'dataHealth',
 ] as const satisfies readonly CronQueueType[];
 
 function escapeHtml(value: string) {

--- a/apps/worker/src/jobs/cron.data-health.ts
+++ b/apps/worker/src/jobs/cron.data-health.ts
@@ -1,0 +1,187 @@
+import { db, getLastEventPerProject } from '@openpanel/db';
+import { sendEmail } from '@openpanel/email';
+import { logger as baseLogger } from '@/utils/logger';
+
+const logger = baseLogger.child({ job: 'data-health' });
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+// A brand-new project gets 48h to send its first event before we reach out.
+const NO_DATA_AFTER_MS = 2 * DAY_MS;
+// An active project whose newest event is older than this counts as stalled.
+const STALLED_AFTER_MS = 7 * DAY_MS;
+
+interface OrgAlert {
+  organizationId: string;
+  noData: { id: string; name: string }[];
+  stalled: { id: string; name: string; lastEventAt: Date }[];
+}
+
+async function recipientsForOrg(organizationId: string) {
+  const members = await db.member.findMany({
+    where: {
+      organizationId,
+      user: { deletedAt: null },
+    },
+    include: { user: { select: { email: true, firstName: true } } },
+  });
+  const seen = new Map<string, string | undefined>();
+  for (const member of members) {
+    if (member.user?.email && !seen.has(member.user.email)) {
+      seen.set(member.user.email, member.user.firstName ?? undefined);
+    }
+  }
+  return seen;
+}
+
+/**
+ * Daily rescue emails for paying/trialing orgs whose tracking is broken:
+ * projects that never received an event (48h grace) and projects whose event
+ * flow stalled for 7+ days. A silently broken install reads as "the product
+ * stopped working" — a working install is the cheapest retention there is.
+ *
+ * Dedupe: `noDataNotifiedAt` is sent once per project; `dataStoppedNotifiedAt`
+ * is compared against the newest event, so data resuming and stalling again
+ * notifies again without any clearing step.
+ */
+export async function dataHealthCronJob() {
+  if (process.env.SELF_HOSTED === 'true') {
+    return;
+  }
+
+  const now = Date.now();
+  const lastEventByProject = await getLastEventPerProject();
+
+  // Prefilter on the raw status column (computed fields can't be used in
+  // `where`), then refine with the canonical subscription state below.
+  const projects = await db.project.findMany({
+    where: {
+      deleteAt: null,
+      organization: { subscriptionStatus: { in: ['active', 'trialing'] } },
+    },
+    select: {
+      id: true,
+      name: true,
+      createdAt: true,
+      organizationId: true,
+      noDataNotifiedAt: true,
+      dataStoppedNotifiedAt: true,
+      organization: { select: { id: true, subscriptionState: true } },
+    },
+  });
+
+  const byOrg = new Map<string, OrgAlert>();
+
+  for (const project of projects) {
+    const state = project.organization.subscriptionState;
+    if (state !== 'active' && state !== 'trialing') {
+      continue;
+    }
+
+    const lastEventAt = lastEventByProject.get(project.id);
+
+    if (!lastEventAt) {
+      // Never received an event. One notice per project, after the grace
+      // period. (The onboarding drip already nudges brand-new orgs, so this
+      // mainly catches additional projects and broken installs.)
+      const oldEnough = now - project.createdAt.getTime() > NO_DATA_AFTER_MS;
+      if (oldEnough && !project.noDataNotifiedAt) {
+        const entry = byOrg.get(project.organizationId) ?? {
+          organizationId: project.organizationId,
+          noData: [],
+          stalled: [],
+        };
+        entry.noData.push({ id: project.id, name: project.name });
+        byOrg.set(project.organizationId, entry);
+      }
+      continue;
+    }
+
+    const stalled = now - lastEventAt.getTime() > STALLED_AFTER_MS;
+    const alreadyNotifiedForThisStall =
+      project.dataStoppedNotifiedAt &&
+      project.dataStoppedNotifiedAt > lastEventAt;
+    if (stalled && !alreadyNotifiedForThisStall) {
+      const entry = byOrg.get(project.organizationId) ?? {
+        organizationId: project.organizationId,
+        noData: [],
+        stalled: [],
+      };
+      entry.stalled.push({
+        id: project.id,
+        name: project.name,
+        lastEventAt,
+      });
+      byOrg.set(project.organizationId, entry);
+    }
+  }
+
+  let emailsSent = 0;
+
+  for (const alert of byOrg.values()) {
+    try {
+      const recipients = await recipientsForOrg(alert.organizationId);
+      if (recipients.size === 0) {
+        continue;
+      }
+
+      const dashboardUrl = `${process.env.DASHBOARD_URL}/${alert.organizationId}`;
+
+      if (alert.noData.length > 0) {
+        for (const [to, firstName] of recipients) {
+          await sendEmail('tracking-no-data', {
+            to,
+            data: {
+              firstName,
+              projectNames: alert.noData.map((p) => p.name),
+              dashboardUrl,
+            },
+          });
+          emailsSent++;
+        }
+        await db.project.updateMany({
+          where: { id: { in: alert.noData.map((p) => p.id) } },
+          data: { noDataNotifiedAt: new Date() },
+        });
+      }
+
+      if (alert.stalled.length > 0) {
+        const newestLastEvent = alert.stalled
+          .map((p) => p.lastEventAt)
+          .sort((a, b) => b.getTime() - a.getTime())[0];
+        for (const [to, firstName] of recipients) {
+          await sendEmail('tracking-data-stopped', {
+            to,
+            data: {
+              firstName,
+              projectNames: alert.stalled.map((p) => p.name),
+              lastEventDate: newestLastEvent?.toLocaleDateString('en-US', {
+                month: 'long',
+                day: 'numeric',
+              }),
+              dashboardUrl,
+            },
+          });
+          emailsSent++;
+        }
+        await db.project.updateMany({
+          where: { id: { in: alert.stalled.map((p) => p.id) } },
+          data: { dataStoppedNotifiedAt: new Date() },
+        });
+      }
+    } catch (err) {
+      logger.error(
+        { err, organizationId: alert.organizationId },
+        'Data-health alert failed'
+      );
+    }
+  }
+
+  logger.info(
+    {
+      projects: projects.length,
+      organizations: byOrg.size,
+      emailsSent,
+    },
+    'Data-health check complete'
+  );
+}

--- a/apps/worker/src/jobs/cron.data-health.ts
+++ b/apps/worker/src/jobs/cron.data-health.ts
@@ -124,7 +124,7 @@ export async function dataHealthCronJob() {
         continue;
       }
 
-      const dashboardUrl = `${process.env.DASHBOARD_URL}/${alert.organizationId}`;
+      const dashboardUrl = `${process.env.DASHBOARD_URL ?? 'https://dashboard.openpanel.dev'}/${alert.organizationId}`;
 
       if (alert.noData.length > 0) {
         for (const [to, firstName] of recipients) {

--- a/apps/worker/src/jobs/cron.ts
+++ b/apps/worker/src/jobs/cron.ts
@@ -9,6 +9,7 @@ import {
 import type { CronQueuePayload } from '@openpanel/queue';
 import type { Job } from 'bullmq';
 import { cohortRefreshCronJob } from './cron.cohort-refresh';
+import { dataHealthCronJob } from './cron.data-health';
 import { jobDelete } from './cron.delete';
 import { insightCleanupCronJob } from './cron.insight-cleanup';
 import { weeklyDigestCronJob } from './cron.weekly-digest';
@@ -74,6 +75,9 @@ export async function cronJob(job: Job<CronQueuePayload>) {
     }
     case 'weeklyDigest': {
       return await weeklyDigestCronJob();
+    }
+    case 'dataHealth': {
+      return await dataHealthCronJob();
     }
   }
 }

--- a/apps/worker/src/jobs/cron.weekly-digest.ts
+++ b/apps/worker/src/jobs/cron.weekly-digest.ts
@@ -6,7 +6,11 @@ import { logger as baseLogger } from '@/utils/logger';
 const logger = baseLogger.child({ job: 'weekly-digest' });
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const MIN_EVENTS = 5000;
+// Keep this low: the digest is our main "value without logging in" touchpoint,
+// and the old 5000 gate excluded customers on smaller plans — exactly the ones
+// who benefit most from the reminder. Zero-visitor weeks are still skipped per
+// send, so quiet projects don't get empty emails.
+const MIN_EVENTS = 100;
 const MAX_INSIGHTS = 5;
 
 type DigestData = EmailData<'weekly-digest'>;

--- a/apps/worker/src/jobs/notification.ts
+++ b/apps/worker/src/jobs/notification.ts
@@ -1,6 +1,7 @@
 import type { Job } from 'bullmq';
 
 import { Prisma, db } from '@openpanel/db';
+import { sendEmail } from '@openpanel/email';
 import { sendDiscordNotification } from '@openpanel/integrations/src/discord';
 import { sendSlackNotification } from '@openpanel/integrations/src/slack';
 import { execute as executeJavaScriptTemplate } from '@openpanel/js-runtime';
@@ -29,6 +30,35 @@ export async function notificationJob(job: Job<NotificationQueuePayload>) {
       }
 
       if (notification.sendToEmail) {
+        const project = await db.project.findUniqueOrThrow({
+          where: { id: notification.projectId },
+          select: { name: true, organizationId: true },
+        });
+        const members = await db.member.findMany({
+          where: {
+            organizationId: project.organizationId,
+            user: { deletedAt: null },
+          },
+          include: { user: { select: { email: true } } },
+        });
+        const emails = new Set(
+          members.flatMap((member) =>
+            member.user?.email ? [member.user.email] : [],
+          ),
+        );
+        for (const to of emails) {
+          // Per-recipient unsubscribe (product_alerts category) is handled
+          // inside sendEmail.
+          await sendEmail('notification-rule', {
+            to,
+            data: {
+              title: notification.title,
+              message: notification.message,
+              projectName: project.name,
+              dashboardUrl: `${process.env.DASHBOARD_URL}/${project.organizationId}/${notification.projectId}`,
+            },
+          });
+        }
         return;
       }
 

--- a/apps/worker/src/jobs/notification.ts
+++ b/apps/worker/src/jobs/notification.ts
@@ -55,7 +55,7 @@ export async function notificationJob(job: Job<NotificationQueuePayload>) {
               title: notification.title,
               message: notification.message,
               projectName: project.name,
-              dashboardUrl: `${process.env.DASHBOARD_URL}/${project.organizationId}/${notification.projectId}`,
+              dashboardUrl: `${process.env.DASHBOARD_URL ?? 'https://dashboard.openpanel.dev'}/${project.organizationId}/${notification.projectId}`,
             },
           });
         }

--- a/apps/worker/src/jobs/sessions.ts
+++ b/apps/worker/src/jobs/sessions.ts
@@ -122,68 +122,97 @@ async function sendUsageAlerts(organization: Organization, count: number) {
     count <= limit &&
     !organization.usageWarningSentAt;
 
-  if (!exceeded && !nearLimit) {
+  if (!(exceeded || nearLimit)) {
     return;
   }
 
-  const admins = await db.member.findMany({
+  // Claim the alert atomically BEFORE sending: session jobs for different
+  // projects of the same org can run concurrently, and both would otherwise
+  // read null markers and double-send. Marking the warning together with the
+  // exceeded notice keeps a both-thresholds-in-one-jump crossing from queueing
+  // a redundant warning afterwards. Rolled back if every send fails.
+  const claimedAt = new Date();
+  const claimed = await db.organization.updateMany({
     where: {
-      organizationId: organization.id,
-      role: 'org:admin',
-      user: { deletedAt: null },
+      id: organization.id,
+      ...(exceeded
+        ? { usageExceededSentAt: null }
+        : { usageWarningSentAt: null }),
     },
-    include: { user: { select: { email: true, firstName: true } } },
+    data: exceeded
+      ? { usageExceededSentAt: claimedAt, usageWarningSentAt: claimedAt }
+      : { usageWarningSentAt: claimedAt },
   });
-
-  const billingUrl = `${process.env.DASHBOARD_URL}/${organization.id}/billing`;
-  const recipients = new Map(
-    admins
-      .filter((member) => member.user?.email)
-      .map((member) => [member.user!.email, member.user!.firstName ?? undefined])
-  );
-
-  for (const [email, firstName] of recipients) {
-    if (exceeded) {
-      await sendEmail('usage-limit-exceeded', {
-        to: email,
-        data: {
-          firstName,
-          organizationName: organization.name,
-          billingUrl,
-          eventsLimit: limit,
-        },
-      });
-    } else {
-      await sendEmail('usage-near-limit', {
-        to: email,
-        data: {
-          firstName,
-          organizationName: organization.name,
-          billingUrl,
-          eventsCount: count,
-          eventsLimit: limit,
-        },
-      });
-    }
+  if (claimed.count === 0) {
+    return;
   }
 
-  await db.organization.update({
-    where: { id: organization.id },
-    data: exceeded
-      ? // Mark the warning as sent too — crossing both thresholds between two
-        // runs must not queue a redundant warning after the exceeded notice.
-        { usageExceededSentAt: new Date(), usageWarningSentAt: new Date() }
-      : { usageWarningSentAt: new Date() },
-  });
+  try {
+    const admins = await db.member.findMany({
+      where: {
+        organizationId: organization.id,
+        role: 'org:admin',
+        user: { deletedAt: null },
+      },
+      include: { user: { select: { email: true, firstName: true } } },
+    });
 
-  logger.info(
-    {
-      organizationId: organization.id,
-      count,
-      limit,
-      kind: exceeded ? 'exceeded' : 'near-limit',
-      recipients: recipients.size,
-    },
-    'Sent usage alert emails'
-  );
+    const billingUrl = `${process.env.DASHBOARD_URL ?? 'https://dashboard.openpanel.dev'}/${organization.id}/billing`;
+    const recipients = new Map(
+      admins
+        .filter((member) => member.user?.email)
+        .map((member) => [
+          member.user!.email,
+          member.user!.firstName ?? undefined,
+        ])
+    );
+
+    for (const [email, firstName] of recipients) {
+      if (exceeded) {
+        await sendEmail('usage-limit-exceeded', {
+          to: email,
+          data: {
+            firstName,
+            organizationName: organization.name,
+            billingUrl,
+            eventsLimit: limit,
+          },
+        });
+      } else {
+        await sendEmail('usage-near-limit', {
+          to: email,
+          data: {
+            firstName,
+            organizationName: organization.name,
+            billingUrl,
+            eventsCount: count,
+            eventsLimit: limit,
+          },
+        });
+      }
+    }
+
+    logger.info(
+      {
+        organizationId: organization.id,
+        count,
+        limit,
+        kind: exceeded ? 'exceeded' : 'near-limit',
+        recipients: recipients.size,
+      },
+      'Sent usage alert emails'
+    );
+  } catch (error) {
+    // Release the claim so the next usage update retries the alert.
+    await db.organization.updateMany({
+      where: { id: organization.id },
+      data: exceeded
+        ? {
+            usageExceededSentAt: null,
+            usageWarningSentAt: organization.usageWarningSentAt,
+          }
+        : { usageWarningSentAt: null },
+    });
+    throw error;
+  }
 }

--- a/apps/worker/src/jobs/sessions.ts
+++ b/apps/worker/src/jobs/sessions.ts
@@ -8,10 +8,13 @@ import {
   getOrganizationBillingEventsCount,
   getProjectEventsCount,
 } from '@openpanel/db';
+import type { Organization } from '@openpanel/db';
+import { sendEmail } from '@openpanel/email';
 import { cacheable } from '@openpanel/redis';
 import { createSessionEnd } from './events.create-session-end';
 
 const INT4_MAX = 2_147_483_647;
+const USAGE_WARNING_THRESHOLD = 0.8;
 
 export async function sessionsJob(job: Job<SessionsQueuePayload>) {
   const res = await createSessionEnd(job);
@@ -88,7 +91,99 @@ const updateEventsCount = cacheable(async function updateEventsCount(
               : organization.subscriptionPeriodEventsCountExceededAt,
       },
     });
+
+    if (!isSelfHosted) {
+      try {
+        await sendUsageAlerts(organization, organizationEventsCount);
+      } catch (e) {
+        logger.error({ err: e }, 'Failed to send usage alert emails');
+      }
+    }
   }
 
   return true;
 }, 60 * 60);
+
+/**
+ * One warning at 80% and one notice at 100% per billing cycle. The sent-at
+ * markers are cleared by the Polar webhook when a new cycle resets the usage
+ * counter (or the limit is raised), so each cycle can alert again.
+ */
+async function sendUsageAlerts(organization: Organization, count: number) {
+  const limit = organization.subscriptionPeriodEventsLimit;
+  if (!limit || limit <= 0) {
+    return;
+  }
+
+  const exceeded = count > limit && !organization.usageExceededSentAt;
+  const nearLimit =
+    !exceeded &&
+    count >= limit * USAGE_WARNING_THRESHOLD &&
+    count <= limit &&
+    !organization.usageWarningSentAt;
+
+  if (!exceeded && !nearLimit) {
+    return;
+  }
+
+  const admins = await db.member.findMany({
+    where: {
+      organizationId: organization.id,
+      role: 'org:admin',
+      user: { deletedAt: null },
+    },
+    include: { user: { select: { email: true, firstName: true } } },
+  });
+
+  const billingUrl = `${process.env.DASHBOARD_URL}/${organization.id}/billing`;
+  const recipients = new Map(
+    admins
+      .filter((member) => member.user?.email)
+      .map((member) => [member.user!.email, member.user!.firstName ?? undefined])
+  );
+
+  for (const [email, firstName] of recipients) {
+    if (exceeded) {
+      await sendEmail('usage-limit-exceeded', {
+        to: email,
+        data: {
+          firstName,
+          organizationName: organization.name,
+          billingUrl,
+          eventsLimit: limit,
+        },
+      });
+    } else {
+      await sendEmail('usage-near-limit', {
+        to: email,
+        data: {
+          firstName,
+          organizationName: organization.name,
+          billingUrl,
+          eventsCount: count,
+          eventsLimit: limit,
+        },
+      });
+    }
+  }
+
+  await db.organization.update({
+    where: { id: organization.id },
+    data: exceeded
+      ? // Mark the warning as sent too — crossing both thresholds between two
+        // runs must not queue a redundant warning after the exceeded notice.
+        { usageExceededSentAt: new Date(), usageWarningSentAt: new Date() }
+      : { usageWarningSentAt: new Date() },
+  });
+
+  logger.info(
+    {
+      organizationId: organization.id,
+      count,
+      limit,
+      kind: exceeded ? 'exceeded' : 'near-limit',
+      recipients: recipients.size,
+    },
+    'Sent usage alert emails'
+  );
+}

--- a/packages/constants/index.ts
+++ b/packages/constants/index.ts
@@ -606,6 +606,11 @@ export const emailCategories = {
     label: 'Weekly digest',
     description: 'A weekly summary of your analytics with AI-surfaced insights',
   },
+  product_alerts: {
+    label: 'Product alerts',
+    description:
+      'Important notices about your projects: tracking stopped sending data, event limits, and alerts from your notification rules',
+  },
 } as const;
 
 export type EmailCategory = keyof typeof emailCategories;

--- a/packages/db/prisma/migrations/20260822110000_data_health_and_usage_alerts/migration.sql
+++ b/packages/db/prisma/migrations/20260822110000_data_health_and_usage_alerts/migration.sql
@@ -1,0 +1,9 @@
+-- Usage-alert dedupe markers (cleared on billing-cycle reset / limit raise)
+-- and data-health notice markers for the dataHealth cron.
+ALTER TABLE "organizations"
+  ADD COLUMN "usageWarningSentAt" TIMESTAMP(3),
+  ADD COLUMN "usageExceededSentAt" TIMESTAMP(3);
+
+ALTER TABLE "projects"
+  ADD COLUMN "noDataNotifiedAt" TIMESTAMP(3),
+  ADD COLUMN "dataStoppedNotifiedAt" TIMESTAMP(3);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -114,6 +114,10 @@ model Organization {
   // subscriptionStartsAt (overwritten with each period start on renewal) this
   // is stable, so it can measure tenure (e.g. the switch-to-yearly prompt).
   subscriptionFirstStartedAt              DateTime?
+  // Usage-alert dedupe markers — cleared when a new billing cycle resets the
+  // usage counter (or the limit is raised), so each cycle can warn once.
+  usageWarningSentAt                      DateTime?
+  usageExceededSentAt                     DateTime?
 
   // When deleteAt > now(), the organization will be deleted
   deleteAt DateTime?
@@ -250,6 +254,12 @@ model Project {
   allowUnsafeRevenueTracking Boolean       @default(false)
   /// [IPrismaProjectFilters]
   filters                    Json          @default("[]")
+  // Data-health notice markers set by the dataHealth cron. `noDataNotifiedAt`:
+  // told the org this project never received events. `dataStoppedNotifiedAt`:
+  // told them the event flow stalled — compared against the last event time, so
+  // a resume followed by a new stall notifies again without clearing.
+  noDataNotifiedAt           DateTime?
+  dataStoppedNotifiedAt      DateTime?
 
   clients           Client[]
   reports           Report[]

--- a/packages/db/src/services/notification.service.ts
+++ b/packages/db/src/services/notification.service.ts
@@ -50,16 +50,16 @@ export const BASE_INTEGRATIONS: Integration[] = [
     },
     organizationId: '',
   },
-  // {
-  //   id: EMAIL_NOTIFICATION_INTEGRATION_ID,
-  //   name: 'Email',
-  //   createdAt: new Date(),
-  //   updatedAt: new Date(),
-  //   config: {
-  //     type: EMAIL_NOTIFICATION_INTEGRATION_ID,
-  //   },
-  //   organizationId: '',
-  // },
+  {
+    id: EMAIL_NOTIFICATION_INTEGRATION_ID,
+    name: 'Email',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    config: {
+      type: EMAIL_NOTIFICATION_INTEGRATION_ID,
+    },
+    organizationId: '',
+  },
 ];
 
 export const isBaseIntegration = (id: string) =>

--- a/packages/db/src/services/project.service.ts
+++ b/packages/db/src/services/project.service.ts
@@ -1,6 +1,10 @@
 import { cacheable } from '@openpanel/redis';
 import sqlstring from 'sqlstring';
-import { chQuery, TABLE_NAMES } from '../clickhouse/client';
+import {
+  chQuery,
+  convertClickhouseDateToJs,
+  TABLE_NAMES,
+} from '../clickhouse/client';
 import { ClientType, type Prisma, type Project } from '../prisma-client';
 import { db } from '../prisma-client';
 
@@ -117,6 +121,25 @@ export const getProjectEventsCount = async (projectId: string) => {
     `SELECT sum(event_count) as count FROM ${TABLE_NAMES.event_names_mv} WHERE project_id = ${sqlstring.escape(projectId)} AND name NOT IN ('session_start', 'session_end')`
   );
   return res[0]?.count;
+};
+
+/**
+ * Newest event timestamp per project, for the whole instance in one query.
+ * Reads the same pre-aggregated MV as getProjectEventsCount (it stores
+ * max(created_at) per (project_id, name) block), so this scans thousands of
+ * rows instead of the raw events table. Projects with no events are absent
+ * from the map.
+ */
+export const getLastEventPerProject = async (): Promise<Map<string, Date>> => {
+  const res = await chQuery<{ project_id: string; last_event_at: string }>(
+    `SELECT project_id, max(created_at) as last_event_at FROM ${TABLE_NAMES.event_names_mv} GROUP BY project_id`
+  );
+  return new Map(
+    res.map((row) => [
+      row.project_id,
+      convertClickhouseDateToJs(row.last_event_at),
+    ])
+  );
 };
 
 /**

--- a/packages/db/src/services/project.service.ts
+++ b/packages/db/src/services/project.service.ts
@@ -1,10 +1,12 @@
 import { cacheable } from '@openpanel/redis';
 import sqlstring from 'sqlstring';
 import {
+  ch,
   chQuery,
   convertClickhouseDateToJs,
   TABLE_NAMES,
 } from '../clickhouse/client';
+import { clix } from '../clickhouse/query-builder';
 import { ClientType, type Prisma, type Project } from '../prisma-client';
 import { db } from '../prisma-client';
 
@@ -131,9 +133,14 @@ export const getProjectEventsCount = async (projectId: string) => {
  * from the map.
  */
 export const getLastEventPerProject = async (): Promise<Map<string, Date>> => {
-  const res = await chQuery<{ project_id: string; last_event_at: string }>(
-    `SELECT project_id, max(created_at) as last_event_at FROM ${TABLE_NAMES.event_names_mv} GROUP BY project_id`
-  );
+  const res = await clix(ch)
+    .select<{ project_id: string; last_event_at: string }>([
+      'project_id',
+      'max(created_at) AS last_event_at',
+    ])
+    .from(TABLE_NAMES.event_names_mv)
+    .groupBy(['project_id'])
+    .execute();
   return new Map(
     res.map((row) => [
       row.project_id,

--- a/packages/email/src/emails/index.tsx
+++ b/packages/email/src/emails/index.tsx
@@ -15,10 +15,19 @@ import OnboardingTrialEnded, {
 import OnboardingTrialEnding, {
   zOnboardingTrialEnding,
 } from './onboarding-trial-ending';
+import NotificationRule, { zNotificationRule } from './notification-rule';
 import OnboardingWelcome, { zOnboardingWelcome } from './onboarding-welcome';
 import OnboardingWhatToTrack, {
   zOnboardingWhatToTrack,
 } from './onboarding-what-to-track';
+import TrackingDataStopped, {
+  zTrackingDataStopped,
+} from './tracking-data-stopped';
+import TrackingNoData, { zTrackingNoData } from './tracking-no-data';
+import UsageLimitExceeded, {
+  zUsageLimitExceeded,
+} from './usage-limit-exceeded';
+import UsageNearLimit, { zUsageNearLimit } from './usage-near-limit';
 import WeeklyDigest, { zWeeklyDigest } from './weekly-digest';
 
 export const templates = {
@@ -79,6 +88,40 @@ export const templates = {
     Component: WeeklyDigest,
     schema: zWeeklyDigest,
     category: 'weekly_digest' as const,
+  },
+  'usage-near-limit': {
+    subject: (data: z.infer<typeof zUsageNearLimit>) =>
+      `You've used ${Math.round((data.eventsCount / data.eventsLimit) * 100)}% of your monthly events`,
+    Component: UsageNearLimit,
+    schema: zUsageNearLimit,
+    category: 'product_alerts' as const,
+  },
+  'usage-limit-exceeded': {
+    subject: () => 'Event limit reached — charts paused, data still collected',
+    Component: UsageLimitExceeded,
+    schema: zUsageLimitExceeded,
+    category: 'product_alerts' as const,
+  },
+  'tracking-no-data': {
+    subject: () => "Your tracking isn't sending data yet",
+    Component: TrackingNoData,
+    schema: zTrackingNoData,
+    category: 'product_alerts' as const,
+  },
+  'tracking-data-stopped': {
+    subject: (data: z.infer<typeof zTrackingDataStopped>) =>
+      data.projectNames.length === 1
+        ? `${data.projectNames[0]} stopped sending events`
+        : 'Some of your projects stopped sending events',
+    Component: TrackingDataStopped,
+    schema: zTrackingDataStopped,
+    category: 'product_alerts' as const,
+  },
+  'notification-rule': {
+    subject: (data: z.infer<typeof zNotificationRule>) => data.title,
+    Component: NotificationRule,
+    schema: zNotificationRule,
+    category: 'product_alerts' as const,
   },
 } as const;
 

--- a/packages/email/src/emails/notification-rule.tsx
+++ b/packages/email/src/emails/notification-rule.tsx
@@ -1,0 +1,51 @@
+import { Text } from '@react-email/components';
+import React from 'react';
+import { z } from 'zod';
+import { Button } from '../components/button';
+import { Layout } from '../components/layout';
+import { withUtm } from '../utm';
+
+export const zNotificationRule = z.object({
+  title: z.string(),
+  message: z.string(),
+  projectName: z.string().optional(),
+  dashboardUrl: z.string().optional(),
+});
+
+export type Props = z.infer<typeof zNotificationRule>;
+export default NotificationRule;
+export function NotificationRule({
+  title,
+  message,
+  projectName,
+  dashboardUrl,
+  unsubscribeUrl,
+}: Props & { unsubscribeUrl?: string }) {
+  return (
+    <Layout unsubscribeUrl={unsubscribeUrl}>
+      <Text>
+        🔔 <strong>{title}</strong>
+        {projectName ? ` — ${projectName}` : ''}
+      </Text>
+      <Text>{message}</Text>
+      {dashboardUrl && (
+        <Text>
+          <Button href={withUtm(dashboardUrl, 'notification-rule')}>
+            Open dashboard
+          </Button>
+        </Text>
+      )}
+      <Text>
+        You're receiving this because a notification rule you set up matched.
+        Manage rules under Notifications in your project.
+      </Text>
+    </Layout>
+  );
+}
+
+NotificationRule.PreviewProps = {
+  title: 'Conversion: Sign up completed',
+  message: 'A user completed the sign-up funnel.',
+  projectName: 'My website',
+  dashboardUrl: 'https://dashboard.openpanel.dev/org-id/project-id',
+};

--- a/packages/email/src/emails/tracking-data-stopped.tsx
+++ b/packages/email/src/emails/tracking-data-stopped.tsx
@@ -1,0 +1,74 @@
+import { Link, Text } from '@react-email/components';
+import React from 'react';
+import { z } from 'zod';
+import { Button } from '../components/button';
+import { Layout } from '../components/layout';
+import { withUtm } from '../utm';
+
+export const zTrackingDataStopped = z.object({
+  firstName: z.string().optional(),
+  projectNames: z.array(z.string()).min(1),
+  lastEventDate: z.string().optional(),
+  dashboardUrl: z.string(),
+});
+
+export type Props = z.infer<typeof zTrackingDataStopped>;
+export default TrackingDataStopped;
+export function TrackingDataStopped({
+  firstName,
+  projectNames,
+  lastEventDate,
+  dashboardUrl = 'https://dashboard.openpanel.dev',
+  unsubscribeUrl,
+}: Props & { unsubscribeUrl?: string }) {
+  const single = projectNames.length === 1;
+  const names = projectNames.join(', ');
+  return (
+    <Layout unsubscribeUrl={unsubscribeUrl}>
+      <Text>Hi{firstName ? ` ${firstName}` : ''},</Text>
+      <Text>
+        {single
+          ? `Your project ${names} stopped`
+          : `Your projects (${names}) stopped`}{' '}
+        sending events
+        {lastEventDate
+          ? ` — the last one arrived on ${lastEventDate}`
+          : ' about a week ago'}
+        .
+      </Text>
+      <Text>
+        This usually isn't intentional: a deploy that dropped the tracking
+        snippet, a changed client ID, or a new domain that isn't in your allowed
+        origins. Worth a quick check so you don't end up with a gap in your
+        data.
+      </Text>
+      <Text>
+        <Button href={withUtm(dashboardUrl, 'tracking-data-stopped')}>
+          Check your project
+        </Button>
+      </Text>
+      <Text>
+        The{' '}
+        <Link
+          href={withUtm(
+            'https://openpanel.dev/docs/get-started/install-openpanel',
+            'tracking-data-stopped'
+          )}
+        >
+          install guide
+        </Link>{' '}
+        covers a re-install for every framework. If it stopped on purpose — no
+        action needed, and sorry for the noise. Otherwise, reply and I'll help
+        you debug it.
+      </Text>
+      <Text>Carl</Text>
+    </Layout>
+  );
+}
+
+TrackingDataStopped.PreviewProps = {
+  firstName: 'Alex',
+  projectNames: ['My website'],
+  lastEventDate: 'August 14',
+  dashboardUrl: 'https://dashboard.openpanel.dev/org-id',
+};

--- a/packages/email/src/emails/tracking-no-data.tsx
+++ b/packages/email/src/emails/tracking-no-data.tsx
@@ -1,0 +1,66 @@
+import { Link, Text } from '@react-email/components';
+import React from 'react';
+import { z } from 'zod';
+import { Button } from '../components/button';
+import { Layout } from '../components/layout';
+import { withUtm } from '../utm';
+
+export const zTrackingNoData = z.object({
+  firstName: z.string().optional(),
+  projectNames: z.array(z.string()).min(1),
+  dashboardUrl: z.string(),
+});
+
+export type Props = z.infer<typeof zTrackingNoData>;
+export default TrackingNoData;
+export function TrackingNoData({
+  firstName,
+  projectNames,
+  dashboardUrl = 'https://dashboard.openpanel.dev',
+  unsubscribeUrl,
+}: Props & { unsubscribeUrl?: string }) {
+  const single = projectNames.length === 1;
+  const names = projectNames.join(', ');
+  return (
+    <Layout unsubscribeUrl={unsubscribeUrl}>
+      <Text>Hi{firstName ? ` ${firstName}` : ''},</Text>
+      <Text>
+        {single
+          ? `Your project ${names} hasn't`
+          : `Your projects (${names}) haven't`}{' '}
+        received any events yet — which usually means the tracking snippet isn't
+        installed, or something is blocking it.
+      </Text>
+      <Text>
+        The most common fixes: the snippet isn't on the page (or not deployed
+        yet), the client ID doesn't match, or the domain isn't in your allowed
+        origins.
+      </Text>
+      <Text>
+        <Button href={withUtm(dashboardUrl, 'tracking-no-data')}>
+          Verify your install
+        </Button>
+      </Text>
+      <Text>
+        Framework-specific instructions are in the{' '}
+        <Link
+          href={withUtm(
+            'https://openpanel.dev/docs/get-started/install-openpanel',
+            'tracking-no-data'
+          )}
+        >
+          install guide
+        </Link>
+        . And if you've tried and it still doesn't work, reply to this email —
+        I'll personally help you get it running.
+      </Text>
+      <Text>Carl</Text>
+    </Layout>
+  );
+}
+
+TrackingNoData.PreviewProps = {
+  firstName: 'Alex',
+  projectNames: ['My website'],
+  dashboardUrl: 'https://dashboard.openpanel.dev/org-id',
+};

--- a/packages/email/src/emails/usage-limit-exceeded.tsx
+++ b/packages/email/src/emails/usage-limit-exceeded.tsx
@@ -1,0 +1,62 @@
+import { Text } from '@react-email/components';
+import React from 'react';
+import { z } from 'zod';
+import { Button } from '../components/button';
+import { Layout } from '../components/layout';
+import { withUtm } from '../utm';
+
+export const zUsageLimitExceeded = z.object({
+  firstName: z.string().optional(),
+  organizationName: z.string(),
+  billingUrl: z.string(),
+  eventsLimit: z.number(),
+});
+
+const formatNumber = (count: number) =>
+  new Intl.NumberFormat('en-US').format(count);
+
+export type Props = z.infer<typeof zUsageLimitExceeded>;
+export default UsageLimitExceeded;
+export function UsageLimitExceeded({
+  firstName,
+  organizationName,
+  billingUrl = 'https://dashboard.openpanel.dev',
+  eventsLimit,
+  unsubscribeUrl,
+}: Props & { unsubscribeUrl?: string }) {
+  return (
+    <Layout unsubscribeUrl={unsubscribeUrl}>
+      <Text>Hi{firstName ? ` ${firstName}` : ''},</Text>
+      <Text>
+        {organizationName} has reached its monthly limit of{' '}
+        {formatNumber(eventsLimit)} events.
+      </Text>
+      <Text>
+        Important: we're still collecting every incoming event, so nothing is
+        being lost. But your charts are paused at the moment you hit the limit —
+        new data won't show until you upgrade or your next billing cycle starts.
+      </Text>
+      <Text>
+        Upgrading takes a minute and unlocks everything collected in the
+        meantime.
+      </Text>
+      <Text>
+        <Button href={withUtm(billingUrl, 'usage-limit-exceeded')}>
+          Upgrade your plan
+        </Button>
+      </Text>
+      <Text>
+        If this month was an outlier, you can also just wait for the cycle to
+        reset. And if you're stuck between plans, reply and I'll help.
+      </Text>
+      <Text>Carl</Text>
+    </Layout>
+  );
+}
+
+UsageLimitExceeded.PreviewProps = {
+  firstName: 'Alex',
+  organizationName: 'Acme',
+  billingUrl: 'https://dashboard.openpanel.dev/org-id/billing',
+  eventsLimit: 5000,
+};

--- a/packages/email/src/emails/usage-near-limit.tsx
+++ b/packages/email/src/emails/usage-near-limit.tsx
@@ -1,0 +1,62 @@
+import { Text } from '@react-email/components';
+import React from 'react';
+import { z } from 'zod';
+import { Button } from '../components/button';
+import { Layout } from '../components/layout';
+import { withUtm } from '../utm';
+
+export const zUsageNearLimit = z.object({
+  firstName: z.string().optional(),
+  organizationName: z.string(),
+  billingUrl: z.string(),
+  eventsCount: z.number(),
+  eventsLimit: z.number(),
+});
+
+const formatNumber = (count: number) =>
+  new Intl.NumberFormat('en-US').format(count);
+
+export type Props = z.infer<typeof zUsageNearLimit>;
+export default UsageNearLimit;
+export function UsageNearLimit({
+  firstName,
+  organizationName,
+  billingUrl = 'https://dashboard.openpanel.dev',
+  eventsCount,
+  eventsLimit,
+  unsubscribeUrl,
+}: Props & { unsubscribeUrl?: string }) {
+  const percent = Math.round((eventsCount / eventsLimit) * 100);
+  return (
+    <Layout unsubscribeUrl={unsubscribeUrl}>
+      <Text>Hi{firstName ? ` ${firstName}` : ''},</Text>
+      <Text>
+        Heads up: {organizationName} has used {formatNumber(eventsCount)} of its{' '}
+        {formatNumber(eventsLimit)} monthly events ({percent}%).
+      </Text>
+      <Text>
+        If you go over the limit, we keep collecting every event — nothing is
+        lost — but your charts stop showing new data until you upgrade or the
+        next billing cycle starts.
+      </Text>
+      <Text>
+        <Button href={withUtm(billingUrl, 'usage-near-limit')}>
+          See usage &amp; plans
+        </Button>
+      </Text>
+      <Text>
+        Questions about which plan fits? Reply to this email and I'll help you
+        pick.
+      </Text>
+      <Text>Carl</Text>
+    </Layout>
+  );
+}
+
+UsageNearLimit.PreviewProps = {
+  firstName: 'Alex',
+  organizationName: 'Acme',
+  billingUrl: 'https://dashboard.openpanel.dev/org-id/billing',
+  eventsCount: 4200,
+  eventsLimit: 5000,
+};

--- a/packages/queue/src/queues.ts
+++ b/packages/queue/src/queues.ts
@@ -160,6 +160,10 @@ export type CronQueuePayloadWeeklyDigest = {
   type: 'weeklyDigest';
   payload: undefined;
 };
+export type CronQueuePayloadDataHealth = {
+  type: 'dataHealth';
+  payload: undefined;
+};
 export type CronQueuePayload =
   | CronQueuePayloadSalt
   | CronQueuePayloadFlushEvents
@@ -177,7 +181,8 @@ export type CronQueuePayload =
   | CronQueuePayloadSessionReaper
   | CronQueuePayloadSessionVacuum
   | CronQueuePayloadInsightCleanup
-  | CronQueuePayloadWeeklyDigest;
+  | CronQueuePayloadWeeklyDigest
+  | CronQueuePayloadDataHealth;
 
 export type CronQueueType = CronQueuePayload['type'];
 


### PR DESCRIPTION
## Why

A silently broken install, or charts that silently freeze at the event cap, both read as "the product stopped working" to someone who doesn't log in every day — and today neither triggers any outbound notice.

**Stacked on #451.**

## What

- **Usage alerts**: 80% warning + 100% exceeded emails to org admins, triggered in the sessions job where the usage counter is computed. Dedupe markers (`usageWarningSentAt` / `usageExceededSentAt`) reset on billing-cycle rollover and limit raises via the Polar webhook. New in-app ≥80% banner; the exceeded banner now says explicitly that events are still collected and only chart display pauses.
- **dataHealth cron** (daily 07:30 UTC): for paying/trialing orgs, emails when a project never received events (48h grace, once per project) or the event flow stalled 7+ days. Stall notices re-arm automatically when data resumes and stalls again (`dataStoppedNotifiedAt` vs last event time — no clearing step). Powered by new `getLastEventPerProject()` reading `distinct_event_names_mv` — one instance-wide pre-aggregated query (verified against local CH).
- **Notification-rule email channel wired**: `sendToEmail` was a silent no-op in the worker even though the UI persisted the toggle; now sends a `notification-rule` email to org members, and the Email integration is enabled in `BASE_INTEGRATIONS` (config type + UI already existed).
- **New `product_alerts` email category** — unsubscribe suppression, one-click List-Unsubscribe, and the prefs page pick it up automatically. 5 new react-email templates.
- **Weekly digest `MIN_EVENTS` 5000 → 100** so customers on smaller plans receive the digest too; zero-visitor weeks are still skipped per send.

## Tests

Typecheck + full suite green. Crons can be exercised via `GET /debug/cron/dataHealth`; emails log to console without SMTP/Resend configured.

https://claude.ai/code/session_017resSrRFv7wxsc9ifsALAh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added usage alerts at 80% and 100% of monthly event limits, with upgrade guidance.
  - Added email notifications for project notification rules.
  - Added data-health alerts for projects with no data or stalled tracking.
  - Added email guidance for installing or troubleshooting tracking.
- **Improvements**
  - Usage alerts reset when limits increase or a new billing cycle begins.
  - Weekly digest emails now support projects with over 100 events.
  - Event collection continues while charts are paused after reaching usage limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->