### PR TITLE
Move reports between dashboards

### DIFF
--- a/apps/start/src/components/dashboards/select-dashboard.tsx
+++ b/apps/start/src/components/dashboards/select-dashboard.tsx
@@ -53,12 +53,15 @@ export function SelectDashboard({
   );
 
   const handleCreateDashboard = () => {
-    if (newDashboardName.trim()) {
-      dashboardMutation.mutate({
-        name: newDashboardName.trim(),
-        projectId,
-      });
+    const name = newDashboardName.trim();
+    if (!name || dashboardMutation.isPending) {
+      return;
     }
+
+    dashboardMutation.mutate({
+      name,
+      projectId,
+    });
   };
 
   const dashboards = (dashboardQuery.data ?? []).filter(

--- a/apps/start/src/components/dashboards/select-dashboard.tsx
+++ b/apps/start/src/components/dashboards/select-dashboard.tsx
@@ -111,10 +111,15 @@ export function SelectDashboard({
             value={newDashboardName}
             onChange={(e) => setNewDashboardName(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                handleCreateDashboard();
+              if (e.key !== 'Enter') {
+                return;
               }
+              // Enter confirms an IME candidate, it should not submit.
+              if (e.nativeEvent.isComposing || e.keyCode === 229) {
+                return;
+              }
+              e.preventDefault();
+              handleCreateDashboard();
             }}
           />
           <Button

--- a/apps/start/src/components/dashboards/select-dashboard.tsx
+++ b/apps/start/src/components/dashboards/select-dashboard.tsx
@@ -1,0 +1,133 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { handleError, useTRPC } from '@/integrations/trpc/react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ArrowLeftIcon, PlusIcon, SaveIcon } from 'lucide-react';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+export function SelectDashboard({
+  value,
+  onChange,
+  projectId,
+  excludeDashboardId,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  projectId: string;
+  excludeDashboardId?: string;
+}) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [isCreatingNew, setIsCreatingNew] = useState(false);
+  const [newDashboardName, setNewDashboardName] = useState('');
+
+  const form = useForm({
+    resolver: zodResolver(z.object({ name: z.string().min(1, 'Required') })),
+    defaultValues: {
+      name: '',
+    },
+  });
+
+  const dashboardQuery = useQuery(
+    trpc.dashboard.list.queryOptions({
+      projectId,
+    }),
+  );
+
+  const dashboardMutation = useMutation(
+    trpc.dashboard.create.mutationOptions({
+      onError: handleError,
+      async onSuccess(res) {
+        queryClient.invalidateQueries(trpc.dashboard.list.pathFilter());
+        await dashboardQuery.refetch();
+        onChange(res.id);
+        setIsCreatingNew(false);
+        setNewDashboardName('');
+        form.reset();
+      },
+    }),
+  );
+
+  const handleCreateDashboard = () => {
+    if (newDashboardName.trim()) {
+      dashboardMutation.mutate({
+        name: newDashboardName.trim(),
+        projectId,
+      });
+    }
+  };
+
+  const dashboards = (dashboardQuery.data ?? []).filter(
+    (dashboard) => dashboard.id !== excludeDashboardId,
+  );
+
+  return (
+    <div className="space-y-3">
+      <Label>Dashboard</Label>
+
+      {!isCreatingNew ? (
+        <div className="row gap-2 flex-wrap">
+          {dashboards.map((dashboard) => (
+            <Button
+              type="button"
+              key={dashboard.id}
+              variant={value === dashboard.id ? 'default' : 'outline'}
+              onClick={() => onChange(dashboard.id)}
+            >
+              {dashboard.name}
+            </Button>
+          ))}
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              setIsCreatingNew(true);
+              onChange('');
+            }}
+            icon={PlusIcon}
+          >
+            Create new dashboard
+          </Button>
+        </div>
+      ) : (
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            icon={ArrowLeftIcon}
+            onClick={() => {
+              setIsCreatingNew(false);
+              setNewDashboardName('');
+              form.reset();
+            }}
+          />
+          <Input
+            placeholder="Enter dashboard name"
+            value={newDashboardName}
+            onChange={(e) => setNewDashboardName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleCreateDashboard();
+              }
+            }}
+          />
+          <Button
+            type="button"
+            onClick={handleCreateDashboard}
+            disabled={!newDashboardName.trim() || dashboardMutation.isPending}
+            variant="outline"
+            icon={SaveIcon}
+          >
+            {dashboardMutation.isPending ? 'Creating...' : 'Create'}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/start/src/components/dashboards/select-dashboard.tsx
+++ b/apps/start/src/components/dashboards/select-dashboard.tsx
@@ -4,7 +4,7 @@ import { Label } from '@/components/ui/label';
 import { handleError, useTRPC } from '@/integrations/trpc/react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeftIcon, PlusIcon, SaveIcon } from 'lucide-react';
-import { useState } from 'react';
+import { useId, useState } from 'react';
 
 export function SelectDashboard({
   value,
@@ -21,6 +21,8 @@ export function SelectDashboard({
   const queryClient = useQueryClient();
   const [isCreatingNew, setIsCreatingNew] = useState(false);
   const [newDashboardName, setNewDashboardName] = useState('');
+  const [previousValue, setPreviousValue] = useState('');
+  const newDashboardNameId = useId();
 
   const dashboardQuery = useQuery(
     trpc.dashboard.list.queryOptions({
@@ -59,7 +61,9 @@ export function SelectDashboard({
 
   return (
     <div className="space-y-3">
-      <Label>Dashboard</Label>
+      <Label htmlFor={isCreatingNew ? newDashboardNameId : undefined}>
+        Dashboard
+      </Label>
 
       {!isCreatingNew ? (
         <div className="row gap-2 flex-wrap">
@@ -78,6 +82,7 @@ export function SelectDashboard({
             type="button"
             variant="outline"
             onClick={() => {
+              setPreviousValue(value);
               setIsCreatingNew(true);
               onChange('');
             }}
@@ -93,12 +98,15 @@ export function SelectDashboard({
             variant="outline"
             size="icon"
             icon={ArrowLeftIcon}
+            aria-label="Back to dashboard selection"
             onClick={() => {
               setIsCreatingNew(false);
               setNewDashboardName('');
+              onChange(previousValue);
             }}
           />
           <Input
+            id={newDashboardNameId}
             placeholder="Enter dashboard name"
             value={newDashboardName}
             onChange={(e) => setNewDashboardName(e.target.value)}

--- a/apps/start/src/components/dashboards/select-dashboard.tsx
+++ b/apps/start/src/components/dashboards/select-dashboard.tsx
@@ -2,12 +2,9 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { handleError, useTRPC } from '@/integrations/trpc/react';
-import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeftIcon, PlusIcon, SaveIcon } from 'lucide-react';
 import { useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { z } from 'zod';
 
 export function SelectDashboard({
   value,
@@ -25,13 +22,6 @@ export function SelectDashboard({
   const [isCreatingNew, setIsCreatingNew] = useState(false);
   const [newDashboardName, setNewDashboardName] = useState('');
 
-  const form = useForm({
-    resolver: zodResolver(z.object({ name: z.string().min(1, 'Required') })),
-    defaultValues: {
-      name: '',
-    },
-  });
-
   const dashboardQuery = useQuery(
     trpc.dashboard.list.queryOptions({
       projectId,
@@ -47,7 +37,6 @@ export function SelectDashboard({
         onChange(res.id);
         setIsCreatingNew(false);
         setNewDashboardName('');
-        form.reset();
       },
     }),
   );
@@ -79,6 +68,7 @@ export function SelectDashboard({
               type="button"
               key={dashboard.id}
               variant={value === dashboard.id ? 'default' : 'outline'}
+              aria-pressed={value === dashboard.id}
               onClick={() => onChange(dashboard.id)}
             >
               {dashboard.name}
@@ -106,7 +96,6 @@ export function SelectDashboard({
             onClick={() => {
               setIsCreatingNew(false);
               setNewDashboardName('');
-              form.reset();
             }}
           />
           <Input

--- a/apps/start/src/components/report/report-item.tsx
+++ b/apps/start/src/components/report/report-item.tsx
@@ -7,7 +7,12 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/utils/cn';
-import { CopyIcon, MoreHorizontal, Trash } from 'lucide-react';
+import {
+  CopyIcon,
+  LayoutPanelTopIcon,
+  MoreHorizontal,
+  Trash,
+} from 'lucide-react';
 
 import { timeWindows } from '@openpanel/constants';
 
@@ -41,6 +46,7 @@ export function ReportItem({
   interval,
   onDelete,
   onDuplicate,
+  onMove,
 }: {
   report: any;
   organizationId: string;
@@ -51,6 +57,7 @@ export function ReportItem({
   interval: any;
   onDelete: (reportId: string) => void;
   onDuplicate: (reportId: string) => void;
+  onMove?: (reportId: string) => void;
 }) {
   const router = useRouter();
   const chartRange = report.range;
@@ -149,6 +156,17 @@ export function ReportItem({
                 <CopyIcon size={16} className="mr-2" />
                 Duplicate
               </DropdownMenuItem>
+              {onMove && (
+                <DropdownMenuItem
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onMove(report.id);
+                  }}
+                >
+                  <LayoutPanelTopIcon size={16} className="mr-2" />
+                  Move to dashboard
+                </DropdownMenuItem>
+              )}
               <DropdownMenuGroup>
                 <DropdownMenuItem
                   className="text-destructive"

--- a/apps/start/src/modals/index.tsx
+++ b/apps/start/src/modals/index.tsx
@@ -28,6 +28,7 @@ import EditReport from './edit-report';
 import EventDetails from './event-details';
 import InsightDetails from './insight-details';
 import Instructions from './Instructions';
+import MoveReport from './move-report';
 import OverviewChartDetails from './overview-chart-details';
 import OverviewFilters from './overview-filters';
 import TableFilters from './table-filters';
@@ -66,6 +67,7 @@ const modals = {
   ConfirmDeleteAccount,
   ConfirmDeleteOrganization,
   SaveReport,
+  MoveReport,
   AddDashboard,
   EditDashboard,
   EditReport,

--- a/apps/start/src/modals/move-report.tsx
+++ b/apps/start/src/modals/move-report.tsx
@@ -1,0 +1,99 @@
+import { ButtonContainer } from '@/components/button-container';
+import { SelectDashboard } from '@/components/dashboards/select-dashboard';
+import { Button } from '@/components/ui/button';
+import { useAppParams } from '@/hooks/use-app-params';
+import { handleError, useTRPC } from '@/integrations/trpc/react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Controller, useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+import { popModal } from '.';
+import { ModalContent, ModalHeader } from './Modal/Container';
+
+type MoveReportProps = {
+  reportId: string;
+  dashboardId: string;
+};
+
+const validator = z.object({
+  dashboardId: z.string().min(1, 'Required'),
+});
+
+type IForm = z.infer<typeof validator>;
+
+export default function MoveReport({
+  reportId,
+  dashboardId,
+}: MoveReportProps) {
+  const queryClient = useQueryClient();
+  const { projectId } = useAppParams();
+
+  const trpc = useTRPC();
+  const move = useMutation(
+    trpc.report.move.mutationOptions({
+      onError: handleError,
+      onSuccess() {
+        queryClient.invalidateQueries(trpc.report.list.pathFilter());
+        queryClient.invalidateQueries(trpc.dashboard.list.pathFilter());
+        toast('Report moved');
+        popModal();
+      },
+    }),
+  );
+
+  const { handleSubmit, formState, control } = useForm<IForm>({
+    resolver: zodResolver(validator),
+    defaultValues: {
+      dashboardId: '',
+    },
+  });
+
+  return (
+    <ModalContent>
+      <ModalHeader title="Move report" />
+      <form
+        className="flex flex-col gap-4"
+        onSubmit={handleSubmit((values) => {
+          move.mutate({
+            reportId,
+            dashboardId: values.dashboardId,
+          });
+        })}
+      >
+        <Controller
+          control={control}
+          name="dashboardId"
+          render={({ field }) => {
+            return (
+              <SelectDashboard
+                value={field.value}
+                onChange={field.onChange}
+                projectId={projectId!}
+                excludeDashboardId={dashboardId}
+              />
+            );
+          }}
+        />
+        <ButtonContainer>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => popModal()}
+            size="default"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            disabled={!formState.isValid || move.isPending}
+            size="default"
+          >
+            Move
+          </Button>
+        </ButtonContainer>
+      </form>
+    </ModalContent>
+  );
+}

--- a/apps/start/src/modals/save-report.tsx
+++ b/apps/start/src/modals/save-report.tsx
@@ -1,7 +1,7 @@
 import { ButtonContainer } from '@/components/button-container';
+import { SelectDashboard } from '@/components/dashboards/select-dashboard';
 import { InputWithLabel } from '@/components/forms/input-with-label';
 import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
 import { useAppParams } from '@/hooks/use-app-params';
 import { handleError } from '@/integrations/trpc/react';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -12,11 +12,8 @@ import { z } from 'zod';
 
 import type { IReport } from '@openpanel/validation';
 
-import { Input } from '@/components/ui/input';
 import { useTRPC } from '@/integrations/trpc/react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { ArrowLeftIcon, PlusIcon, SaveIcon } from 'lucide-react';
-import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { popModal } from '.';
 import { ModalContent, ModalHeader } from './Modal/Container';
 
@@ -148,131 +145,3 @@ export default function SaveReport({
   );
 }
 
-function SelectDashboard({
-  value,
-  onChange,
-  projectId,
-}: {
-  value: string;
-  onChange: (value: string) => void;
-  projectId: string;
-}) {
-  const trpc = useTRPC();
-  const queryClient = useQueryClient();
-  const [isCreatingNew, setIsCreatingNew] = useState(false);
-  const [newDashboardName, setNewDashboardName] = useState('');
-
-  const form = useForm({
-    resolver: zodResolver(z.object({ name: z.string().min(1, 'Required') })),
-    defaultValues: {
-      name: '',
-    },
-  });
-
-  const dashboardQuery = useQuery(
-    trpc.dashboard.list.queryOptions({
-      projectId: projectId!,
-    }),
-  );
-
-  const dashboardMutation = useMutation(
-    trpc.dashboard.create.mutationOptions({
-      onError: handleError,
-      async onSuccess(res) {
-        queryClient.invalidateQueries(trpc.dashboard.list.pathFilter());
-        await dashboardQuery.refetch();
-        onChange(res.id);
-        setIsCreatingNew(false);
-        setNewDashboardName('');
-        form.reset();
-      },
-    }),
-  );
-
-  const handleSelectChange = (selectedValue: string) => {
-    if (selectedValue === 'create-new') {
-      setIsCreatingNew(true);
-      onChange(''); // Clear the current selection
-    } else {
-      setIsCreatingNew(false);
-      onChange(selectedValue);
-    }
-  };
-
-  const handleCreateDashboard = () => {
-    if (newDashboardName.trim()) {
-      dashboardMutation.mutate({
-        name: newDashboardName.trim(),
-        projectId,
-      });
-    }
-  };
-
-  const selectedDashboard = dashboardQuery.data?.find((d) => d.id === value);
-
-  return (
-    <div className="space-y-3">
-      <Label>Dashboard</Label>
-
-      {!isCreatingNew ? (
-        <div className="row gap-2 flex-wrap">
-          {dashboardQuery.data?.map((dashboard) => (
-            <Button
-              type="button"
-              key={dashboard.id}
-              variant={value === dashboard.id ? 'default' : 'outline'}
-              onClick={() => onChange(dashboard.id)}
-            >
-              {dashboard.name}
-            </Button>
-          ))}
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => {
-              setIsCreatingNew(true);
-              onChange('');
-            }}
-            icon={PlusIcon}
-          >
-            Create new dashboard
-          </Button>
-        </div>
-      ) : (
-        <div className="flex gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            icon={ArrowLeftIcon}
-            onClick={() => {
-              setIsCreatingNew(false);
-              setNewDashboardName('');
-              form.reset();
-            }}
-          />
-          <Input
-            placeholder="Enter dashboard name"
-            value={newDashboardName}
-            onChange={(e) => setNewDashboardName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                handleCreateDashboard();
-              }
-            }}
-          />
-          <Button
-            type="button"
-            onClick={handleCreateDashboard}
-            disabled={!newDashboardName.trim() || dashboardMutation.isPending}
-            variant="outline"
-            icon={SaveIcon}
-          >
-            {dashboardMutation.isPending ? 'Creating...' : 'Create'}
-          </Button>
-        </div>
-      )}
-    </div>
-  );
-}

--- a/apps/start/src/routes/_app.$organizationId.$projectId.dashboards_.$dashboardId.tsx
+++ b/apps/start/src/routes/_app.$organizationId.$projectId.dashboards_.$dashboardId.tsx
@@ -412,6 +412,9 @@ function Component() {
                 onDuplicate={(reportId) => {
                   reportDuplicate.mutate({ reportId });
                 }}
+                onMove={(reportId) => {
+                  pushModal('MoveReport', { reportId, dashboardId });
+                }}
               />
             </div>
           ))}

--- a/packages/trpc/src/routers/report.ts
+++ b/packages/trpc/src/routers/report.ts
@@ -9,7 +9,11 @@ import {
 import { zReport } from '@openpanel/validation';
 
 import { getProjectAccess } from '../access';
-import { TRPCForbiddenError, TRPCNotFoundError } from '../errors';
+import {
+  TRPCBadRequestError,
+  TRPCForbiddenError,
+  TRPCNotFoundError,
+} from '../errors';
 import { createTRPCRouter, protectedProcedure } from '../trpc';
 
 export const reportRouter = createTRPCRouter({
@@ -119,6 +123,69 @@ export const reportRouter = createTRPCRouter({
           endDate: report.range === 'custom' ? report.endDate : null,
         },
       });
+    }),
+  move: protectedProcedure
+    .input(
+      z.object({
+        reportId: z.string(),
+        dashboardId: z.string(),
+      }),
+    )
+    .mutation(async ({ input: { reportId, dashboardId }, ctx }) => {
+      const report = await db.report.findUniqueOrThrow({
+        where: {
+          id: reportId,
+        },
+      });
+
+      const access = await getProjectAccess({
+        userId: ctx.session.userId,
+        projectId: report.projectId,
+      });
+
+      if (!access) {
+        throw new TRPCForbiddenError('You do not have access to this project');
+      }
+
+      if (report.dashboardId === dashboardId) {
+        throw new TRPCBadRequestError('Report is already on this dashboard');
+      }
+
+      const dashboard = await db.dashboard.findUniqueOrThrow({
+        where: {
+          id: dashboardId,
+        },
+      });
+
+      // A report keeps its own projectId and that is what powers the chart
+      // queries, public shares included. Moving it to a dashboard in another
+      // project would expose the source project through the target project.
+      if (dashboard.projectId !== report.projectId) {
+        throw new TRPCBadRequestError(
+          'You can only move a report to a dashboard in the same project',
+        );
+      }
+
+      const [, moved] = await db.$transaction([
+        // The layout belongs to the report, not the dashboard. Keeping it would
+        // drop the report on top of whatever already sits at those coordinates
+        // in the target dashboard.
+        db.reportLayout.deleteMany({
+          where: {
+            reportId,
+          },
+        }),
+        db.report.update({
+          where: {
+            id: reportId,
+          },
+          data: {
+            dashboardId,
+          },
+        }),
+      ]);
+
+      return moved;
     }),
   delete: protectedProcedure
     .input(


### PR DESCRIPTION
Closes the UserJot request from Victoria: move a report between dashboards without deleting and recreating it.

## What changed

- New `move` procedure in `packages/trpc/src/routers/report.ts`. It runs `reportLayout.deleteMany` and `report.update` in one transaction, so the report's grid position on the old dashboard is cleared as part of the move. Cross-project moves throw `BAD_REQUEST`. Access control matches the existing `update`, `delete`, and `duplicate` procedures exactly.
- Extracted `SelectDashboard` into `apps/start/src/components/dashboards/select-dashboard.tsx` and added an `excludeDashboardId` prop. This is not a `<Select>` element, it's a row of buttons plus an inline create-new input, pulled out of the save-report flow as-is.
- New `move-report.tsx` modal.
- `report-item.tsx` gets an optional `onMove` prop.
- The dashboard route wires the modal in.

## Verification

`tsc --noEmit` is clean in both `packages/trpc` and `apps/start`. No database migration is needed.

## Notes for reviewers

The old inline dashboard picker had two dead bindings, `handleSelectChange` and `selectedDashboard`. Neither was referenced in the JSX. They weren't carried over.

`biome check --write` rewrites large amounts of unrelated code in every touched file, so it wasn't used as a gate here. Those rewrites were reverted and the edits reapplied by hand to keep the diff scoped to this feature. For what it's worth, `edit-dashboard.tsx` fails biome unmodified at HEAD, so this isn't new.

## Questions for reviewers

These are product decisions, not implementation details, so I'd rather ask than guess:

1. Should cross-project moves stay rejected permanently, or is `BAD_REQUEST` here a temporary restriction until that's supported?
2. Every move drops the report's grid position. Is that acceptable, or should the layout carry over, or get placed deliberately on the target dashboard?
3. Moving a report to the dashboard it's already on returns `BAD_REQUEST`. The UI already excludes that option from the picker, so is that response worth keeping, or should it just be a no-op?

## Out of scope

`report.list` (`packages/trpc/src/routers/report.ts:16-29`) and `dashboard.list` (`packages/trpc/src/routers/dashboard.ts:18-26`) don't call `getProjectAccess`, and no report procedure checks `AccessLevel`. The new `move` procedure matches its neighbours rather than diverging from them. This is a pre-existing gap and probably deserves its own issue rather than being fixed in passing here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Move reports between dashboards from the report actions menu.
  * Select an existing dashboard or create a new one when saving reports.
  * Dashboard selection preserves the previous choice when returning from creation, with improved keyboard and accessibility support.
* **Bug Fixes**
  * Prevent invalid moves, including transfers to the current dashboard or another project.
  * Reports refresh automatically after moving, with confirmation and error feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->