### PR TITLE
perf(properties): list event property keys via GROUP BY so the projection applies

### DIFF
--- a/packages/db/src/services/event.service.ts
+++ b/packages/db/src/services/event.service.ts
@@ -1251,14 +1251,23 @@ export async function listEventPropertiesCore(input: {
   columns: readonly string[];
   properties: Array<{ property_key: string; event_name: string }>;
 }> {
+  // GROUP BY rather than DISTINCT: both return the same set of
+  // (property_key, name) pairs, but a multi-column DISTINCT cannot be matched
+  // against the epv_keys aggregating projection, so it degrades to a full scan
+  // of the project's MV slice. `name` is a tie-breaker for the ORDER BY —
+  // without it the LIMIT slices an arbitrary subset of the rows sharing a
+  // property_key, which is also what made the two spellings return different
+  // windows.
   const builder = clix(ch)
     .select<{ property_key: string; event_name: string }>([
-      'distinct property_key',
+      'property_key',
       'name as event_name',
     ])
     .from(TABLE_NAMES.event_property_values_mv)
     .where('project_id', '=', input.projectId)
+    .groupBy(['property_key', 'name'])
     .orderBy('property_key', 'ASC')
+    .orderBy('name', 'ASC')
     .limit(500);
 
   if (input.eventName) {

--- a/packages/mcp/src/tools/analytics/property-values.ts
+++ b/packages/mcp/src/tools/analytics/property-values.ts
@@ -26,14 +26,20 @@ export function registerPropertyValueTools(
     async ({ projectId: inputProjectId, eventName }) =>
       withErrorHandling(async () => {
         const projectId = await resolveProjectId(context, inputProjectId);
+        // GROUP BY rather than DISTINCT so the epv_keys projection can serve
+        // this (a multi-column DISTINCT cannot be matched against an
+        // aggregating projection); `name` tie-breaks the ORDER BY so the
+        // LIMIT window is deterministic. See listEventPropertiesCore.
         const builder = clix(ch)
           .select<{ property_key: string; event_name: string }>([
-            'distinct property_key',
+            'property_key',
             'name as event_name',
           ])
           .from(TABLE_NAMES.event_property_values_mv)
           .where('project_id', '=', projectId)
+          .groupBy(['property_key', 'name'])
           .orderBy('property_key', 'ASC')
+          .orderBy('name', 'ASC')
           .limit(500);
 
         if (eventName) {


### PR DESCRIPTION
Follow-up to #446 — the last property-picker path still doing a full scan.

## Problem

`listEventPropertiesCore` and the identical MCP `list_event_properties` tool select `DISTINCT property_key, name`. A **multi-column `DISTINCT` cannot be matched against an aggregating projection**, so neither query can use `epv_keys` and both full-scan the project's slice of `event_property_values_mv`.

Measured on a 1.64B-row MV (real deployment, warm):

| form | rows read | time | bytes |
|---|---|---|---|
| `SELECT DISTINCT property_key, name` (today) | **1,639,500,093** | **20.2s** | **48.3 GiB** |
| `GROUP BY property_key, name` (this PR) | **77,832** | **0.02s** | **0.003 GiB** |

Same 500 rows. `EXPLAIN` confirms the rewrite reads `epv_keys` (14 of 200,142 granules) where the `DISTINCT` form reads the base table in full.

## Equivalence

The two spellings return the **identical set** of `(property_key, name)` pairs — verified on a frozen slice of the same MV: 30,169 rows from each, with identical `cityHash64` checksums.

One wrinkle worth stating explicitly: the existing `ORDER BY property_key ASC` does **not** determine which rows `LIMIT 500` keeps. On the deployment above, ~30K pairs span only ~10 distinct keys inside that window, so the tie groups are large and the two spellings sliced *different* 500-row windows even though the underlying sets matched. This PR therefore also adds **`name` as an ORDER BY tie-breaker**, which makes the output deterministic and the two forms byte-identical — verified row for row.

So the change is: same result set, now deterministic, served from the projection.

## Scope

Both call sites (`packages/db` service + `packages/mcp` tool) — they carried the same query. Pure query-shape change: no signature, return type, or consumer changes; both still built with `clix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event property listings to return unique property and event-name combinations.
  * Results are now consistently sorted by property key and event name for more predictable display and analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->