### PR TITLE
feat(dashboard): mark built-in properties with $ in the property picker

### DIFF
--- a/apps/start/src/components/report/sidebar/PropertiesCombobox.tsx
+++ b/apps/start/src/components/report/sidebar/PropertiesCombobox.tsx
@@ -93,6 +93,27 @@ const DEFAULT_CATEGORIES: PropertiesComboboxCategory[] = [
   'group',
 ];
 
+// Built-in ("reserved") properties — the geo/device/session columns and the
+// built-in profile fields — carry no `properties.` / `profile.properties.`
+// prefix. A client-sent property can share the same name (built-in geo-IP
+// `country` vs a `properties.country` the SDK sends), so both render as just
+// "country" with no way to tell them apart. Mark the built-ins with a leading
+// `$` (the reserved-property convention). Display only — the selected `value`,
+// and the filter it produces, is the raw property, unchanged.
+function toPropertyAction(property: string): PropertiesComboboxAction {
+  const reserved =
+    !property.startsWith('properties.') &&
+    !property.startsWith('profile.properties.');
+  const name = property.split('.').pop() ?? property;
+  return {
+    value: property,
+    label: reserved ? `$${name}` : name,
+    description: reserved
+      ? 'OpenPanel'
+      : property.split('.').slice(0, -1).join('.'),
+  };
+}
+
 function SearchHeader({
   onBack,
   onSearch,
@@ -189,21 +210,13 @@ export function PropertiesCombobox({
       (property) =>
         property.startsWith('profile') && shouldShowProperty(property)
     )
-    .map((property) => ({
-      value: property,
-      label: property.split('.').pop() ?? property,
-      description: property.split('.').slice(0, -1).join('.'),
-    }));
+    .map(toPropertyAction);
   const eventActions = allProperties
     .filter(
       (property) =>
         !property.startsWith('profile') && shouldShowProperty(property)
     )
-    .map((property) => ({
-      value: property,
-      label: property.split('.').pop() ?? property,
-      description: property.split('.').slice(0, -1).join('.'),
-    }));
+    .map(toPropertyAction);
   const sessionActions = SESSION_ACTIONS.filter((a) =>
     shouldShowProperty(a.value),
   );


### PR DESCRIPTION
## Problem

The property picker renders OpenPanel's **built-in** columns (geo-IP `country`, `os`, `region`, `city`, `browser`, `device`…) and **client-sent** properties (`properties.country` etc.) with the **same label**. When a client sends a property that shares a built-in name, the picker shows **two identical "country" rows** — one for the geo-IP column, one for `properties.country` — with no way to tell them apart.

## Fix

Mark built-in ("reserved") properties — anything not under `properties.` / `profile.properties.` — with a leading **`$`** (reserved-property convention), subtext **"OpenPanel"**:

```
$country      OpenPanel      ← built-in geo-IP column
country       properties     ← client-sent properties.country
```

**Display only** — the selected `value` (and the filter/breakdown it produces) is the raw property, unchanged, so saved reports keep working; search still matches (`$country` contains "country"). Applies to both the event and profile property lists.

One file: `apps/start/src/components/report/sidebar/PropertiesCombobox.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved property action labels in the report sidebar.
  * Reserved properties now display with the correct `$` prefix and panel description.
  * Client properties retain their derived names and namespace descriptions.
  * Selected property values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->