### PR TITLE
fix(common): don't drop device overrides when the user agent looks like a server

### DIFF
--- a/packages/common/server/parser-user-agent.test.ts
+++ b/packages/common/server/parser-user-agent.test.ts
@@ -128,6 +128,43 @@ describe('parseUserAgent', () => {
       model: 'Custom Model',
     });
   });
+
+  it('should apply overrides on a non-browser sdk user agent', () => {
+    // A native SDK sends a plain name/version UA, which the server heuristic
+    // matches, but it also states what the device is. The overrides win.
+    const ua = 'my-sdk/1.0.0';
+    const overrides = {
+      __os: 'Android',
+      __osVersion: '13',
+      __device: 'mobile',
+      __brand: 'Acme',
+      __model: 'A105',
+    };
+
+    expect(parseUserAgent(ua, overrides)).toEqual({
+      isServer: false,
+      device: 'mobile',
+      os: 'Android',
+      osVersion: '13',
+      browser: undefined,
+      browserVersion: undefined,
+      brand: 'Acme',
+      model: 'A105',
+    });
+  });
+
+  it('should still be a server when a non-browser user agent sends no device overrides', () => {
+    expect(parseUserAgent('my-sdk/1.0.0', { __ip: '1.2.3.4' })).toEqual({
+      isServer: true,
+      device: 'server',
+      os: '',
+      osVersion: '',
+      browser: '',
+      browserVersion: '',
+      brand: '',
+      model: '',
+    });
+  });
 });
 
 describe('getDevice', () => {

--- a/packages/common/server/parser-user-agent.ts
+++ b/packages/common/server/parser-user-agent.ts
@@ -247,7 +247,10 @@ export function parseUserAgent(
   if (!ua) return parsedServerUa;
   const res = parse(ua);
 
-  if (isServer(res)) {
+  // A native SDK sends a plain name/version UA, which the server heuristic
+  // matches, but it also states what device it is running on. Trust that over
+  // the heuristic, otherwise the overrides are silently dropped.
+  if (isServer(res) && !hasDeviceOverrides(overrides)) {
     return parsedServerUa;
   }
 
@@ -285,6 +288,15 @@ export function parseUserAgent(
     model,
     isServer: false,
   } as const;
+}
+
+const DEVICE_OVERRIDE_KEYS = ['__os', '__device', '__brand', '__model'] as const;
+
+function hasDeviceOverrides(overrides?: Record<string, unknown>) {
+  if (!overrides) return false;
+  return DEVICE_OVERRIDE_KEYS.some(
+    (key) => typeof overrides[key] === 'string' && overrides[key] !== '',
+  );
 }
 
 function isServer(res: UAParser.IResult) {


### PR DESCRIPTION
fixes #466

`parseUserAgent` returned `parsedServerUa` before it ever looked at `overrides`, so `__os`, `__model`, `__brand` and `__device` were silently dropped for any sdk whose user agent matches the server heuristic. that is every non-browser sdk, since a plain `name/version` string is what `SINGLE_NAME_VERSION_REGEX` matches.

the shortcut is now taken only when the caller has not said what the device is.

behaviour change worth flagging: events from native sdks that send device overrides are no longer treated as server events, so in `events.incoming-event.ts` they open their own session with a real `deviceId` instead of riding along on an existing one with an empty one. that is the point of the fix, but it does change what lands in clickhouse for anyone already sending overrides from a non-browser sdk.

two tests added to `parser-user-agent.test.ts`: a native sdk ua plus overrides resolves to the real device (fails on main), and the same ua with no device overrides is still a server (passes on main, there to show the shortcut is intact).

`@openpanel/common` suite: 63 passed. typecheck clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device detection for non-browser SDK user agents with device information overrides.
  * Preserved operating system, device, brand, and model details instead of incorrectly classifying these requests as server devices.
  * IP-only overrides continue to use server-device detection as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->