### PR TITLE
chore(cohorts): drop the superseded profile-keyed summary MVs

### DIFF
--- a/packages/db/code-migrations/23-drop-old-cohort-summary-mvs.ts
+++ b/packages/db/code-migrations/23-drop-old-cohort-summary-mvs.ts
@@ -1,0 +1,48 @@
+import { TABLE_NAMES } from '../src/clickhouse/client';
+import {
+  dropTable,
+  runClickhouseMigrationCommands,
+} from '../src/clickhouse/migration';
+import { getIsCluster } from './helpers';
+
+/**
+ * Drop the profile-keyed cohort summary MVs superseded by migration 20.
+ *
+ *   - profile_event_summary_mv           (created in migration 13)
+ *   - profile_event_property_summary_mv  (created in migration 14)
+ *
+ * Migration 20 created replacements keyed for the queries that read them,
+ * migration 21 filled them with history, and cohort.service has read the new
+ * tables since. The old pair kept receiving inserts so the change stayed
+ * revertible by pointer while the new tables were verified. Nothing reads
+ * them now, so they are two MV triggers firing on every event insert for no
+ * consumer.
+ *
+ * Clustered installs have two objects per MV: `<name>` is the Distributed
+ * table and `<name>_replicated` is the materialized view itself. The
+ * Distributed table goes first so nothing can route a read at a view that is
+ * mid-drop. Dropping the view takes its implicit `.inner_id.<uuid>` storage
+ * with it, so there is no third name to clean up.
+ *
+ * Deliberately one-way. The aggregated history goes with the tables, and
+ * rerunning migrations 13 and 14 would only bring back empty structure, so a
+ * down() would be a rollback in name only. If you need them back, those two
+ * migrations hold the definitions and migration 15 the backfill.
+ */
+
+const SUPERSEDED_MVS = [
+  TABLE_NAMES.profile_event_summary_mv,
+  TABLE_NAMES.profile_event_property_summary_mv,
+];
+
+export async function up() {
+  const isClustered = getIsCluster();
+
+  const sqls = SUPERSEDED_MVS.flatMap((name) =>
+    isClustered
+      ? [dropTable(name, true), dropTable(`${name}_replicated`, true)]
+      : [dropTable(name, false)],
+  );
+
+  await runClickhouseMigrationCommands(sqls);
+}

--- a/packages/db/src/clickhouse/client.ts
+++ b/packages/db/src/clickhouse/client.ts
@@ -66,6 +66,8 @@ export const TABLE_NAMES = {
   groups: 'groups',
   cohort_members: 'cohort_members',
   cohort_metadata: 'cohort_metadata',
+  // Superseded by the two event_*_summary_mv entries above and dropped in
+  // migration 23. Kept because migrations 13, 14 and 15 still name them.
   profile_event_summary_mv: 'profile_event_summary_mv',
   // Same content as the two MVs above, keyed for the cohort criteria that
   // read them (event + window first, profile last) rather than by profile.

--- a/packages/db/src/services/delete.service.ts
+++ b/packages/db/src/services/delete.service.ts
@@ -49,8 +49,6 @@ export async function deleteFromClickhouse(projectIds: string[]) {
     TABLE_NAMES.event_property_values_mv,
     TABLE_NAMES.cohort_members,
     TABLE_NAMES.cohort_metadata,
-    TABLE_NAMES.profile_event_summary_mv,
-    TABLE_NAMES.profile_event_property_summary_mv,
     TABLE_NAMES.event_profile_summary_mv,
     TABLE_NAMES.event_property_profile_summary_mv,
   ];


### PR DESCRIPTION
Follow-up to #458, as discussed.

## Why now

#458 replaced `profile_event_summary_mv` and `profile_event_property_summary_mv` with pairs keyed for the queries that actually read them (migration 20), filled those with history (migration 21), and pointed `cohort.service` at the new tables.

The old pair was deliberately left in place and kept receiving inserts, so the change stayed revertible by pointer while the new tables were verified. Nothing reads them now, so all they do is fire two extra MV triggers on every event insert for no consumer. This drops them.

## What changes

`23-drop-old-cohort-summary-mvs.ts` drops the two views.

`delete.service` stops naming them. That part isn't cosmetic: `ALTER TABLE ... DELETE` against a dropped table is `UNKNOWN_TABLE`, so leaving those entries would break project deletion. Confirmed against the post-drop schema:

```
Code: 60. DB::Exception: Could not find table: profile_event_summary_mv. (UNKNOWN_TABLE)
```

Their `TABLE_NAMES` entries stay, with a comment saying why: migrations 13, 14 and 15 still reference them and have to keep compiling. Happy to inline the literals in those three and remove the constants instead, if you'd rather not carry them.

## Clusters

A clustered install has two objects per MV: `<name>` is the Distributed table and `<name>_replicated` is the view itself. The Distributed table is dropped first so nothing can route a read at a view that's mid-drop. Dropping the view takes its implicit `.inner_id.<uuid>` storage with it, so there's no third name to clean up (verified: inner table count goes 8 → 6 on both nodes).

## Testing

Standalone ClickHouse 26.1.3 and a keeper-backed **2-shard** cluster on 25.3, each built from an empty database through migration 21 before dropping.

| | standalone | 2-shard cluster |
|---|---|---|
| Both MVs gone | yes | yes, on both nodes |
| Inner storage tables released | 8 → 6 | 8 → 6 on both nodes |
| Cohort reads still resolve | 50 profiles | 50 from either node |
| Ingestion after the drop | continues | continues |
| Second run | no-op | no-op |
| Every statement `delete.service` emits | 11/11 accepted | 11/11 accepted |

## One-way

No `down()`. The aggregated history goes with the tables, and rerunning migrations 13 and 14 would only bring back empty structure, so a `down()` here would be a rollback in name only. The header notes where the definitions live if anyone ever needs them back.

## Unrelated, but worth flagging

`main` currently has duplicate migration numbers: `20-cohort-summary-mv-sort-key` alongside `20-invite-project-access-levels`, and `21-backfill-cohort-summary-mvs` alongside `21-wind-down-onboarding-pointer`. `migrate.ts` sorts on the numeric prefix, so ties fall back to `readdirSync` order, which is filesystem-dependent. Harmless for these pairs since they're independent, but it's a latent ordering hazard. I numbered this one 23 to stay clear of `22-add-events-inserted-at`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Removed obsolete cohort summary data views from ClickHouse installations.
  * Updated data cleanup behavior to stop targeting retired summary views.
  * Preserved compatibility for existing migrations that reference legacy views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->