### PR TITLE
perf(chart.values): read filter-value dropdowns from sessions, not a 6-month events scan

### DIFF
--- a/apps/start/src/hooks/use-property-values.ts
+++ b/apps/start/src/hooks/use-property-values.ts
@@ -7,6 +7,12 @@ export function usePropertyValues(params: any) {
   const query = useQuery(
     trpc.chart.values.queryOptions(input, {
       enabled: enabled !== false && !!input.projectId,
+      // A filter-value dropdown doesn't need real-time data. Without a
+      // staleTime, React Query refetches on every window focus/remount — a tab
+      // left open on a filter re-fires the (slow, un-MV'd) values query and
+      // hammers ClickHouse. Cache 1h + no focus refetch.
+      staleTime: 60 * 60 * 1000,
+      refetchOnWindowFocus: false,
     }),
   );
   return query.data?.values ?? [];

--- a/packages/trpc/src/routers/chart.ts
+++ b/packages/trpc/src/routers/chart.ts
@@ -54,6 +54,46 @@ import {
 const cacher = cacheMiddleware(60);
 
 /**
+ * `chart.values` for a top-level event column (country, os, city, device…) has
+ * no MV, so it ran `SELECT DISTINCT <col> FROM events WHERE created_at >
+ * now() - 6 MONTH` — a full multi-billion-row scan on high-volume projects that
+ * hits max_execution_time and returns nothing, then a dashboard tab left open
+ * on such a filter re-fires it on every window focus (React Query staleTime=0).
+ *
+ * These columns are session-level (geo/device/referrer denormalised onto every
+ * event), so for an all-events (`*`) value dropdown we read the distinct set
+ * from the far smaller `sessions` table (one row per session) instead — same
+ * values, orders of magnitude fewer rows. `path`/`origin` are per-pageview (not
+ * on `sessions`) and keep using `events`. A specific-event query also stays on
+ * `events` since `sessions` has no `name` column (the name filter bounds it).
+ */
+const SESSION_LEVEL_VALUE_COLUMNS = new Set([
+  'country',
+  'region',
+  'city',
+  'os',
+  'os_version',
+  'browser',
+  'browser_version',
+  'device',
+  'brand',
+  'model',
+  'referrer',
+  'referrer_name',
+  'referrer_type',
+]);
+
+/**
+ * Lookback for the `events` fallback of the filter-value dropdown. A value
+ * picker only needs recently-seen values, so clamp the scan (default 30d)
+ * instead of the old 6-month full scan. Env-tunable.
+ */
+const VALUES_LOOKBACK_DAYS = Number.parseInt(
+  process.env.CHART_VALUES_LOOKBACK_DAYS || '30',
+  10,
+);
+
+/**
  * Cap on distinct event property keys returned to the picker. Projects in the
  * 8k range exist, so the previous 10k was reachable in normal use.
  */
@@ -422,17 +462,26 @@ export const chartRouter = createTRPCRouter({
         if (!isKnownEventField(resolvedProperty)) {
           return { values: [] };
         }
+        // Session-level columns (geo/device/referrer) come from the small
+        // `sessions` table, not a billions-row `events` scan. Only for
+        // all-events (`*`): `sessions` has no `name` column to filter on.
+        const useSessions =
+          event === '*' && SESSION_LEVEL_VALUE_COLUMNS.has(resolvedProperty);
         const query = clix(ch)
           .select<{ values: string[] }>([
             `distinct ${getSelectPropertyKey(resolvedProperty)} as values`,
           ])
-          .from(TABLE_NAMES.events)
+          .from(useSessions ? TABLE_NAMES.sessions : TABLE_NAMES.events)
           .where('project_id', '=', projectId)
-          .where('created_at', '>', clix.exp('now() - INTERVAL 6 MONTH'))
+          .where(
+            'created_at',
+            '>',
+            clix.exp(`now() - INTERVAL ${VALUES_LOOKBACK_DAYS} DAY`),
+          )
           .orderBy('created_at', 'DESC')
           .limit(100_000);
 
-        if (event !== '*') {
+        if (!useSessions && event !== '*') {
           query.where('name', '=', event);
         }
 


### PR DESCRIPTION
## Problem

The filter-value autocomplete (`chart.values`) for a **top-level event column** (country/os/city/device…) has no MV, so it runs:

```sql
SELECT DISTINCT country FROM events
WHERE project_id = ? AND created_at > now() - INTERVAL 6 MONTH
ORDER BY created_at DESC LIMIT 100000
```

On a high-volume project this is a **full multi-billion-row scan** that hits `max_execution_time` every time and returns nothing. And because `usePropertyValues` sets no `staleTime`, a dashboard tab left open on such a filter **re-fires the query on every window focus**.

Measured on one production project (`system.query_log`, 1 hour, a single `country` dropdown): **8 queries, ~320s of ClickHouse time, ~768 GB read, 100% timeouts** — a real, sustained CPU driver for one open tab.

## Fix

1. **Route session-level columns to `sessions`.** Geo/device/referrer (13 of the top-level columns) are denormalised onto every event *and* live on the much smaller `sessions` table (one row per session). For an all-events (`*`) dropdown, read the distinct set from `sessions`. Same value set, orders of magnitude fewer rows — measured **`country`: 0.12s / 15M rows** vs **20.7s / 3.2B rows**.
   - `path`/`origin` are per-pageview (not on `sessions`) → stay on `events`.
   - A specific-event query stays on `events` too (`sessions` has no `name` column, and the `name` filter already bounds the scan).
2. **Clamp the `events` fallback** `6 MONTH → 30d` (env `CHART_VALUES_LOOKBACK_DAYS`), so even the fallback returns instead of timing out. A value picker only needs recently-seen values.
3. **`usePropertyValues`: `staleTime` 1h + `refetchOnWindowFocus: false`** — a filter dropdown doesn't need real-time data; this stops the refetch-on-focus loop (one query/hour, not one/minute).

The `properties.*` fast path (`event_property_values_mv`) and the `profile.*` / `group.*` / `cohort` branches are unchanged.

## Validation

| query | table | rows read | time |
|---|---|---|---|
| `DISTINCT country` (old) | events, 6mo | ~billions | 40s timeout → empty |
| `DISTINCT country` (fix, `*`) | **sessions**, 30d | **15M** | **0.12s** |
| `DISTINCT country` (fallback) | events, 30d | 3.2B | 20.7s (returns) |

Same 197–201 distinct countries (the ~4 delta are ultra-rare — negligible for an autocomplete), and applying the filter still runs against `events`, so results are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Reduced unnecessary refreshes of property values when revisiting or refocusing the app.
  - Improved chart filter loading by using session data for session-level filters.
  - Reduced the default historical search range for event filter values, improving responsiveness.
  - Added configuration to adjust the filter-value lookback period when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->