### PR TITLE
Escape timeframe and project id values in ClickHouse queries

### DIFF
--- a/packages/db/src/buffers/event-buffer.test.ts
+++ b/packages/db/src/buffers/event-buffer.test.ts
@@ -254,6 +254,20 @@ describe('EventBuffer', () => {
     querySpy.mockRestore();
   });
 
+  it('escapes the project id in the active visitor query', async () => {
+    const querySpy = vi
+      .spyOn(chClient, 'chQuery')
+      .mockResolvedValueOnce([{ count: 0 }] as any);
+
+    await eventBuffer.getActiveVisitorCount("p9' OR 1=1 --");
+
+    const sql = querySpy.mock.calls[0]![0];
+    expect(sql).toContain("project_id = 'p9\\' OR 1=1 --'");
+    expect(sql).not.toContain("project_id = 'p9' OR");
+
+    querySpy.mockRestore();
+  });
+
   it('handles multiple sessions independently — all events go to buffer', async () => {
     const t0 = Date.now();
     const count1 = await eventBuffer.getBufferSize();

--- a/packages/db/src/buffers/event-buffer.ts
+++ b/packages/db/src/buffers/event-buffer.ts
@@ -1,4 +1,5 @@
 import { getRedisCache, publishEvent } from '@openpanel/redis';
+import sqlstring from 'sqlstring';
 import { ch, chQuery } from '../clickhouse/client';
 import type { IClickhouseEvent } from '../services/event.service';
 import { BaseBuffer } from './base-buffer';
@@ -255,7 +256,7 @@ export class EventBuffer extends BaseBuffer {
     const rows = await chQuery<{ count: number }>(
       `SELECT uniq(profile_id) AS count
        FROM events
-       WHERE project_id = '${projectId}'
+       WHERE project_id = ${sqlstring.escape(projectId)}
          AND profile_id != ''
          AND created_at >= now() - INTERVAL 5 MINUTE`
     );

--- a/packages/db/src/services/cohort.service.test.ts
+++ b/packages/db/src/services/cohort.service.test.ts
@@ -1,0 +1,90 @@
+import type { EventCriteria } from '@openpanel/validation';
+import { describe, expect, it } from 'vitest';
+import { buildEventCriteriaQuery } from './cohort.service';
+
+const PROJECT_ID = 'test-cohort-timeframe';
+
+function criteria(timeframe: EventCriteria['timeframe']): EventCriteria {
+  return {
+    name: 'screen_view',
+    filters: [],
+    timeframe,
+  } as EventCriteria;
+}
+
+/**
+ * Remove every quoted string literal from the SQL, leaving the skeleton the
+ * ClickHouse parser would act on. Anything a caller smuggled in stays inside a
+ * literal if it was escaped properly, so it disappears here; if it broke out,
+ * it shows up in the skeleton.
+ */
+function skeleton(sql: string): string {
+  return sql.replace(/'(?:\\.|[^'\\])*'/g, "''");
+}
+
+// Values that break out of a naive `toDate('${value}')` interpolation.
+const HOSTILE = [
+  "2024-01-01') OR 1=1 --",
+  "2024-01-01'",
+  "2024-01-01') UNION ALL SELECT id FROM profiles --",
+];
+
+describe('buildEventCriteriaQuery timeframe escaping', () => {
+  it.each(HOSTILE)('escapes a hostile start (%s)', (start) => {
+    const sql = buildEventCriteriaQuery(
+      PROJECT_ID,
+      criteria({ type: 'absolute', start })
+    );
+
+    // The value survives as exactly one quoted literal inside toDate(...).
+    expect(sql).toContain(
+      `event_date >= toDate('${start.replace(/'/g, "\\'")}')`
+    );
+    // The parser sees the same shape as a well-formed date: no extra clause,
+    // no early close of the toDate() call, no trailing comment.
+    expect(skeleton(sql)).toContain("event_date >= toDate('')");
+    expect(skeleton(sql)).not.toMatch(/OR|UNION|--/);
+  });
+
+  it.each(HOSTILE)('escapes a hostile end (%s)', (end) => {
+    const sql = buildEventCriteriaQuery(
+      PROJECT_ID,
+      criteria({ type: 'absolute', start: '2024-01-01', end })
+    );
+
+    expect(sql).toContain(
+      `event_date BETWEEN toDate('2024-01-01') AND toDate('${end.replace(/'/g, "\\'")}')`
+    );
+    expect(skeleton(sql)).toContain(
+      "event_date BETWEEN toDate('') AND toDate('')"
+    );
+    expect(skeleton(sql)).not.toMatch(/OR|UNION|--/);
+  });
+
+  it('leaves well-formed dates readable', () => {
+    expect(
+      buildEventCriteriaQuery(
+        PROJECT_ID,
+        criteria({ type: 'absolute', start: '2024-01-01' })
+      )
+    ).toContain("event_date >= toDate('2024-01-01')");
+
+    expect(
+      buildEventCriteriaQuery(
+        PROJECT_ID,
+        criteria({ type: 'absolute', start: '2024-01-01', end: '2024-02-01' })
+      )
+    ).toContain(
+      "event_date BETWEEN toDate('2024-01-01') AND toDate('2024-02-01')"
+    );
+  });
+
+  it('still builds relative timeframes', () => {
+    expect(
+      buildEventCriteriaQuery(
+        PROJECT_ID,
+        criteria({ type: 'relative', value: '30d' })
+      )
+    ).toContain('event_date >= toDate(now() - INTERVAL 30 DAY)');
+  });
+});

--- a/packages/db/src/services/cohort.service.ts
+++ b/packages/db/src/services/cohort.service.ts
@@ -36,11 +36,11 @@ function buildTimeConstraint(timeframe: Timeframe): string {
     return `created_at >= toDate(now() - INTERVAL ${days} DAY)`;
   }
 
-  const start = timeframe.start;
+  const start = sqlstring.escape(timeframe.start);
   if (timeframe.end) {
-    return `created_at BETWEEN toDate('${start}') AND toDate('${timeframe.end}')`;
+    return `created_at BETWEEN toDate(${start}) AND toDate(${sqlstring.escape(timeframe.end)})`;
   }
-  return `created_at >= toDate('${start}')`;
+  return `created_at >= toDate(${start})`;
 }
 
 function getFrequencyOperator(frequency: Frequency): string {

--- a/packages/validation/src/cohort.validation.test.ts
+++ b/packages/validation/src/cohort.validation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { zAbsoluteTimeframe } from './cohort.validation';
+
+describe('zAbsoluteTimeframe', () => {
+  it('accepts a date without an end', () => {
+    expect(
+      zAbsoluteTimeframe.safeParse({ type: 'absolute', start: '2024-01-01' })
+        .success
+    ).toBe(true);
+  });
+
+  it('accepts a date range', () => {
+    expect(
+      zAbsoluteTimeframe.safeParse({
+        type: 'absolute',
+        start: '2024-01-01',
+        end: '2024-02-01',
+      }).success
+    ).toBe(true);
+  });
+
+  it.each([
+    "2024-01-01') OR 1=1 --",
+    '2024-1-1',
+    'yesterday',
+    '',
+  ])('rejects a non-date start (%s)', (start) => {
+    expect(
+      zAbsoluteTimeframe.safeParse({ type: 'absolute', start }).success
+    ).toBe(false);
+  });
+
+  it('rejects a non-date end', () => {
+    expect(
+      zAbsoluteTimeframe.safeParse({
+        type: 'absolute',
+        start: '2024-01-01',
+        end: "2024-01-01') --",
+      }).success
+    ).toBe(false);
+  });
+});

--- a/packages/validation/src/cohort.validation.ts
+++ b/packages/validation/src/cohort.validation.ts
@@ -29,10 +29,15 @@ export const zRelativeTimeframe = z.object({
   value: z.enum(['7d', '30d', '90d', '180d', '365d']),
 });
 
+// toDate() in the cohort query builder only understands plain calendar dates.
+const zDate = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Expected a date in YYYY-MM-DD format');
+
 export const zAbsoluteTimeframe = z.object({
   type: z.literal('absolute'),
-  start: z.string(),
-  end: z.string().optional(),
+  start: zDate,
+  end: zDate.optional(),
 });
 
 export const zTimeframe = z.discriminatedUnion('type', [

--- a/packages/validation/vitest.config.ts
+++ b/packages/validation/vitest.config.ts
@@ -1,0 +1,3 @@
+import { getSharedVitestConfig } from '../../vitest.shared';
+
+export default getSharedVitestConfig({ __dirname });


### PR DESCRIPTION
## What changed

`buildTimeConstraint` in the cohort query builder put the absolute-timeframe `start` and `end` straight into the SQL string, while every other value in the same file goes through `sqlstring.escape`. A date containing a quote came out as SQL the parser read differently from what the builder meant to write. Both values now go through `sqlstring.escape`, matching the rest of the file. `escape` supplies its own quotes, so the literal quotes in the template are gone.

`zAbsoluteTimeframe` accepted any string for `start` and `end`. Both are now constrained to `YYYY-MM-DD`, which is the only shape `toDate()` is being handed here. `end` stays optional. This is a second line rather than a replacement for the escaping.

`getActiveVisitorCount` interpolated `project_id` the same way. Every caller passes an id that already came back from the database, so this is not a behaviour change, just consistency with the queries around it.

## Evidence

- `packages/db/src/services/cohort.service.ts:39-43` — the two raw `toDate('${...}')` interpolations.
- `packages/db/src/services/cohort.service.ts:84`, `:86-88`, `:123`, `:135` — the escaping pattern already used for every other value in the file.
- `packages/validation/src/cohort.validation.ts:32-36` — `start` and `end` as plain `z.string()`.
- `packages/db/src/buffers/event-buffer.ts:254-263` — `project_id` interpolated into the WHERE clause.
- `apps/start/src/components/cohort/cohort-criteria-builder.tsx:336`, `:340-344`, `:399`, `:415`, `:433` — the only producers of absolute timeframes. All of them emit `YYYY-MM-DD`, from `toISOString().split('T')[0]` or an `<input type="date">`, so the new regex does not reject anything the UI sends today.

## Tests

- `packages/db/src/services/cohort.service.test.ts` (new): feeds hostile `start` and `end` values through `buildEventCriteriaQuery` and strips every quoted literal from the result, then asserts the remaining SQL skeleton is the same shape as for a well-formed date. Covers the start-only and start-and-end return paths separately, plus the relative branch. 8 tests, passing.
- `packages/validation/src/cohort.validation.test.ts` (new): `zAbsoluteTimeframe` accepts a date with and without `end`, rejects non-dates. 7 tests, passing.
- `packages/db/src/buffers/event-buffer.test.ts`: the existing `project_id = 'p9'` assertion is unchanged and still holds, since escaping a plain id produces the same text. Added a case with an id containing a quote.

`pnpm --filter validation typecheck` is clean. `pnpm --filter db typecheck` reports 22 errors, the same 22 before and after this branch, all in `src/services/insights/store.ts` and `src/services/notification.service.ts`, none in the files touched here. Biome reports the same diagnostic count per touched file before and after; the new files are clean.

The event-buffer suite needs a local Redis and ClickHouse, which I could not run here, so all 19 of its tests fail on connection refused, including ones this branch does not touch. The new case in it is unverified for that reason. The escaped string it asserts on was confirmed directly against `sqlstring.escape`.

## Left out

- `packages/validation/vitest.config.ts` is new. The validation package had no vitest config, so its tests were not being picked up by the workspace. It is the same three lines as every other package's config.
- I did not switch `getActiveVisitorCount` to a bound parameter. `chQuery` only forwards `ClickHouseSettings`, not `query_params`, so that would have meant changing the client signature for one call site.
- An empty `start` now fails validation where it previously built `toDate('')`. The date input can be cleared, so a half-filled cohort form will be rejected instead of saving a criterion that matches nothing. That seemed like the better of the two, but it is a visible change and worth a second opinion.
- The access-control shape of the `/live/visitors` WebSocket handler is untouched. Public share widgets connect to it without a session, so it needs a decision rather than a patch.
