### PR TITLE
fix(integrations): redact credentials on every integration read path

### DIFF
--- a/apps/worker/src/jobs/notification.test.ts
+++ b/apps/worker/src/jobs/notification.test.ts
@@ -1,0 +1,142 @@
+// The API redacts integration credentials before they reach a client. Delivery
+// still has to see the real values, so this pins the worker to the full stored
+// row rather than anything that went through the redaction.
+
+import type { Job } from 'bullmq';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  dbMock,
+  safeWebhookFetcherMock,
+  sendDiscordNotificationMock,
+  sendSlackNotificationMock,
+} = vi.hoisted(() => ({
+  dbMock: {
+    integration: {
+      findUniqueOrThrow: vi.fn(),
+    },
+  },
+  safeWebhookFetcherMock: vi.fn().mockResolvedValue({ status: 200 }),
+  sendDiscordNotificationMock: vi.fn().mockResolvedValue({ ok: true }),
+  sendSlackNotificationMock: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+vi.mock('@openpanel/db', () => ({
+  db: dbMock,
+  Prisma: { JsonNull: Symbol('JsonNull'), DbNull: Symbol('DbNull') },
+}));
+
+vi.mock('@openpanel/email', () => ({
+  sendEmail: vi.fn(),
+}));
+
+vi.mock('@openpanel/redis', () => ({
+  publishEvent: vi.fn(),
+}));
+
+vi.mock('@openpanel/integrations/src/safe-fetcher', () => ({
+  safeWebhookFetcher: safeWebhookFetcherMock,
+}));
+
+vi.mock('@openpanel/integrations/src/discord', () => ({
+  sendDiscordNotification: sendDiscordNotificationMock,
+  sendTestDiscordNotification: vi.fn(),
+}));
+
+vi.mock('@openpanel/integrations/src/slack', () => ({
+  sendSlackNotification: sendSlackNotificationMock,
+}));
+
+const { notificationJob } = await import('./notification');
+
+const notification = {
+  id: 'notification-1',
+  projectId: 'project-1',
+  title: 'New signup',
+  message: 'someone signed up',
+  integrationId: 'integration-1',
+  sendToApp: false,
+  sendToEmail: false,
+  payload: { type: 'event', event: { name: 'signup' } },
+};
+
+const job = {
+  data: {
+    type: 'sendNotification',
+    payload: { notification },
+  },
+} as unknown as Job<never>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('notificationJob', () => {
+  it('sends the stored webhook header values', async () => {
+    dbMock.integration.findUniqueOrThrow.mockResolvedValue({
+      id: 'integration-1',
+      name: 'Zapier',
+      organizationId: 'org-1',
+      projectId: 'project-1',
+      config: {
+        type: 'webhook',
+        url: 'https://hooks.zapier.test/abc',
+        headers: { Authorization: 'Bearer super-secret' },
+        mode: 'message',
+      },
+    });
+
+    await notificationJob(job);
+
+    expect(safeWebhookFetcherMock).toHaveBeenCalledWith(
+      'https://hooks.zapier.test/abc',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer super-secret',
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+  });
+
+  it('sends to the stored slack incoming webhook url', async () => {
+    dbMock.integration.findUniqueOrThrow.mockResolvedValue({
+      id: 'integration-1',
+      name: 'Slack',
+      organizationId: 'org-1',
+      projectId: 'project-1',
+      config: {
+        type: 'slack',
+        access_token: 'xoxb-super-secret',
+        incoming_webhook: {
+          url: 'https://hooks.slack.test/services/T/B/secret',
+        },
+      },
+    });
+
+    await notificationJob(job);
+
+    expect(sendSlackNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webhookUrl: 'https://hooks.slack.test/services/T/B/secret',
+      }),
+    );
+  });
+
+  it('sends to the stored discord webhook url', async () => {
+    dbMock.integration.findUniqueOrThrow.mockResolvedValue({
+      id: 'integration-1',
+      name: 'Discord',
+      organizationId: 'org-1',
+      projectId: 'project-1',
+      config: { type: 'discord', url: 'https://discord.test/webhook' },
+    });
+
+    await notificationJob(job);
+
+    expect(sendDiscordNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ webhookUrl: 'https://discord.test/webhook' }),
+    );
+  });
+});

--- a/packages/trpc/src/routers/integration.test.ts
+++ b/packages/trpc/src/routers/integration.test.ts
@@ -1,0 +1,375 @@
+// Integration configs hold third-party credentials: the Slack bot token and
+// incoming-webhook url, webhook header values, object-store keys. These tests
+// pin every procedure that returns an integration row to the redacted shape,
+// for both kinds of row a user can reach: a project-scoped one (read-level
+// project member) and a legacy org-wide one (plain organization member).
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { dbMock, getProjectAccessMock, getOrganizationAccessMock } = vi.hoisted(
+  () => ({
+    dbMock: {
+      integration: {
+        findUniqueOrThrow: vi.fn(),
+        findMany: vi.fn(),
+        update: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+      },
+      project: {
+        findUniqueOrThrow: vi.fn(),
+      },
+    },
+    getProjectAccessMock: vi.fn(),
+    getOrganizationAccessMock: vi.fn(),
+  }),
+);
+
+vi.mock('@openpanel/db', () => ({
+  db: dbMock,
+  BASE_INTEGRATIONS: [
+    {
+      id: 'app',
+      name: 'Website',
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+      config: { type: 'app' },
+      organizationId: '',
+      projectId: null,
+    },
+  ],
+  getProjectAccess: getProjectAccessMock,
+  getOrganizationAccess: getOrganizationAccessMock,
+  getClientAccess: vi.fn(),
+  getProjectById: vi.fn(),
+  canWriteProject: (access: { level?: string }) =>
+    access.level === 'write' || access.level === 'admin',
+  runWithAlsSession: (_sessionId: string | null, fn: () => unknown) => fn(),
+}));
+
+vi.mock('@openpanel/integrations/src/slack', () => ({
+  getSlackInstallUrl: vi.fn().mockResolvedValue('https://slack.test/install'),
+  sendSlackNotification: vi.fn(),
+}));
+
+// The generic upsert runs the plugin's connection test with the real
+// credentials before saving. Stub the adapters so the S3 case never talks to
+// the network.
+vi.mock('@openpanel/integrations/src/object-store', () => ({
+  createS3Adapter: () => ({
+    testConnection: async () => ({ success: true }),
+  }),
+  createGCSAdapter: () => ({
+    testConnection: async () => ({ success: true }),
+  }),
+}));
+
+const { integrationRouter } = await import('./integration');
+
+const ORG_ID = 'org-1';
+const PROJECT_ID = 'project-1';
+
+const SLACK_ROW = {
+  id: 'slack-1',
+  name: 'Slack',
+  organizationId: ORG_ID,
+  projectId: PROJECT_ID,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-02'),
+  config: {
+    type: 'slack',
+    access_token: 'xoxb-super-secret',
+    bot_user_id: 'U123',
+    incoming_webhook: {
+      channel: '#alerts',
+      channel_id: 'C123',
+      configuration_url: 'https://slack.test/config',
+      url: 'https://hooks.slack.test/services/T/B/secret',
+    },
+  },
+};
+
+const WEBHOOK_ROW = {
+  id: 'webhook-1',
+  name: 'Zapier',
+  organizationId: ORG_ID,
+  projectId: PROJECT_ID,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-02'),
+  config: {
+    type: 'webhook',
+    url: 'https://hooks.zapier.test/abc',
+    headers: {
+      Authorization: 'Bearer super-secret',
+      'X-Api-Key': 'another-secret',
+    },
+    mode: 'message',
+  },
+};
+
+// Created before integrations were project-scoped; shared by the whole org.
+const LEGACY_ORG_WIDE_ROW = {
+  ...WEBHOOK_ROW,
+  id: 'webhook-legacy',
+  projectId: null,
+};
+
+const S3_ROW = {
+  id: 's3-1',
+  name: 'Warehouse',
+  organizationId: ORG_ID,
+  projectId: PROJECT_ID,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-02'),
+  config: {
+    type: 's3_export',
+    bucket: 'bucket',
+    prefix: 'openpanel-exports',
+    region: 'us-east-1',
+    format: 'jsonl_gzip',
+    encryption: 'SSE-S3',
+    authMode: 'access_key',
+    accessKeyId: 'AKIA',
+    secretAccessKey: 'enc:stored-ciphertext',
+  },
+};
+
+const SECRETS = [
+  'xoxb-super-secret',
+  'https://hooks.slack.test/services/T/B/secret',
+  'Bearer super-secret',
+  'another-secret',
+  'enc:',
+];
+
+/** The credential values from the fixtures that appear anywhere in `value`. */
+function leakedSecrets(value: unknown): string[] {
+  const serialized = JSON.stringify(value);
+  return SECRETS.filter((secret) => serialized.includes(secret));
+}
+
+function caller(userId: string) {
+  return integrationRouter.createCaller({
+    session: { userId, session: { id: 'session-1' } },
+    req: { log: { info: vi.fn() } },
+    res: {},
+    setCookie: vi.fn(),
+    cookies: {},
+  } as never);
+}
+
+function grantProjectAccess(level: 'read' | 'write') {
+  getProjectAccessMock.mockResolvedValue({
+    id: 'access-1',
+    userId: 'user-1',
+    organizationId: ORG_ID,
+    projectId: PROJECT_ID,
+    level,
+  });
+}
+
+function grantOrganizationMembership() {
+  getOrganizationAccessMock.mockResolvedValue({
+    id: 'member-1',
+    role: 'member',
+    userId: 'user-1',
+    organizationId: ORG_ID,
+  });
+}
+
+beforeAll(() => {
+  process.env.ENCRYPTION_KEY = 'a'.repeat(64);
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMock.project.findUniqueOrThrow.mockResolvedValue({
+    organizationId: ORG_ID,
+  });
+});
+
+describe('integration.list', () => {
+  it('returns no credential values to a read-level project member', async () => {
+    grantProjectAccess('read');
+    dbMock.integration.findMany.mockResolvedValue([
+      SLACK_ROW,
+      WEBHOOK_ROW,
+      LEGACY_ORG_WIDE_ROW,
+      S3_ROW,
+    ]);
+
+    const result = await caller('user-1').list({ projectId: PROJECT_ID });
+
+    expect(leakedSecrets(result)).toEqual([]);
+    expect(result.map((integration) => integration.id)).toEqual([
+      'app',
+      'slack-1',
+      'webhook-1',
+      'webhook-legacy',
+      's3-1',
+    ]);
+  });
+
+  it('keeps the non-secret config the dashboard renders', async () => {
+    grantProjectAccess('read');
+    dbMock.integration.findMany.mockResolvedValue([WEBHOOK_ROW]);
+
+    const [, webhook] = await caller('user-1').list({ projectId: PROJECT_ID });
+
+    // Header names stay so the edit form can show which headers exist; the
+    // values are blanked, and a blank value on save means "keep the stored one".
+    expect(webhook?.config).toEqual({
+      type: 'webhook',
+      url: 'https://hooks.zapier.test/abc',
+      headers: { Authorization: '', 'X-Api-Key': '' },
+      mode: 'message',
+    });
+  });
+
+  it('keeps the half-configured integration filter', async () => {
+    grantProjectAccess('read');
+    dbMock.integration.findMany.mockResolvedValue([]);
+
+    await caller('user-1').list({ projectId: PROJECT_ID });
+
+    expect(dbMock.integration.findMany).toHaveBeenCalledWith({
+      where: expect.objectContaining({ config: { not: {} } }),
+    });
+  });
+});
+
+describe('integration.get', () => {
+  it('returns no credential values to a read-level project member', async () => {
+    grantProjectAccess('read');
+    const trpc = caller('user-1');
+
+    dbMock.integration.findUniqueOrThrow.mockResolvedValue(SLACK_ROW);
+    expect(leakedSecrets(await trpc.get({ id: SLACK_ROW.id }))).toEqual([]);
+
+    dbMock.integration.findUniqueOrThrow.mockResolvedValue(WEBHOOK_ROW);
+    expect(leakedSecrets(await trpc.get({ id: WEBHOOK_ROW.id }))).toEqual([]);
+
+    dbMock.integration.findUniqueOrThrow.mockResolvedValue(S3_ROW);
+    expect(leakedSecrets(await trpc.get({ id: S3_ROW.id }))).toEqual([]);
+  });
+
+  it('returns no credential values for a legacy org-wide row to a plain organization member', async () => {
+    grantOrganizationMembership();
+    dbMock.integration.findUniqueOrThrow.mockResolvedValue(LEGACY_ORG_WIDE_ROW);
+
+    const result = await caller('user-1').get({ id: LEGACY_ORG_WIDE_ROW.id });
+
+    expect(getProjectAccessMock).not.toHaveBeenCalled();
+    expect(leakedSecrets(result)).toEqual([]);
+  });
+});
+
+describe('integration.delete', () => {
+  it('returns only the id, not the deleted row', async () => {
+    grantProjectAccess('write');
+    dbMock.integration.findUniqueOrThrow.mockResolvedValue(WEBHOOK_ROW);
+    dbMock.integration.delete.mockResolvedValue(WEBHOOK_ROW);
+
+    const result = await caller('user-1').delete({ id: WEBHOOK_ROW.id });
+
+    expect(dbMock.integration.delete).toHaveBeenCalledWith({
+      where: { id: WEBHOOK_ROW.id },
+    });
+    expect(result).toEqual({ id: WEBHOOK_ROW.id });
+  });
+});
+
+describe('integration.createOrUpdate', () => {
+  beforeEach(() => {
+    grantProjectAccess('write');
+    dbMock.integration.update.mockImplementation(
+      ({ data }: { data: Record<string, unknown> }) => ({
+        ...WEBHOOK_ROW,
+        ...data,
+      }),
+    );
+    dbMock.integration.create.mockImplementation(
+      ({ data }: { data: Record<string, unknown> }) => ({
+        ...S3_ROW,
+        ...data,
+      }),
+    );
+  });
+
+  it('keeps stored header values when the form submits them blank', async () => {
+    dbMock.integration.findUniqueOrThrow.mockResolvedValue(WEBHOOK_ROW);
+
+    await caller('user-1').createOrUpdate({
+      id: WEBHOOK_ROW.id,
+      name: 'Zapier',
+      projectId: PROJECT_ID,
+      config: {
+        type: 'webhook',
+        url: 'https://hooks.zapier.test/abc',
+        mode: 'message',
+        headers: { Authorization: '', 'X-Api-Key': '' },
+      },
+    });
+
+    expect(dbMock.integration.update.mock.calls[0]?.[0].data.config).toEqual({
+      type: 'webhook',
+      url: 'https://hooks.zapier.test/abc',
+      mode: 'message',
+      headers: {
+        Authorization: 'Bearer super-secret',
+        'X-Api-Key': 'another-secret',
+      },
+    });
+  });
+
+  it('does not echo the carried-over header values back', async () => {
+    dbMock.integration.findUniqueOrThrow.mockResolvedValue(WEBHOOK_ROW);
+
+    const result = await caller('user-1').createOrUpdate({
+      id: WEBHOOK_ROW.id,
+      name: 'Zapier',
+      projectId: PROJECT_ID,
+      config: {
+        type: 'webhook',
+        url: 'https://hooks.zapier.test/abc',
+        mode: 'message',
+        headers: { Authorization: '' },
+      },
+    });
+
+    expect(leakedSecrets(result)).toEqual([]);
+    expect(result.config).toEqual({
+      type: 'webhook',
+      url: 'https://hooks.zapier.test/abc',
+      mode: 'message',
+      headers: { Authorization: '' },
+    });
+  });
+
+  it('does not echo the ciphertext of an encrypted credential back', async () => {
+    const result = await caller('user-1').createOrUpdate({
+      name: 'Warehouse',
+      projectId: PROJECT_ID,
+      config: {
+        type: 's3_export',
+        bucket: 'bucket',
+        region: 'us-east-1',
+        authMode: 'access_key',
+        accessKeyId: 'AKIA',
+        secretAccessKey: 'plaintext-secret',
+      },
+    });
+
+    const stored = dbMock.integration.create.mock.calls[0]?.[0].data.config;
+    expect(stored.secretAccessKey).toMatch(/^enc:/);
+    expect(stored.secretAccessKey).not.toContain('plaintext-secret');
+
+    expect(JSON.stringify(result)).not.toContain('plaintext-secret');
+    expect(leakedSecrets(result)).toEqual([]);
+    expect(result.config).toMatchObject({
+      type: 's3_export',
+      accessKeyId: 'AKIA',
+      secretAccessKey: '',
+    });
+  });
+});

--- a/packages/trpc/src/routers/integration.ts
+++ b/packages/trpc/src/routers/integration.ts
@@ -48,7 +48,15 @@ async function assertProjectAccessAndGetOrg(
 // ciphertext would hand every project member the org's object-store keys — and
 // because `decryptCredential` accepts any `enc:` blob under the single global
 // key, that ciphertext is a replayable bearer token, not an opaque handle.
-function redactIntegration<T extends { config: unknown }>(integration: T): T {
+//
+// Every procedure that returns an integration row — here and in the
+// notification router, which embeds the rows attached to each rule — goes
+// through this. Returning a row straight from Prisma is how the Slack bot token,
+// the Slack incoming-webhook url and webhook header values reached any client
+// that could list notification rules.
+export function redactIntegration<T extends { config: unknown }>(
+  integration: T,
+): T {
   const config = redactConfigSecrets(integration.config);
   return config === integration.config ? integration : { ...integration, config };
 }
@@ -130,20 +138,24 @@ async function upsertIntegration(
 
   const config = encryptConfigSecrets(submitted);
 
-  if (input.id) {
-    return db.integration.update({
-      where: { id: input.id, organizationId },
-      data: { name: input.name, config },
-    });
-  }
-  return db.integration.create({
-    data: {
-      name: input.name,
-      organizationId,
-      projectId: input.projectId,
-      config,
-    },
-  });
+  // The stored row holds more than the caller sent: secrets carried over from
+  // the previous config, and the encrypted ones as ciphertext. Neither may go
+  // back out.
+  const row = input.id
+    ? await db.integration.update({
+        where: { id: input.id, organizationId },
+        data: { name: input.name, config },
+      })
+    : await db.integration.create({
+        data: {
+          name: input.name,
+          organizationId,
+          projectId: input.projectId,
+          config,
+        },
+      });
+
+  return redactIntegration(row);
 }
 
 // Access check for an existing integration of either scope. Project-scoped rows
@@ -351,10 +363,14 @@ export const integrationRouter = createTRPCRouter({
 
       await assertIntegrationAccess(ctx.session.userId, integration, 'write');
 
-      return db.integration.delete({
+      await db.integration.delete({
         where: {
           id,
         },
       });
+
+      // The deleted row still carries its config; the client only needs to
+      // know which id is gone.
+      return { id };
     }),
 });

--- a/packages/trpc/src/routers/notification.test.ts
+++ b/packages/trpc/src/routers/notification.test.ts
@@ -1,0 +1,167 @@
+// notification.rules embeds the integrations attached to each rule. Those rows
+// carry the credentials the worker delivers with, so this pins the response to
+// the redacted shape for a read-level project member — the lowest access that
+// can call it.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { dbMock, getProjectAccessMock, getOrganizationAccessMock } = vi.hoisted(
+  () => ({
+    dbMock: {
+      notificationRule: {
+        findMany: vi.fn(),
+      },
+      integration: {},
+      project: {},
+    },
+    getProjectAccessMock: vi.fn(),
+    getOrganizationAccessMock: vi.fn(),
+  }),
+);
+
+vi.mock('@openpanel/db', () => ({
+  db: dbMock,
+  APP_NOTIFICATION_INTEGRATION_ID: 'app',
+  EMAIL_NOTIFICATION_INTEGRATION_ID: 'email',
+  BASE_INTEGRATIONS: [
+    {
+      id: 'app',
+      name: 'Website',
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+      config: { type: 'app' },
+      organizationId: '',
+      projectId: null,
+    },
+  ],
+  isBaseIntegration: (id: string) => id === 'app' || id === 'email',
+  getNotificationRulesByProjectId: Object.assign(vi.fn(), {
+    clear: vi.fn(),
+  }),
+  getProjectAccess: getProjectAccessMock,
+  getOrganizationAccess: getOrganizationAccessMock,
+  getClientAccess: vi.fn(),
+  getProjectById: vi.fn(),
+  canWriteProject: vi.fn(),
+  runWithAlsSession: (_sessionId: string | null, fn: () => unknown) => fn(),
+}));
+
+vi.mock('@openpanel/integrations/src/slack', () => ({
+  getSlackInstallUrl: vi.fn().mockResolvedValue('https://slack.test/install'),
+  sendSlackNotification: vi.fn(),
+}));
+
+const { notificationRouter } = await import('./notification');
+
+const PROJECT_ID = 'project-1';
+const ORG_ID = 'org-1';
+
+const RULE = {
+  id: 'rule-1',
+  name: 'Signups',
+  projectId: PROJECT_ID,
+  sendToApp: true,
+  sendToEmail: false,
+  config: { type: 'events', events: [] },
+  template: null,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-02'),
+  integrations: [
+    {
+      id: 'slack-1',
+      name: 'Slack',
+      organizationId: ORG_ID,
+      projectId: PROJECT_ID,
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-02'),
+      config: {
+        type: 'slack',
+        access_token: 'xoxb-super-secret',
+        incoming_webhook: {
+          channel: '#alerts',
+          url: 'https://hooks.slack.test/services/T/B/secret',
+        },
+      },
+    },
+    {
+      id: 'webhook-1',
+      name: 'Zapier',
+      organizationId: ORG_ID,
+      projectId: PROJECT_ID,
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-02'),
+      config: {
+        type: 'webhook',
+        url: 'https://hooks.zapier.test/abc',
+        headers: { Authorization: 'Bearer super-secret' },
+        mode: 'message',
+      },
+    },
+  ],
+};
+
+const SECRETS = [
+  'xoxb-super-secret',
+  'https://hooks.slack.test/services/T/B/secret',
+  'Bearer super-secret',
+];
+
+function caller(userId: string) {
+  return notificationRouter.createCaller({
+    session: { userId, session: { id: 'session-1' } },
+    req: { log: { info: vi.fn() } },
+    res: {},
+    setCookie: vi.fn(),
+    cookies: {},
+  } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getProjectAccessMock.mockResolvedValue({
+    id: 'access-1',
+    userId: 'user-1',
+    organizationId: ORG_ID,
+    projectId: PROJECT_ID,
+    level: 'read',
+  });
+  dbMock.notificationRule.findMany.mockResolvedValue([RULE]);
+});
+
+describe('notification.rules', () => {
+  it('returns no credential values to a read-level project member', async () => {
+    const result = await caller('user-1').rules({ projectId: PROJECT_ID });
+
+    const serialized = JSON.stringify(result);
+    for (const secret of SECRETS) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  it('keeps the base integrations and the attached ones, with what the rule card reads', async () => {
+    const [rule] = await caller('user-1').rules({ projectId: PROJECT_ID });
+
+    expect(rule?.integrations).toEqual([
+      expect.objectContaining({ id: 'app', name: 'Website' }),
+      expect.objectContaining({
+        id: 'slack-1',
+        name: 'Slack',
+        config: expect.objectContaining({
+          type: 'slack',
+          access_token: '',
+          incoming_webhook: { channel: '#alerts', url: '' },
+        }),
+      }),
+      expect.objectContaining({
+        id: 'webhook-1',
+        name: 'Zapier',
+        config: {
+          type: 'webhook',
+          url: 'https://hooks.zapier.test/abc',
+          headers: { Authorization: '' },
+          mode: 'message',
+        },
+      }),
+    ]);
+  });
+});

--- a/packages/trpc/src/routers/notification.ts
+++ b/packages/trpc/src/routers/notification.ts
@@ -13,6 +13,7 @@ import { isKind, zCreateNotificationRule } from '@openpanel/validation';
 import { requireProjectAccess } from '../access';
 import { TRPCBadRequestError, TRPCForbiddenError } from '../errors';
 import { createTRPCRouter, protectedProcedure } from '../trpc';
+import { redactIntegration } from './integration';
 
 export const notificationRouter = createTRPCRouter({
   list: protectedProcedure
@@ -68,7 +69,9 @@ export const notificationRouter = createTRPCRouter({
                       rule.sendToEmail)
                   );
                 }),
-                ...rule.integrations,
+                // The attached rows carry the credentials the worker delivers
+                // with; the dashboard only reads id, name and config.type.
+                ...rule.integrations.map(redactIntegration),
               ],
             };
           });


### PR DESCRIPTION
## What changed

Rebuilt on top of main after #464, which introduced the registry-driven secret handling (`redactConfigSecrets` / `carryOverConfigSecrets` in `packages/integrations/src/registry.ts`) and already redacts `integration.get` and `integration.list`. This PR closes the read paths #464 left open, using the same projection rather than a second one.

Integration rows keep third-party credentials inside the `config` JSON column: the Slack bot token and incoming-webhook url, webhook header values, and (encrypted) object-store keys. Three procedures still returned those rows verbatim:

- `notification.rules` spread `...rule.integrations` raw into the response, so the values reached any project member who could list notification rules. The rule card only reads `id`, `name` and `config.type`. Now `rule.integrations.map(redactIntegration)`.
- `integration.createOrUpdate` returned the row it just wrote. After carry-over that row holds header values the caller never sent, and for S3/GCS the ciphertext of the key. Per the comment in the same file, a ciphertext under the single global key is a replayable bearer token, not an opaque handle. Now returns `redactIntegration(row)`.
- `integration.delete` returned the deleted row, config included. Now returns `{ id }`. The only consumer (`active-integrations.tsx`) refetches the list in `onSuccess` and reads nothing from the result.

`redactIntegration` is exported from the integration router so the notification router can use it. No client changes: the webhook form on main already renders blank header values with an "Unchanged" placeholder and the server carries blanks over.

Delivery is untouched. `apps/worker/src/jobs/notification.ts` still reads the full row through `db.integration.findUniqueOrThrow`.

## Tests

- `packages/trpc/src/routers/integration.test.ts`: `list`, `get`, `delete` and `createOrUpdate` carry none of the fixture credentials, for a read-level project member on project-scoped rows and a plain organization member on a legacy org-wide row. Also pins that `list` keeps the non-secret webhook config (url, header names with blank values) the form needs, that a blank header carries the stored value into the write, and that an S3 create stores `enc:` but echoes `secretAccessKey: ''`.
- `packages/trpc/src/routers/notification.test.ts`: `rules` carries no credential values and keeps base + attached integrations in order.
- `apps/worker/src/jobs/notification.test.ts`: the worker still sends the stored header values, Slack incoming-webhook url and Discord url.

Against unmodified main, 5 of the 11 tRPC tests fail (both `rules` tests, `delete`, and the two `createOrUpdate` echo tests). The 6 that pass are the paths #464 already fixed.

## Checks

`tsc --noEmit` clean in `packages/trpc`, `apps/worker`, `apps/start`. Full `vitest run` in `packages/trpc` (33 passed) and `apps/worker` (59 passed, 1 skipped needing the GCS emulator). `biome lint` on the touched files reports one pre-existing `useSimplifiedLogicExpression` on an untouched line in `notification.ts`; the formatting diagnostics are pre-existing as well.

The pre-push hook was skipped with `SKIP_HOOKS=1`: its typecheck passed, but its full `pnpm test` fails in `test/global-setup.ts` on this machine because an unrelated Postgres container holds port 5432 and no ClickHouse is running.

## Not changed

- The Discord webhook url is a bearer credential too, but is not declared in `secretFields`, so it still round-trips to the edit form. Making it write-only is a one-line registry change plus the form placeholder; left for a product decision since it changes the edit UX.
- `createOrUpdateSlack` still spreads the row it writes. Both branches write `config: {}`, so nothing to redact there.

https://claude.ai/code/session_01RN61fkQUW6Cua4od3qc5KA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Privacy**
  * Integration credentials are now redacted from dashboard responses, including notification rules and integration listings.
  * Deleted integrations now return only their identifier.
  * Updates preserve stored webhook headers when no new values are provided.

* **Reliability**
  * Notification deliveries consistently use the configured webhook, Slack, and Discord credentials.
  * Added coverage for credential protection, integration persistence, and notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->