### PR TITLE
fix(track): don't drop increment/decrement for a not-yet-created profile

### DIFF
--- a/apps/api/src/controllers/track.controller.ts
+++ b/apps/api/src/controllers/track.controller.ts
@@ -321,29 +321,33 @@ async function adjustProfileProperty(
 ): Promise<void> {
   const { profileId, property, value } = payload;
   const profile = await getProfileById(String(profileId), projectId);
-  if (!profile) {
-    throw new HttpError('Profile not found', { status: 404 });
-  }
+
+  // A missing profile is not an error. An increment/decrement legitimately
+  // fires before the profile's first event or identify has landed (a common
+  // race), or for an anonymous/transient id. Follow Mixpanel `$add`/`$subtract`
+  // semantics — treat the current value as 0 and upsert — so the delta is
+  // preserved and the profile is created, instead of dropping the operation.
+  const properties = profile?.properties ?? {};
 
   const parsed = Number.parseInt(
-    pathOr<string>('0', property.split('.'), profile.properties),
+    pathOr<string>('0', property.split('.'), properties),
     10
   );
 
+  // An existing value that isn't a number can't be adjusted; skip rather than
+  // rejecting the request (and never overwrite it with a NaN).
   if (Number.isNaN(parsed)) {
-    throw new HttpError('Property value is not a number', { status: 400 });
+    return;
   }
 
-  profile.properties = assocPath(
-    property.split('.'),
-    parsed + direction * (value || 1),
-    profile.properties
-  );
-
   await upsertProfile({
-    id: profile.id,
+    id: profile?.id ?? String(profileId),
     projectId,
-    properties: profile.properties,
+    properties: assocPath(
+      property.split('.'),
+      parsed + direction * (value || 1),
+      properties
+    ),
     isExternal: true,
   });
 }


### PR DESCRIPTION
## Summary

`increment` / `decrement` (`adjustProfileProperty`) currently **drops the operation** when the target profile doesn't exist yet, or when the existing value isn't numeric. This changes it to follow Mixpanel `$add` / `$subtract` semantics — treat the current value as `0`, create/upsert the profile, and apply the delta — so the counter is preserved instead of lost.

## The problem

```ts
async function adjustProfileProperty(payload, projectId, direction) {
  const { profileId, property, value } = payload;
  const profile = await getProfileById(String(profileId), projectId);
  if (!profile) {
    throw new HttpError('Profile not found', { status: 404 });      // ← drops the op
  }
  const parsed = Number.parseInt(pathOr('0', property.split('.'), profile.properties), 10);
  if (Number.isNaN(parsed)) {
    throw new HttpError('Property value is not a number', { status: 400 });  // ← drops the op
  }
  ...
}
```

A missing profile here is **not an error condition** — it's a normal race. An `increment`/`decrement` legitimately fires:

- **before the profile's first `track`/`identify` event has landed** (the profile row is created lazily by those, so a counter op that arrives first finds nothing), or
- for an **anonymous / transient id** that has no profile yet.

In both cases the current code rejects the request and the increment is **silently lost** — the counter is never created, and the client has no way to recover it. This diverges from Mixpanel's `$add` / `$subtract`, which create the profile and start the property from `0`.

The `NaN` branch has the same shape: a single non-numeric value on the property `400`s the whole request rather than being skipped.

## The fix

```ts
const profile = await getProfileById(String(profileId), projectId);

// A missing profile is not an error — treat the current value as 0 and upsert.
const properties = profile?.properties ?? {};

const parsed = Number.parseInt(pathOr('0', property.split('.'), properties), 10);

// Non-numeric existing value: skip rather than reject (never overwrite with NaN).
if (Number.isNaN(parsed)) {
  return;
}

await upsertProfile({
  id: profile?.id ?? String(profileId),
  projectId,
  properties: assocPath(property.split('.'), parsed + direction * (value || 1), properties),
  isExternal: true,
});
```

| Case | Before | After |
|---|---|---|
| Profile exists, numeric value | increments | increments *(unchanged)* |
| Profile missing | **404, op dropped** | creates profile, value = `0 + delta` |
| Existing value non-numeric | **400, op dropped** | skipped (no overwrite) |

## Compatibility

- **No behaviour change for existing numeric profiles** — the common path is byte-for-byte the same.
- The only newly-created rows are profiles that would previously have `404`'d; they're created via the same `upsertProfile(..., isExternal: true)` used elsewhere in this handler.

## Testing / notes

- Verified the branch is `main` + this single commit (clean diff on `adjustProfileProperty` only). `HttpError` remains used elsewhere in the file, so its import is untouched.
- I hit this in production on a fork: because our variant threw a bare `Error` (→ retryable **500** rather than a 404), the SDK retried each failure and amplified a handful of unique increments into a 5xx storm. Upstream's `404` isn't retryable so it won't storm — but the underlying **lost-increment** behaviour is the same, which is what this PR addresses. Happy to add tests in the style you prefer if this direction looks good.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile property adjustments now create a profile when the requested profile does not exist.
  * Increment and decrement operations continue to work for existing numeric properties.
  * Invalid or non-numeric property values are skipped without returning an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->