### PR TITLE
fix(db): return the newest events, not an arbitrary slice

### DIFF
--- a/packages/db/src/services/event.service.ts
+++ b/packages/db/src/services/event.service.ts
@@ -1331,9 +1331,7 @@ export interface QueryEventsInput {
   limit?: number;
 }
 
-export async function queryEventsCore(
-  input: QueryEventsInput
-): Promise<IClickhouseEvent[]> {
+export function buildQueryEventsQuery(input: QueryEventsInput) {
   const builder = clix(ch)
     .select<IClickhouseEvent>([])
     .from(TABLE_NAMES.events)
@@ -1434,5 +1432,13 @@ export async function queryEventsCore(
     }
   }
 
-  return builder.limit(input.limit ?? 20).execute();
+  // Without an explicit order ClickHouse returns whatever it reads first, so a
+  // bare LIMIT hands back an arbitrary slice of the window, not the newest.
+  return builder.orderBy('created_at', 'DESC').limit(input.limit ?? 20);
+}
+
+export async function queryEventsCore(
+  input: QueryEventsInput
+): Promise<IClickhouseEvent[]> {
+  return buildQueryEventsQuery(input).execute();
 }

--- a/packages/db/src/services/query-events-sql.test.ts
+++ b/packages/db/src/services/query-events-sql.test.ts
@@ -1,0 +1,72 @@
+/**
+ * SQL-shape tests for the shared event query.
+ *
+ * Same strategy as profile-metrics-sql.test.ts: string assertions always run;
+ * `EXPLAIN` validation runs against a locally reachable ClickHouse
+ * (`pnpm dock:up`) and skips otherwise.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { ch } from '../clickhouse/client';
+import { buildQueryEventsQuery } from './event.service';
+
+const PROJECT_ID = 'test-sql-validation';
+
+let chReachable = false;
+
+beforeAll(async () => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  try {
+    await ch.command({ query: 'SELECT 1' });
+    chReachable = true;
+  } catch {
+    chReachable = false;
+  }
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+const itCH = (name: string, fn: () => Promise<void>) =>
+  it(name, async (ctx) => {
+    if (!chReachable) {
+      ctx.skip('ClickHouse not reachable at CLICKHOUSE_URL');
+    }
+    await fn();
+  });
+
+describe('buildQueryEventsQuery', () => {
+  // Callers label these rows `created_at desc` and call them recent events, so
+  // the cut has to happen after the sort rather than wherever the scan starts.
+  it('takes the newest rows, not an arbitrary slice', () => {
+    const sql = buildQueryEventsQuery({ projectId: PROJECT_ID }).toSQL();
+    expect(sql).toContain('ORDER BY created_at DESC');
+    expect(sql.indexOf('ORDER BY')).toBeLessThan(sql.indexOf('LIMIT'));
+  });
+
+  it('keeps the default and the caller limit', () => {
+    expect(buildQueryEventsQuery({ projectId: PROJECT_ID }).toSQL()).toContain(
+      'LIMIT 20',
+    );
+    expect(
+      buildQueryEventsQuery({ projectId: PROJECT_ID, limit: 100 }).toSQL(),
+    ).toContain('LIMIT 100');
+  });
+
+  it('still applies the filters', () => {
+    const sql = buildQueryEventsQuery({
+      projectId: PROJECT_ID,
+      profileId: 'profile-1',
+      eventNames: ['session_start'],
+    }).toSQL();
+    expect(sql).toContain('profile_id');
+    expect(sql).toContain('session_start');
+  });
+
+  itCH('parses and resolves against ClickHouse', async () => {
+    await ch.command({
+      query: `EXPLAIN ${buildQueryEventsQuery({ projectId: PROJECT_ID }).toSQL()}`,
+    });
+  });
+});


### PR DESCRIPTION
fixes #475.

`queryEventsCore` ended with `.limit(input.limit ?? 20).execute()` and no `ORDER BY`, so clickhouse returned whatever it read first. events sort on `(project_id, toDate(created_at), created_at, name)` partitioned by month, so a bare limit hands back an arbitrary slice of the window. every caller labels those rows as recent: the mcp tool passes `sortedBy: 'created_at desc'`, `zLimit` tells the model results are ranked, and the agent tools call them recent events.

sorting before the limit. clickhouse can read the sort key in reverse for this, so it is not a full sort of the window.

measured on a local clickhouse with the same sort key and partitioning, 90 days of one profile's events, one per day, limit 5. before: `2026-09-01`, then `2026-07-01` through `2026-07-04`. after: `2026-09-01` back to `2026-08-28`.

the query builder is split out so the shape can be tested, same as `buildProfileMetricsSql`. the ordering test fails on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Event results are now consistently sorted from newest to oldest.
  * Event queries continue to support filtering and configurable result limits, with a default limit of 20.

* **Tests**
  * Added coverage for event query ordering, filtering, limits, and ClickHouse compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->