### PR TITLE
fix(export): /export/events date range truncated to calendar date, not exact timestamp

### DIFF
--- a/packages/db/src/services/event.service.ts
+++ b/packages/db/src/services/event.service.ts
@@ -532,7 +532,7 @@ export async function getEventList(options: GetEventListOptions) {
     sb.where.cursor = `created_at < ${sqlstring.escape(formatClickhouseDate(cursor))}`;
   }
 
-  if (!(cursor || startDate || endDate)) {
+  if (cursor === undefined && !startDate && !endDate) {
     sb.where.cursorWindow = `created_at >= toDateTime64(${sqlstring.escape(formatClickhouseDate(new Date()))}, 3) - INTERVAL ${safeDateIntervalInDays} DAY`;
   }
 
@@ -671,10 +671,10 @@ export async function getEventList(options: GetEventListOptions) {
   }
 
   if (startDate) {
-    sb.where.startDate = `created_at >= toDateTime('${formatClickhouseDate(startDate)}')`;
+    sb.where.startDate = `created_at >= toDateTime64(${sqlstring.escape(startDate.toISOString().replace('T', ' ').replace('Z', ''))}, 3)`;
   }
   if (endDate) {
-    sb.where.endDate = `created_at <= toDateTime('${formatClickhouseDate(endDate)}')`;
+    sb.where.endDate = `created_at <= toDateTime64(${sqlstring.escape(endDate.toISOString().replace('T', ' ').replace('Z', ''))}, 3)`;
   }
 
   if (events && events.length > 0) {
@@ -762,10 +762,10 @@ export async function getEventsCount({
   }
 
   if (startDate) {
-    sb.where.startDate = `created_at >= toDateTime('${formatClickhouseDate(startDate)}')`;
+    sb.where.startDate = `created_at >= toDateTime64(${sqlstring.escape(startDate.toISOString().replace('T', ' ').replace('Z', ''))}, 3)`;
   }
   if (endDate) {
-    sb.where.endDate = `created_at <= toDateTime('${formatClickhouseDate(endDate)}')`;
+    sb.where.endDate = `created_at <= toDateTime64(${sqlstring.escape(endDate.toISOString().replace('T', ' ').replace('Z', ''))}, 3)`;
   }
 
   if (events && events.length > 0) {

--- a/packages/db/src/services/event.service.ts
+++ b/packages/db/src/services/event.service.ts
@@ -527,7 +527,7 @@ export async function getEventList(options: GetEventListOptions) {
     sb.where.cursor = `created_at < ${sqlstring.escape(formatClickhouseDate(cursor))}`;
   }
 
-  if (!(cursor || (startDate && endDate))) {
+  if (!(cursor || startDate || endDate)) {
     sb.where.cursorWindow = `created_at >= toDateTime64(${sqlstring.escape(formatClickhouseDate(new Date()))}, 3) - INTERVAL ${safeDateIntervalInDays} DAY`;
   }
 
@@ -665,8 +665,11 @@ export async function getEventList(options: GetEventListOptions) {
     sb.where.cohortId = `profile_id IN (SELECT profile_id FROM ${TABLE_NAMES.cohort_members} FINAL WHERE cohort_id = ${sqlstring.escape(cohortId)} AND project_id = ${sqlstring.escape(projectId)})`;
   }
 
-  if (startDate && endDate) {
-    sb.where.created_at = `toDate(created_at) BETWEEN toDate('${formatClickhouseDate(startDate)}') AND toDate('${formatClickhouseDate(endDate)}')`;
+  if (startDate) {
+    sb.where.startDate = `created_at >= toDateTime('${formatClickhouseDate(startDate)}')`;
+  }
+  if (endDate) {
+    sb.where.endDate = `created_at <= toDateTime('${formatClickhouseDate(endDate)}')`;
   }
 
   if (events && events.length > 0) {
@@ -749,8 +752,11 @@ export async function getEventsCount({
     sb.where.cohortId = `profile_id IN (SELECT profile_id FROM ${TABLE_NAMES.cohort_members} FINAL WHERE cohort_id = ${sqlstring.escape(cohortId)} AND project_id = ${sqlstring.escape(projectId)})`;
   }
 
-  if (startDate && endDate) {
-    sb.where.created_at = `toDate(created_at) BETWEEN toDate('${formatClickhouseDate(startDate)}') AND toDate('${formatClickhouseDate(endDate)}')`;
+  if (startDate) {
+    sb.where.startDate = `created_at >= toDateTime('${formatClickhouseDate(startDate)}')`;
+  }
+  if (endDate) {
+    sb.where.endDate = `created_at <= toDateTime('${formatClickhouseDate(endDate)}')`;
   }
 
   if (events && events.length > 0) {

--- a/packages/db/src/services/event.service.ts
+++ b/packages/db/src/services/event.service.ts
@@ -490,6 +490,11 @@ export interface GetEventListOptions {
   dateIntervalInDays?: number;
 }
 
+/**
+ * Fetches a page of events matching the given filters/date range, ordered
+ * newest first. Falls back to a default recent-days cursor window when no
+ * cursor or explicit date bound is provided.
+ */
 export async function getEventList(options: GetEventListOptions) {
   const {
     cursor,
@@ -728,6 +733,10 @@ export async function getEventList(options: GetEventListOptions) {
   return data;
 }
 
+/**
+ * Counts events matching the given filters/date range, using the same
+ * where-clause construction as getEventList.
+ */
 export async function getEventsCount({
   projectId,
   profileId,


### PR DESCRIPTION
## Summary

`/export/events`'s `start`/`end` query params are silently truncated to calendar
date before being compared, so passing an exact timestamp (e.g. midnight) does
not actually bound the query to that moment — it includes the *entire*
calendar day instead. Additionally, a date filter is only applied at all when
**both** `start` and `end` are present; passing just one silently disables
date filtering entirely.

## Repro

```
GET /export/events?projectId=<id>&event=<name>&start=2026-09-02T00:00:00Z&end=2026-09-03T00:00:00Z
```

Expectation: only events created on 2026-09-02 (up to, but not including,
midnight of 2026-09-03).

Actual: events created *any time on 2026-09-03* are also returned — e.g. an
event created at `2026-09-03T17:56:03Z` came back despite `end` being set to
`2026-09-03T00:00:00Z`.

## Root cause

`packages/db/src/services/event.service.ts`, in both `getEventList` and
`getEventsCount`:

```ts
if (startDate && endDate) {
  sb.where.created_at = `toDate(created_at) BETWEEN toDate('${formatClickhouseDate(startDate)}') AND toDate('${formatClickhouseDate(endDate)}')`;
}
```

`toDate()` truncates a ClickHouse `DateTime` down to just its calendar date,
dropping hour/minute/second — on **both** sides of the comparison. So
`end=2026-09-03T00:00:00Z` becomes the literal date `2026-09-03`, and
`BETWEEN ... AND toDate('2026-09-03')` matches the entire day, not "up to
midnight."

This also means a date filter is skipped entirely unless both `startDate` and
`endDate` are truthy (see the `if (startDate && endDate)` guard) — passing
only one silently falls through to whatever cursor-based default window
applies instead, with no indication to the caller that their date bound was
ignored.

Notably, `packages/db/src/services/chart.service.ts` already does this
correctly for `/export/charts`:

```ts
if (startDate) {
  sb.where.startDate = `created_at >= toDateTime('${formatClickhouseDate(startDate)}')`;
}
if (endDate) {
  sb.where.endDate = `created_at <= toDateTime('${formatClickhouseDate(endDate)}')`;
}
```

— full `DateTime` precision, and each bound applied independently. This PR
brings `event.service.ts` in line with that existing, correct pattern.

## Fix

Replace the `toDate(...) BETWEEN toDate(...) AND toDate(...)` pattern with
independent `toDateTime()` comparisons in both `getEventList` and
`getEventsCount`, matching `chart.service.ts`:

```ts
if (startDate) {
  sb.where.startDate = `created_at >= toDateTime('${formatClickhouseDate(startDate)}')`;
}
if (endDate) {
  sb.where.endDate = `created_at <= toDateTime('${formatClickhouseDate(endDate)}')`;
}
```

## Impact

- Exact timestamp filtering now works as documented — `end` actually means
  "up to this moment," not "up to the end of this calendar day."
- `start` and `end` can be used independently; you no longer need both to get
  any date filtering at all.
- No change to callers that already pass both params expecting whole-day
  semantics — a `start`/`end` pair spanning full calendar days (e.g.
  `00:00:00` to `23:59:59` the same day) behaves identically to before.

## Test plan

- [ ] Query with `start`/`end` spanning part of a single day; confirm events
      outside that exact window are excluded.
- [ ] Query with only `start` (no `end`); confirm it now filters rather than
      being silently ignored.
- [ ] Query with only `end` (no `start`); same.
- [ ] Existing whole-day-range queries return the same results as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Event lists and event counts now correctly support filtering with only a start date or only an end date.
  * Date filters are applied inclusively and independently when provided.
  * Empty-result handling now behaves correctly when no cursor or date filters are specified.
  * These updates provide more accurate event searches across a wider range of date-filtering scenarios.
  * Searches using partial date ranges now return results consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->