### PR TITLE
Reject webhook template forms the validator cannot check

### DIFF
--- a/packages/js-runtime/src/execute.ts
+++ b/packages/js-runtime/src/execute.ts
@@ -1,3 +1,5 @@
+import { validate } from './validate';
+
 /**
  * Executes a JavaScript function template
  * @param code - JavaScript function code (arrow function or function expression)
@@ -8,6 +10,14 @@ export function execute(
   code: string,
   payload: Record<string, unknown>,
 ): unknown {
+  // Templates are checked when they are saved, but the stored string is what
+  // ends up in new Function() here. Check it again at run time rather than
+  // trusting whatever passed validation at save time.
+  const validation = validate(code);
+  if (!validation.valid) {
+    throw new Error(`Invalid JavaScript template: ${validation.error}`);
+  }
+
   try {
     // Create the function code that will be executed
     // 'use strict' ensures 'this' is undefined (not global object)

--- a/packages/js-runtime/src/validate.test.ts
+++ b/packages/js-runtime/src/validate.test.ts
@@ -139,6 +139,93 @@ describe('validate', () => {
     });
   });
 
+  describe('Computed and indirect access', () => {
+    it('should block a computed call target', () => {
+      const result = validate(
+        `(payload) => payload['constructor']['constructor']('return 1')()`,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Computed property access');
+    });
+
+    it('should block a computed call target reached by optional chaining', () => {
+      const result = validate(
+        `(payload) => payload?.['constructor']['constructor']('return 1')()`,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Computed property access');
+    });
+
+    it('should block a computed key written with escape sequences', () => {
+      const result = validate(
+        `(payload) => payload['\\u0063onstructor']['constructor']('return 1')()`,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Computed property access');
+    });
+
+    it('should block a computed call target on a nested value', () => {
+      const result = validate(
+        `(payload) => payload.properties['toString']()`,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Computed property access');
+    });
+
+    it("should block 'new' on a non-identifier callee", () => {
+      const result = validate(
+        `(payload) => new (payload['constructor']['constructor'])('return 1')`,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("target of 'new'");
+    });
+
+    it("should block 'new' on a member expression", () => {
+      const result = validate('(payload) => new payload.Thing()');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("target of 'new'");
+    });
+
+    it('should block dynamic import()', () => {
+      const result = validate(`(payload) => import('node:fs')`);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Dynamic import()');
+    });
+  });
+
+  describe('Prototype writes', () => {
+    it('should block writing through __proto__', () => {
+      const result = validate(
+        '(payload) => { payload.__proto__.x = 1; return payload; }',
+      );
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('__proto__');
+    });
+
+    it('should block writing through a computed __proto__ key', () => {
+      const result = validate(
+        `(payload) => { payload['__proto__'].x = 1; return payload; }`,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('__proto__');
+    });
+
+    it('should block writing to a prototype', () => {
+      const result = validate(
+        '(payload) => { payload.constructor.prototype.x = 1; return payload; }',
+      );
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('not allowed');
+    });
+
+    it('should still allow writing an ordinary property', () => {
+      const result = validate(
+        '(payload) => { const out = {}; out.event = payload.name; return out; }',
+      );
+      expect(result.valid).toBe(true);
+    });
+  });
+
   describe('Invalid syntax', () => {
     it('should reject non-function code', () => {
       const result = validate('const x = 1;');
@@ -327,6 +414,15 @@ describe('execute', () => {
       expect(() => {
         execute(code, basePayload);
       }).toThrow('Error executing JavaScript template');
+    });
+
+    it('should refuse to run a stored template that fails validation', () => {
+      // A template that was persisted at some point but does not pass
+      // validation must not reach new Function().
+      const code = `(payload) => payload['constructor']['constructor']('return 1')()`;
+      expect(() => {
+        execute(code, basePayload);
+      }).toThrow('Invalid JavaScript template');
     });
   });
 });

--- a/packages/js-runtime/src/validate.test.ts
+++ b/packages/js-runtime/src/validate.test.ts
@@ -218,6 +218,14 @@ describe('validate', () => {
       expect(result.error).toContain('not allowed');
     });
 
+    it('should block writing through a no-substitution template literal key', () => {
+      const result = validate(
+        '(payload) => { payload[`__proto__`].x = 1; return payload; }',
+      );
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('__proto__');
+    });
+
     it('should still allow writing an ordinary property', () => {
       const result = validate(
         '(payload) => { const out = {}; out.event = payload.name; return out; }',

--- a/packages/js-runtime/src/validate.ts
+++ b/packages/js-runtime/src/validate.ts
@@ -12,6 +12,60 @@ import {
 } from './ast-walker';
 
 /**
+ * Property names that must never be written through. Assigning to any of
+ * these reaches objects shared with the rest of the worker process.
+ */
+const FORBIDDEN_WRITE_PROPERTIES = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+]);
+
+/**
+ * The static name of a member expression's property, or undefined when the key
+ * is only known at run time (obj[someVariable]).
+ */
+function staticPropertyName(
+  member: Record<string, unknown>
+): string | undefined {
+  const prop = member.property as Record<string, unknown> | undefined;
+  if (!prop) {
+    return undefined;
+  }
+  if (member.computed) {
+    // Only a literal key can be resolved. Babel has already decoded any
+    // \u / \x escapes into StringLiteral.value by this point.
+    return prop.type === 'StringLiteral' ? (prop.value as string) : undefined;
+  }
+  return prop.type === 'Identifier' ? (prop.name as string) : undefined;
+}
+
+/**
+ * Walk an assignment target back down its member chain and return the first
+ * forbidden property name it passes through, if any. payload.__proto__.x is a
+ * write to 'x' but goes through '__proto__', so the whole chain matters.
+ */
+function forbiddenPropertyInChain(
+  target: Record<string, unknown>
+): string | undefined {
+  let current: Record<string, unknown> | undefined = target;
+
+  while (
+    current &&
+    (current.type === 'MemberExpression' ||
+      current.type === 'OptionalMemberExpression')
+  ) {
+    const name = staticPropertyName(current);
+    if (name && FORBIDDEN_WRITE_PROPERTIES.has(name)) {
+      return name;
+    }
+    current = current.object as Record<string, unknown> | undefined;
+  }
+
+  return undefined;
+}
+
+/**
  * Validates that a JavaScript function is safe to execute
  * by checking the AST for allowed operations only (allowlist approach)
  */
@@ -104,6 +158,13 @@ export function validate(code: string): {
         node.type === 'ExportDeclaration'
       ) {
         validationError = 'import/export statements are not allowed';
+        return;
+      }
+
+      // Block dynamic import(). @babel/parser emits 'Import' as the callee of
+      // the surrounding CallExpression; 'ImportExpression' is the ESTree shape.
+      if (node.type === 'Import' || node.type === 'ImportExpression') {
+        validationError = 'Dynamic import() is not allowed';
         return;
       }
 
@@ -212,12 +273,17 @@ export function validate(code: string): {
           const prop = callee.property as Record<string, unknown>;
           const computed = callee.computed as boolean;
 
+          // A computed key (obj[expr]()) cannot be matched against the
+          // allowlist, because the property name is only known at run time.
+          // Refuse it rather than letting it past the checks below unseen.
+          if (computed) {
+            validationError =
+              'Computed property access on a call target is not allowed. Use a literal method name, e.g. value.toUpperCase().';
+            return;
+          }
+
           // Static method call on global object: Math.random(), JSON.parse()
-          if (
-            obj.type === 'Identifier' &&
-            prop.type === 'Identifier' &&
-            !computed
-          ) {
+          if (obj.type === 'Identifier' && prop.type === 'Identifier') {
             const objName = obj.name as string;
             const methodName = prop.name as string;
 
@@ -232,7 +298,7 @@ export function validate(code: string): {
 
           // Instance method call: arr.map(), str.toLowerCase(), arr?.map()
           // We allow these if the method name is in ALLOWED_INSTANCE_METHODS
-          if (prop.type === 'Identifier' && !computed) {
+          if (prop.type === 'Identifier') {
             const methodName = prop.name as string;
 
             // If calling on something other than an allowed global,
@@ -253,12 +319,35 @@ export function validate(code: string): {
       // Check 'new' expressions - only allow new Date()
       if (node.type === 'NewExpression') {
         const callee = node.callee as Record<string, unknown>;
-        if (callee.type === 'Identifier') {
-          const name = callee.name as string;
-          if (name !== 'Date') {
-            validationError = `'new ${name}()' is not allowed. Only 'new Date()' is permitted.`;
-            return;
-          }
+
+        // Anything other than a bare identifier (a member expression, a
+        // parenthesised expression, another call) names a constructor we
+        // cannot resolve, so it can never be the Date we allow.
+        if (callee.type !== 'Identifier') {
+          validationError =
+            "The target of 'new' must be a plain identifier. Only 'new Date()' is permitted.";
+          return;
+        }
+
+        const name = callee.name as string;
+        if (name !== 'Date') {
+          validationError = `'new ${name}()' is not allowed. Only 'new Date()' is permitted.`;
+          return;
+        }
+      }
+
+      // Block writes that reach the prototype chain: payload.__proto__.x = 1,
+      // payload['constructor'].prototype.y = 2. Reading these is already
+      // handled by the call and 'new' checks above.
+      if (
+        node.type === 'AssignmentExpression' ||
+        node.type === 'UpdateExpression'
+      ) {
+        const target = (node.left ?? node.argument) as Record<string, unknown>;
+        const reached = forbiddenPropertyInChain(target);
+        if (reached) {
+          validationError = `Assigning through '${reached}' is not allowed.`;
+          return;
         }
       }
     });

--- a/packages/js-runtime/src/validate.ts
+++ b/packages/js-runtime/src/validate.ts
@@ -33,9 +33,23 @@ function staticPropertyName(
     return undefined;
   }
   if (member.computed) {
-    // Only a literal key can be resolved. Babel has already decoded any
-    // \u / \x escapes into StringLiteral.value by this point.
-    return prop.type === 'StringLiteral' ? (prop.value as string) : undefined;
+    // A literal key can be resolved. Babel has already decoded any \u / \x
+    // escapes into StringLiteral.value by this point. A template literal
+    // with no substitutions (`__proto__`) is just as static as a string
+    // literal and must resolve the same way, or it walks past this check
+    // unseen.
+    if (prop.type === 'StringLiteral') {
+      return prop.value as string;
+    }
+    if (prop.type === 'TemplateLiteral') {
+      const expressions = prop.expressions as unknown[];
+      const quasis = prop.quasis as Record<string, unknown>[];
+      if (expressions.length === 0 && quasis.length === 1) {
+        const value = quasis[0]!.value as Record<string, unknown>;
+        return value.cooked as string;
+      }
+    }
+    return undefined;
   }
   return prop.type === 'Identifier' ? (prop.name as string) : undefined;
 }


### PR DESCRIPTION
## What changed

`validate()` in `@openpanel/js-runtime` checks webhook JavaScript templates against an allowlist of globals, static methods and instance methods. It only did that check when the code was written as a plain, non-computed identifier. Other spellings of the same access walked past the visitor without ever being compared to the allowlist, so `validate()` returned `valid: true` for them:

- `payload['someMethod']()` — a computed call target. The two branches that consult the allowlist were both guarded on `!computed`, so a computed key matched neither and no other branch picked it up.
- `new (someExpression)()` — the `new` handler only ran its check when the callee was an `Identifier`. A member expression or parenthesised expression fell out of the `if` with no error set.
- `import('node:fs')` — no handler at all. The existing import check covers `ImportDeclaration` only, which is the static `import x from 'y'` form.

The fix rejects each of these rather than skipping them. A computed key cannot be resolved at validation time, so it cannot be matched against the allowlist and is refused. The target of `new` must now be a bare identifier, and that identifier must still be `Date`. Dynamic `import()` is rejected outright.

I also added a check on assignment and update expressions: a write whose member chain passes through `__proto__`, `constructor` or `prototype` is refused. The chain matters rather than just the final property, because `payload.__proto__.x = 1` is a write to `x`.

Separately, `execute()` compiled whatever string it was given. Templates are validated when they are saved, but the saved string is what reaches `new Function()`, and nothing re-checked it on the way. `execute()` now calls `validate()` first and throws before compiling if it fails.

## Evidence

Against `2d4f21e2`:

- `packages/js-runtime/src/validate.ts:216-220` — static-method branch, guarded on `!computed`.
- `packages/js-runtime/src/validate.ts:235` — instance-method branch, also guarded on `!computed`. Between them, a computed call target reached no allowlist check.
- `packages/js-runtime/src/validate.ts:254-263` — `NewExpression` handler; the `if (callee.type === 'Identifier')` at line 256 has no `else`, so a non-identifier callee produced no error.
- `packages/js-runtime/src/execute.ts:20` — `new Function('payload', funcCode)` with no validation in `execute()`.
- `packages/integrations/src/registry.ts:164` — the only place `validate()` runs, on config save.
- `packages/integrations/src/registry.ts:177` — `execute()` on the stored template at delivery time, in the worker.

I confirmed on the base commit that `validate()` returned `valid: true` for all of the forms above, including the escape-sequence spelling `payload['constructor']`, before making any change.

## Tests

12 new cases in `packages/js-runtime/src/validate.test.ts` cover each rejected form plus the `execute()`-level refusal. The existing positive controls are unchanged and still pass: object construction from `payload`, `.map()` with a callback, `new Date().toISOString()`, `Math.round`, template literals, and nested object construction.

`vitest run` on the package: 46 passed. `tsc --noEmit`: clean. Biome reports no findings on the changed files beyond what the package already had on `main` (this package is not currently Biome-clean; `ast-walker.ts`, `index.ts` and the numeric literals in the test fixture were already flagged).

## Deliberately left out

- The plan for this change named `ImportExpression` as the node type for dynamic import. `@babel/parser` without the `estree` plugin actually emits a `CallExpression` whose callee is `Import`. I handle both names so the check survives a parser or plugin change, but the one that fires today is `Import`.
- Computed *reads* are still allowed. Only computed *call targets* are rejected. `payload[key]` for a dynamic `key` remains a reasonable thing for a template to do, and a read on its own does not invoke anything. The call, `new` and prototype-write checks cover the paths where a resolved value would be used.
- The prototype-write check only resolves keys it can see statically: an identifier, or a string literal in a computed position. A write like `payload[k].x = 1` where `k` is a local variable is not resolvable at validation time and is not rejected. Closing that would mean banning computed writes entirely, which is a bigger behavioural change than this needs.
- No schema or API changes, and nothing outside `packages/js-runtime`. The caller in `packages/integrations/src/registry.ts` needed no edit; it already calls both functions.
- `packages/js-runtime/src/ast-walker.ts` has an unused import and some formatting drift that Biome flags. Unrelated to this change, so left alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - JavaScript templates are now validated before execution.
  - Invalid templates are rejected with a clear validation error instead of being executed.
  - Additional unsafe patterns are blocked, including dynamic imports, certain computed property calls, unsupported `new` expressions, and writes to restricted prototype-chain properties.
  - Validation now handles indirect and computed property access, including static template-literal property names, more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->