### PR TITLE
fix(chat): let users save a chart the AI generated to a dashboard

### DIFF
--- a/apps/start/src/components/chat/tool-results/chat-report-result.tsx
+++ b/apps/start/src/components/chat/tool-results/chat-report-result.tsx
@@ -83,24 +83,29 @@ function ChatReportInner({
           }}
         />
       </div>
-      {value.dashboard_url && (
+      {(value.dashboard_url || !report.id) && (
         <div className="border-t px-3 py-1.5 flex items-center justify-between gap-2">
-          <a
-            href={value.dashboard_url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm text-muted-foreground hover:underline"
-          >
-            Open in dashboard →
-          </a>
+          {value.dashboard_url && (
+            <a
+              href={value.dashboard_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-muted-foreground hover:underline"
+            >
+              Open in dashboard →
+            </a>
+          )}
           {!report.id && (
             <Button
               size="sm"
               variant="ghost"
-              className="h-6 text-sm"
+              className="ml-auto h-6 text-sm"
               onClick={() =>
                 pushModal('SaveReport', {
-                  report: report as unknown as IReport,
+                  report: {
+                    ...report,
+                    name: value.name ?? report.name,
+                  } as unknown as IReport,
                   disableRedirect: true,
                 })
               }


### PR DESCRIPTION
## What changed and why

The AI chat renders charts, and there is a Save button meant to put one on a dashboard. It has never rendered. Not "rarely" — for no tool that exists.

The button sat inside a `value.dashboard_url && (...)` block that it shared with the "Open in dashboard" link. Those two controls answer different questions, and sharing a condition broke the button:

- The four tools that produce a saveable ad-hoc chart (`generate_report`, `get_funnel`, `get_rolling_active_users`, `preview_report_with_changes`) all return through `runReportFromConfig`, whose return shape has no `dashboard_url` field. So the whole block was skipped and Save never rendered.
- The one tool that does set `dashboard_url`, `get_report_data`, returns no `report` config, so it bails at the earlier `!report || !report.chartType` guard and never reaches the block at all.

This splits the condition. The link still requires `dashboard_url`, because it is a link to that URL. Save is now gated only on `!report.id`, which is the check that actually matters: it hides Save for a chart that is already a saved report. The container renders when either control has something to show, and Save carries `ml-auto` so it stays right-aligned when it is alone.

The change also passes the chart's title into the modal. Tools return the AI-generated title at the top level of the result, not inside the nested report object, so `defaultValue={report.name}` in the modal was pre-filling blank for every chat chart. Now it pre-fills what the chart is actually called.

One file, frontend only.

## Evidence

- `apps/start/src/components/chat/tool-results/chat-report-result.tsx:86` — the single `value.dashboard_url &&` block wrapping both controls; the `!report.id` check on the button is at :96.
- `packages/mcp/src/tools/analytics/reports.ts:311-352` — `runReportFromConfig`, the path taken by all four ad-hoc chart tools. Its declared return type at :322-329 is `{chartType, interval, startDate, endDate, report, data}`. No `dashboard_url`.
- `packages/mcp/src/tools/analytics/reports.ts:255-303` — `runReport` (`get_report_data`). Sets `dashboard_url` at :295, returns no `report` field, so it fails the guard at `chat-report-result.tsx:57`.
- `apps/api/src/agents/tools/base.ts:384` — the title is spread in as top-level `name`, alongside `...chart`, rather than into the report object.
- `apps/start/src/modals/save-report.tsx:115` — `defaultValue={report.name}`, the field that was pre-filling blank.

No backend change is needed. `report.create` takes `{report: zReport.omit({projectId: true}), dashboardId}` (`packages/trpc/src/routers/report.ts:34-40`) and derives `projectId` from the dashboard row (:56). The only field in `zReport` without a default or optional marker is `series` (`packages/validation/src/index.ts:243-245`), and every chat config sets it. The modal already collects the two things a chat config lacks, name and dashboardId, and submits them itself (`save-report.tsx:101-129`).

## Requested in

UserJot cmtmmqtc500yt0kpiaqkrtkfd, from Chris: "It seemed like it does it right in the chat, but I want it to create reports for me that I can insert into a dashboard."

## Left out on purpose

- **`get_report_data` still renders no chart.** It returns no `report` config, so it stops at the guard on line 57 and shows "Report data returned but no renderable config." That is a separate bug in a separate layer, and fixing it means changing the tool's return shape. Out of scope here. Worth its own issue.
- **`dashboard_url` on ad-hoc charts.** Rather than make `runReportFromConfig` synthesize a URL, the link is simply gated on having one. Saving a chart is the thing that gets it a dashboard to link to.
- **Pre-existing lint in this file.** `biome check` reports 17 diagnostics on this file (class ordering, JSX prop sorting, block statements) on the base commit and 17 after this change. I did not clean them up, to keep the diff readable. Only the Save button's own class string was reordered, because appending `ml-auto` would otherwise have added an 18th.

## Checks

- `tsc --noEmit` in `apps/start`: clean, 0 errors, after running `pnpm db:codegen`. Without the generated Prisma client the repo reports 318 errors; they are all `@openpanel/db has no exported member` cascades and unrelated to this change.
- `biome check` on the changed file: 17 diagnostics, same count as base. No new lint debt.
- `pnpm vitest run` could not run: it needs ClickHouse on 127.0.0.1:8123, which is not available in this environment. There are no tests covering `chat/tool-results/` either way.

The behaviour itself is worth clicking through: generate a chart in chat, confirm Save appears, save it to a dashboard, and confirm a chart that is already a saved report shows no Save button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat report actions now appear when a report can be saved, even if no dashboard link is available.
  * The “Open in dashboard” link only appears when a dashboard is configured.
  * The “Save” button is correctly shown for unsaved reports and aligned to the right.
  * Saving a report now preserves its existing details while applying the report name appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->