### PR TITLE
Render a chart for saved reports in chat instead of a fallback card

### DIFF
--- a/packages/mcp/src/tools/analytics/reports.ts
+++ b/packages/mcp/src/tools/analytics/reports.ts
@@ -7,6 +7,7 @@ import {
   getReportById,
   getReportsByDashboardId,
   getSettingsForProject} from '@openpanel/db';
+import type { IServiceReport } from '@openpanel/db';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { McpAuthContext } from '../../auth';
@@ -222,14 +223,19 @@ export function registerReportTools(
           return result;
         }
 
+        // `runReport` carries the saved report config for callers that render a
+        // chart. An MCP client reads numbers, so drop it rather than spend the
+        // tokens.
+        const { report: _config, ...rest } = result;
+
         // Funnel and metric results are already small and have their own shape;
         // only the multi-series charts need reshaping.
-        const chart = result.data as { series?: ChartSeries[]; metrics?: unknown };
-        if (result.chartType === 'funnel' || result.chartType === 'metric' || !Array.isArray(chart.series)) {
-          return result;
+        const chart = rest.data as { series?: ChartSeries[]; metrics?: unknown };
+        if (rest.chartType === 'funnel' || rest.chartType === 'metric' || !Array.isArray(chart.series)) {
+          return rest;
         }
 
-        const { data: _raw, ...meta } = result;
+        const { data: _raw, ...meta } = rest;
         return {
           ...meta,
           ...shapeChart(chart as { series: ChartSeries[]; metrics: unknown }, {
@@ -267,6 +273,12 @@ export async function runReport(input: {
       startDate: string;
       endDate: string;
       dashboard_url: string;
+      /**
+       * The saved config in the same `zReportInput` shape `runReportFromConfig`
+       * returns, so a caller holding this result can draw the chart instead of
+       * only reading the numbers off `data`.
+       */
+      report: Omit<NonNullable<IServiceReport>, 'layout'>;
       data: unknown;
     }
 > {
@@ -284,6 +296,12 @@ export async function runReport(input: {
   const { startDate, endDate } = getChartStartEndDate(report, timezone);
   const chartInput = { ...report, startDate, endDate, timezone };
 
+  // `layout` is the dashboard grid position, not part of the chart config —
+  // everything else `transformReport` returns already matches `zReportInput`
+  // (the DB `events` column arrives here as `series`). `id` stays on, so a
+  // caller can tell an already-saved report from an ad-hoc one.
+  const { layout: _layout, ...config } = report;
+
   const meta = {
     id: report.id,
     name: report.name,
@@ -293,6 +311,7 @@ export async function runReport(input: {
     startDate,
     endDate,
     dashboard_url: reportUrl(input.organizationId, input.projectId, input.reportId),
+    report: config,
   };
 
   if (report.chartType === 'funnel') {


### PR DESCRIPTION
Ask the AI chat to run a saved report and you get the text "Report data returned but no renderable config" where the chart should be. The numbers are fetched correctly; the renderer just has nothing to draw with.

## What changed

`runReport` now returns the saved report's config under a `report` key, alongside the meta and data it already returned. That is the same key `runReportFromConfig` returns for ad-hoc charts, which is why charts from `generate_report` have always rendered and saved ones have not.

The config comes from the report row `runReport` already loads, so there is no extra query. `transformReport` in the db package already maps the row onto `IReport`, including turning the `events` Json column into `series`, so the only field dropped is `layout` (the dashboard grid position, not part of a chart config). `id` is kept deliberately: the renderer uses `!report.id` to decide whether to offer a Save button, and a report that is already saved should not offer one.

The MCP `get_report_data` tool strips the config back off. An MCP client reads numbers out of the response and cannot draw a chart, so its output shape is unchanged and it does not pay tokens for a config it has no use for.

No change was needed in `apps/api/src/agents/tools/base.ts` — its `get_report_data` returns `runReport`'s result directly, so the config flows through.

## Evidence

- `packages/mcp/src/tools/analytics/reports.ts:287-296` (before this change) built the meta object with id, name, chartType, range, interval, startDate, endDate and dashboard_url. No `report` key anywhere in the function.
- `apps/api/src/agents/tools/base.ts:140-146` returns `runReport(...)` unmodified, so the gap reaches the frontend.
- `apps/start/src/components/chat/tool-results/chat-report-result.tsx:56-65` reads `value.report` and returns the "no renderable config" card when it is missing or has no `chartType`.
- `packages/mcp/src/tools/analytics/reports.ts:342` shows the shape that does work: `report: { ...input.config, projectId }`.
- `packages/db/src/services/reports.service.ts:83-116` is where the DB row becomes an `IReport`, `report.events` → `series` at line 98.
- `apps/start/src/components/report-chart/context.tsx:26` types the prop as `IReportInput & { id?: string }`, which the stored config satisfies.

## Requested in

UserJot: "Chat conversation lost on refresh, and wants chat-generated reports insertable into a dashboard". Found while investigating that report; it is a separate bug in the same component area and ships on its own.

## Deliberately left out

- `chat-report-result.tsx` is untouched. The `!report` guard is correct defensive behaviour for genuinely malformed results, and the fix belongs in the data.
- The Save button gating at `chat-report-result.tsx:86` (`value.dashboard_url &&`) is a separate bug with its own root cause. Not fixed here.
- The config carries the report's own `range`/`startDate`/`endDate` rather than the resolved dates the engine used, so the chart renders the same window the dashboard shows for that report. This matches how `share.report.$shareId.tsx` feeds a saved report to `ReportChart`.
- Biome reports four pre-existing formatting and lint findings in `reports.ts`. They are identical before and after this change, so the file was left unformatted rather than reformatted in an unrelated diff.

## Verification

`pnpm typecheck` passes clean in `packages/mcp`, `apps/api` and `packages/db`. The mcp unit tests pass (8 of 9 files); `src/integration/tools.test.ts` fails with 41 errors, identically on this branch and on the base commit, because it needs local Postgres and ClickHouse and there is no Docker in this environment.

Not verified by running: the end-to-end chat behaviour. A reviewer with a real project should ask the chat to run a saved report and confirm a chart renders, the "Open in dashboard" link still appears, no Save button appears, and reports using breakdowns or global filters render too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Report execution results now include the saved report configuration in the response metadata and typed report field.

* **Bug Fixes**
  * Report data responses no longer expose the saved report configuration to MCP clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->