### PR TITLE
Base clientSecretAuth on the verification result

### DIFF
--- a/apps/api/src/hooks/is-bot.hook.test.ts
+++ b/apps/api/src/hooks/is-bot.hook.test.ts
@@ -73,6 +73,18 @@ describe('isBotHook', () => {
     expect(status).toHaveBeenCalledWith(202);
   });
 
+  it('still handles bots when a client secret was sent but did not verify', async () => {
+    isBot.mockResolvedValue({ name: 'Googlebot', type: 'Search bot' });
+    const req = makeReq({ clientSecretAuth: false });
+    const { reply, status } = makeReply();
+
+    await isBotHook(req as never, reply);
+
+    expect(isBot).toHaveBeenCalledWith('Googlebot/2.1');
+    expect(createBotEvent).toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(202);
+  });
+
   it('passes legitimate public traffic through untouched', async () => {
     isBot.mockResolvedValue(null);
     const req = makeReq({ headers: { 'user-agent': 'node' } as never });

--- a/apps/api/src/utils/auth.test.ts
+++ b/apps/api/src/utils/auth.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for validateSdkRequest — the ingestion auth check behind POST /track
+ * and the deprecated POST /event.
+ *
+ * The behaviour guarded here: `req.clientSecretAuth` and revenue ingestion
+ * follow whether the supplied secret verified against the stored hash, not
+ * whether a secret string was present on the request.
+ */
+
+import type { FastifyRequest } from 'fastify';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const verifyPassword = vi.fn();
+const getClientByIdCached = vi.fn();
+const redisGet = vi.fn();
+const redisSetex = vi.fn();
+
+vi.mock('@openpanel/common/server', () => ({
+  verifyPassword: (...args: unknown[]) => verifyPassword(...args),
+}));
+vi.mock('@openpanel/db', () => ({
+  ClientType: { read: 'read', write: 'write', root: 'root' },
+  getClientByIdCached: (...args: unknown[]) => getClientByIdCached(...args),
+}));
+vi.mock('@openpanel/redis', () => ({
+  getRedisCache: () => ({ get: redisGet, setex: redisSetex }),
+}));
+
+const { validateSdkRequest } = await import('./auth');
+
+const CLIENT_ID = '11111111-1111-4111-8111-111111111111';
+const ORIGIN = 'https://app.example.com';
+
+function makeClient(overrides: Record<string, unknown> = {}) {
+  return {
+    id: CLIENT_ID,
+    projectId: 'proj-1',
+    secret: 'stored-hash',
+    ignoreCorsAndSecret: false,
+    ...overrides,
+    project: {
+      cors: [ORIGIN],
+      allowUnsafeRevenueTracking: false,
+      filters: [],
+      ...((overrides.project as Record<string, unknown>) ?? {}),
+    },
+  };
+}
+
+function makeReq({
+  headers = {},
+  revenue = false,
+}: {
+  headers?: Record<string, string>;
+  revenue?: boolean;
+} = {}) {
+  return {
+    headers: { 'openpanel-client-id': CLIENT_ID, ...headers },
+    clientIp: '1.2.3.4',
+    body: {
+      type: 'track',
+      payload: {
+        name: 'purchase',
+        properties: revenue ? { __revenue: 42 } : {},
+      },
+    },
+  } as unknown as FastifyRequest<never> & { clientSecretAuth?: boolean };
+}
+
+beforeEach(() => {
+  verifyPassword.mockReset();
+  getClientByIdCached.mockReset();
+  redisGet.mockReset();
+  redisSetex.mockReset();
+  redisGet.mockResolvedValue(null);
+  redisSetex.mockResolvedValue('OK');
+  getClientByIdCached.mockResolvedValue(makeClient());
+});
+
+describe('validateSdkRequest', () => {
+  it('does not mark a request authenticated when the secret does not match', async () => {
+    verifyPassword.mockResolvedValue(false);
+    const req = makeReq({
+      headers: { origin: ORIGIN, 'openpanel-client-secret': 'guessed' },
+    });
+
+    await expect(validateSdkRequest(req as never)).resolves.toMatchObject({
+      id: CLIENT_ID,
+    });
+    expect(req.clientSecretAuth).toBe(false);
+    expect(redisSetex).not.toHaveBeenCalled();
+  });
+
+  it('rejects revenue from an origin-authorized request with a bad secret', async () => {
+    verifyPassword.mockResolvedValue(false);
+    const req = makeReq({
+      headers: { origin: ORIGIN, 'openpanel-client-secret': 'guessed' },
+      revenue: true,
+    });
+
+    await expect(validateSdkRequest(req as never)).rejects.toThrow(
+      'Revenue tracking is not allowed without a client secret'
+    );
+    expect(req.clientSecretAuth).toBe(false);
+  });
+
+  it('rejects a bad secret outright when no origin is allowed', async () => {
+    verifyPassword.mockResolvedValue(false);
+    const req = makeReq({
+      headers: { 'openpanel-client-secret': 'guessed' },
+    });
+
+    await expect(validateSdkRequest(req as never)).rejects.toThrow(
+      'Invalid cors or secret'
+    );
+    expect(req.clientSecretAuth).toBe(false);
+  });
+
+  it('lets ordinary browser traffic through on the origin alone', async () => {
+    const req = makeReq({ headers: { origin: ORIGIN } });
+
+    await expect(validateSdkRequest(req as never)).resolves.toMatchObject({
+      id: CLIENT_ID,
+    });
+    expect(req.clientSecretAuth).toBe(false);
+    expect(verifyPassword).not.toHaveBeenCalled();
+  });
+
+  it('authorizes a correct secret without an origin and accepts revenue', async () => {
+    verifyPassword.mockResolvedValue(true);
+    const req = makeReq({
+      headers: { 'openpanel-client-secret': 'correct' },
+      revenue: true,
+    });
+
+    await expect(validateSdkRequest(req as never)).resolves.toMatchObject({
+      id: CLIENT_ID,
+    });
+    expect(req.clientSecretAuth).toBe(true);
+    expect(redisSetex).toHaveBeenCalledWith(
+      expect.stringContaining(`client:auth:${CLIENT_ID}:`),
+      300,
+      'true'
+    );
+  });
+
+  it('trusts a cached successful verification without re-hashing', async () => {
+    redisGet.mockResolvedValue('true');
+    const req = makeReq({ headers: { 'openpanel-client-secret': 'correct' } });
+
+    await validateSdkRequest(req as never);
+
+    expect(req.clientSecretAuth).toBe(true);
+    expect(verifyPassword).not.toHaveBeenCalled();
+  });
+
+  it('does not trust a cached "false" left over from earlier releases', async () => {
+    redisGet.mockResolvedValue('false');
+    verifyPassword.mockResolvedValue(false);
+    const req = makeReq({
+      headers: { origin: ORIGIN, 'openpanel-client-secret': 'guessed' },
+    });
+
+    await validateSdkRequest(req as never);
+
+    expect(req.clientSecretAuth).toBe(false);
+    expect(verifyPassword).toHaveBeenCalled();
+  });
+
+  it('skips the cache entirely when the client has no stored secret', async () => {
+    getClientByIdCached.mockResolvedValue(makeClient({ secret: null }));
+    const req = makeReq({
+      headers: { origin: ORIGIN, 'openpanel-client-secret': 'anything' },
+    });
+
+    await validateSdkRequest(req as never);
+
+    expect(req.clientSecretAuth).toBe(false);
+    expect(redisGet).not.toHaveBeenCalled();
+    expect(redisSetex).not.toHaveBeenCalled();
+    expect(verifyPassword).not.toHaveBeenCalled();
+  });
+
+  it('accepts revenue with no secret when allowUnsafeRevenueTracking is on', async () => {
+    getClientByIdCached.mockResolvedValue(
+      makeClient({ project: { allowUnsafeRevenueTracking: true } })
+    );
+    const req = makeReq({ headers: { origin: ORIGIN }, revenue: true });
+
+    await expect(validateSdkRequest(req as never)).resolves.toMatchObject({
+      id: CLIENT_ID,
+    });
+    expect(req.clientSecretAuth).toBe(false);
+  });
+
+  it('rejects revenue with no secret when allowUnsafeRevenueTracking is off', async () => {
+    const req = makeReq({ headers: { origin: ORIGIN }, revenue: true });
+
+    await expect(validateSdkRequest(req as never)).rejects.toThrow(
+      'Revenue tracking is not allowed without a client secret'
+    );
+  });
+});

--- a/apps/api/src/utils/auth.ts
+++ b/apps/api/src/utils/auth.ts
@@ -1,7 +1,7 @@
 import { verifyPassword } from '@openpanel/common/server';
 import type { IServiceClientWithProject } from '@openpanel/db';
 import { ClientType, getClientByIdCached } from '@openpanel/db';
-import { getCache } from '@openpanel/redis';
+import { getRedisCache } from '@openpanel/redis';
 import type {
   DeprecatedPostEventPayload,
   IProjectFilterIp,
@@ -39,6 +39,46 @@ export class SdkAuthError extends Error {
   }
 }
 
+const CLIENT_SECRET_CACHE_SEC = 60 * 5;
+
+/**
+ * Checks a supplied client secret against the stored hash.
+ *
+ * Only successful verifications are cached. The cache key contains the
+ * caller-supplied secret, so caching a negative result would let anyone create
+ * entries with keys of their choosing. A client with no stored secret skips the
+ * cache entirely.
+ */
+async function verifyClientSecret(
+  clientId: string,
+  clientSecret: string | undefined,
+  storedSecret: string | null | undefined
+): Promise<boolean> {
+  if (!(storedSecret && clientSecret)) {
+    return false;
+  }
+
+  const cacheKey = `client:auth:${clientId}:${Buffer.from(clientSecret).toString('base64')}`;
+
+  // Strict compare: entries written before only positives were cached may still
+  // hold "false".
+  if ((await getRedisCache().get(cacheKey)) === 'true') {
+    return true;
+  }
+
+  const isVerified = await verifyPassword(clientSecret, storedSecret);
+
+  if (isVerified) {
+    getRedisCache()
+      .setex(cacheKey, CLIENT_SECRET_CACHE_SEC, 'true')
+      .catch(() => {
+        // ignore error
+      });
+  }
+
+  return isVerified;
+}
+
 export async function validateSdkRequest(
   req: FastifyRequest<{
     Body: ITrackHandlerPayload | DeprecatedPostEventPayload;
@@ -58,10 +98,6 @@ export async function validateSdkRequest(
   const clientSecret =
     clientSecretNew || clientSecretOld || clientSecretFromBody;
   const origin = headers.origin;
-
-  if (clientSecret) {
-    req.clientSecretAuth = true;
-  }
 
   const createError = (message: string) =>
     new SdkAuthError(message, {
@@ -95,6 +131,16 @@ export async function validateSdkRequest(
     throw createError('Ingestion: Client has no project');
   }
 
+  // Whether the supplied secret actually matches the stored hash. Everything
+  // downstream keys off this, not off the mere presence of a secret.
+  const secretVerified = await verifyClientSecret(
+    clientId,
+    clientSecret,
+    client.secret
+  );
+
+  req.clientSecretAuth = secretVerified;
+
   // Filter out blocked IPs
   const ipFilter = client.project.filters.filter(
     (filter): filter is IProjectFilterIp => filter.type === 'ip'
@@ -119,10 +165,10 @@ export async function validateSdkRequest(
     path(['payload', 'properties', '__revenue'], req.body) ??
     path(['properties', '__revenue'], req.body);
 
-  // Only allow revenue tracking if it was sent with a client secret
+  // Only allow revenue tracking if it was sent with a verified client secret
   // or if the project has allowUnsafeRevenueTracking enabled
   if (
-    !(client.project.allowUnsafeRevenueTracking || clientSecret) &&
+    !(client.project.allowUnsafeRevenueTracking || secretVerified) &&
     typeof revenue !== 'undefined'
   ) {
     throw createError(
@@ -160,16 +206,8 @@ export async function validateSdkRequest(
     }
   }
 
-  if (client.secret && clientSecret) {
-    const isVerified = await getCache(
-      `client:auth:${clientId}:${Buffer.from(clientSecret).toString('base64')}`,
-      60 * 5,
-      async () => await verifyPassword(clientSecret, client.secret!),
-      true
-    );
-    if (isVerified) {
-      return client;
-    }
+  if (secretVerified) {
+    return client;
   }
 
   throw createError('Ingestion: Invalid cors or secret');


### PR DESCRIPTION
## What changed

`req.clientSecretAuth` was set from the *presence* of the client-secret header or body field, before anything compared it against the stored hash. It reported "authenticated" for any string a caller cared to send. The revenue guard in `validateSdkRequest` read the same raw value rather than a verification result. Both now follow whether the secret actually matched.

The restructure:

- Verification moved into a `verifyClientSecret` helper and runs once, right after the client and project load, producing a single `secretVerified` boolean.
- `req.clientSecretAuth = secretVerified`. The field stays, since server-side SDK traffic relies on it, and it is still true for a correct secret.
- The revenue condition is now `allowUnsafeRevenueTracking || secretVerified`.
- The `ignoreCorsAndSecret` and allowed-origin paths no longer return before `secretVerified` has been computed. The authorization outcome is otherwise unchanged: `ignoreCorsAndSecret`, an allowed origin, or a verified secret each authorize the request, and none of them still gives `Ingestion: Invalid cors or secret`.

A browser request that carries a non-matching secret is still authorized by its origin, but now reports `clientSecretAuth` false. Correct server-side SDK traffic and normal origin-authorized browser traffic behave exactly as before.

### Caching

Verification now runs on requests that previously skipped it via the origin paths, which changes what reaches the cache. The cache key embeds the caller-supplied secret, so the helper only writes on a successful verification, and skips the cache entirely when the client has no stored secret. Otherwise any caller could fill the cache with keys of their choosing.

The read compares strictly against `"true"`. Keys written by the current release can hold `"false"`, and those must not be read as a pass after deploy.

One tradeoff: the helper talks to Redis directly instead of going through `getCache`, so this key no longer uses the in-process LRU tier. `getCache` writes whatever the function returns for the full TTL and has no way to skip a write, and adding that option to a shared package felt like the larger change. Verified secrets still get the 5 minute Redis cache, so the argon2 hash is not repeated per request.

## Evidence

- `apps/api/src/utils/auth.ts:62-64` (before) set `req.clientSecretAuth = true` on presence alone.
- `apps/api/src/utils/auth.ts:124-131` (before) gated revenue on `client.project.allowUnsafeRevenueTracking || clientSecret`, the raw string.
- `apps/api/src/utils/auth.ts:163-173` (before) held the only `verifyPassword` call, reached only when the origin paths at `133-161` did not return first.
- `packages/redis/cachable.ts:46-55` writes the function result for the full TTL unconditionally, including `false`.

Consumers of the flag, read and left unchanged: `apps/api/src/hooks/is-bot.hook.ts:20`, `apps/api/src/bots/suspicion.ts:67`, `apps/api/src/controllers/track.controller.ts:214`, `apps/api/src/controllers/event.controller.ts:56`. Both `POST /track` and the deprecated `POST /event` go through `apps/api/src/hooks/client.hook.ts`, so both pick this up.

## Tests

New `apps/api/src/utils/auth.test.ts` covers the origin-plus-bad-secret case (authorized, flag false, revenue rejected), the same request without `__revenue` (the ordinary browser case, must not regress), a correct secret with no origin (authorized, flag true, revenue accepted), both `allowUnsafeRevenueTracking` settings with no secret, an absent `client.secret` with a supplied string (no cache read or write), and the two cache-read cases.

`apps/api/src/hooks/is-bot.hook.test.ts` gains a bot user-agent arriving with an unverified secret, confirming bot handling still runs. The existing case where a verified secret skips bot handling still passes.

Checked against the old semantics: reverting the two behavioural lines fails 5 of the 10 new tests.

## Left out

- `packages/mcp/src/auth.ts:108` has the same cache-the-negative shape. It is a different entry point and rejects on a failed verification rather than carrying the result forward, so it is not part of this change.
- Two lint findings reported by biome on the touched files, a formatting nit in `is-bot.hook.test.ts` and `useIterableCallbackReturn` on the pre-existing cors `find` callback, are identical on the base commit and were left alone.
- No schema, config, or SDK changes.

## Checks

- `vitest run src/utils/auth.test.ts src/hooks/is-bot.hook.test.ts` in `apps/api`: 14 passed.
- `tsc --noEmit` in `apps/api`: clean.
- `biome check` on the three touched files: same two findings as the base commit, no new ones.
- Full `apps/api` suite: 10 of 11 files pass. `src/routes/insights.router.test.ts` times out because Postgres and ClickHouse are not running in this environment, not from anything here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected client-secret authentication so requests are authorized only after successful verification.
  * Prevented revenue tracking from being accepted when an invalid client secret is provided.
  * Improved handling of authenticated requests by reusing successful verification results.
  * Ensured bot detection continues to process requests with invalid client credentials.
  * Preserved valid origin-only browser requests where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->