### PR TITLE
Escape property keys in ClickHouse Map access expressions

### DIFF
--- a/packages/db/src/services/chart.service.ts
+++ b/packages/db/src/services/chart.service.ts
@@ -379,7 +379,9 @@ export function getSelectPropertyKey(
     )})))`;
   }
 
-  return `${aliasPrefix}${match}['${property.replace(new RegExp(`^${match}.`), '')}']`;
+  return `${aliasPrefix}${match}[${sqlstring.escape(
+    property.slice(match.length + 1)
+  )}]`;
 }
 
 
@@ -442,11 +444,19 @@ export function profilePropertiesCteSelect(
 // for the narrowed keys. Matches the raw render from getSelectPropertyKey /
 // the filter builders; never matches the CTE's own `properties['<key>']`,
 // which has no `profile.` prefix. No-op when keys is empty.
+// The Map-access text a `profile.properties.<key>` ref renders as. Must stay
+// identical to what `getSelectPropertyKey` emits for that key: a key whose
+// quotes are escaped there but not here would be searched for in a form the
+// query never contains, leaving the ref pointing at a Map the CTE dropped.
+function profilePropertyRef(key: string): string {
+  return `profile.properties[${sqlstring.escape(key)}]`;
+}
+
 export function rewriteProfilePropertyRefs(sql: string, keys: string[]): string {
   let out = sql;
   for (const k of keys) {
     out = out
-      .split(`profile.properties['${k}']`)
+      .split(profilePropertyRef(k))
       .join(`\`profile.properties.${k}\``);
   }
   return out;

--- a/packages/db/src/services/funnel-sql.test.ts
+++ b/packages/db/src/services/funnel-sql.test.ts
@@ -229,8 +229,10 @@ describe('funnel.service / buildFunnelCte — step pre-filter', () => {
 
   it('filters the scan to rows matching at least one step condition', async () => {
     const sql = await buildChartSql([]);
+    // Each step condition is parenthesised by the WHERE builder and again by
+    // the OR join, hence the doubled parens.
     expect(sql).toContain(
-      "((events.name = 'screen_view') OR (events.name = 'sign_up'))",
+      "(((events.name = 'screen_view')) OR ((events.name = 'sign_up')))",
     );
     for (const condition of funnelService.getFunnelConditions(
       // The same checked narrowing buildFunnelBase applies internally.

--- a/packages/db/src/services/property-key-escaping.test.ts
+++ b/packages/db/src/services/property-key-escaping.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Property keys reach the SQL builders as free text: a filter name, a
+ * breakdown name or a math-metric property from a saved report or an API
+ * call. They end up inside a ClickHouse Map access, so a key carrying a
+ * quote must stay one string literal — otherwise it closes the literal and
+ * the rest of the key is parsed as SQL, next to the `project_id` predicate
+ * that scopes the query to one project.
+ *
+ * String assertions only; no ClickHouse needed.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const { capturedSql } = vi.hoisted(() => ({ capturedSql: [] as string[] }));
+
+vi.mock('../clickhouse/client', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../clickhouse/client')>();
+  return {
+    ...actual,
+    chQuery: (sql: string) => {
+      capturedSql.push(sql);
+      return Promise.resolve([]);
+    },
+  };
+});
+
+import { createSqlBuilder } from '../sql-builder';
+import {
+  collectProfilePropertyKeys,
+  getAggregateChartSql as _getAggregateChartSql,
+  getChartSql as _getChartSql,
+  getSelectPropertyKey,
+  profilePropertiesCteSelect,
+  rewriteProfilePropertyRefs,
+} from './chart.service';
+import { getEventList, getEventsCount } from './event.service';
+
+const getChartSql: (input: any) => Promise<string> = _getChartSql as any;
+const getAggregateChartSql: (input: any) => Promise<string> =
+  _getAggregateChartSql as any;
+
+const PROJECT_ID = 'test-sql-validation';
+const START = '2026-04-14 00:00:00';
+const END = '2026-05-15 00:00:00';
+
+beforeAll(() => {
+  // The chart service logs every query it builds; mute it.
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+// A key that closes the literal, appends its own predicate, and reopens a
+// literal so the tail of the original render still parses.
+const BREAKOUT_KEY = "x'] = '' OR 1 = 1 OR properties['y";
+const BREAKOUT_PROPERTY = `properties.${BREAKOUT_KEY}`;
+
+/**
+ * The query must keep exactly one project_id predicate, and the key must not
+ * have contributed a boolean operator of its own outside a string literal.
+ */
+function expectNoInjectedPredicate(sql: string) {
+  expect(sql.match(/project_id =/g) ?? []).toHaveLength(1);
+  // The payload only ever appears with its quotes escaped, i.e. still inside
+  // the Map key literal.
+  expect(sql).not.toContain("'] = '' OR 1 = 1");
+  expect(sql).toContain("\\'] = \\'\\' OR 1 = 1 OR properties[\\'y'");
+}
+
+describe('getSelectPropertyKey / key escaping', () => {
+  it('renders a key with a quote as a single escaped literal', () => {
+    expect(getSelectPropertyKey(BREAKOUT_PROPERTY, undefined, undefined, undefined, 'e')).toBe(
+      "e.properties['x\\'] = \\'\\' OR 1 = 1 OR properties[\\'y']",
+    );
+  });
+
+  it('escapes backslashes and leaves ] alone', () => {
+    expect(getSelectPropertyKey('properties.a\\b]c')).toBe(
+      "properties['a\\\\b]c']",
+    );
+  });
+
+  it('escapes profile property keys the same way', () => {
+    expect(getSelectPropertyKey("profile.properties.pl'an")).toBe(
+      "profile.properties['pl\\'an']",
+    );
+  });
+
+  it('renders ordinary keys unchanged', () => {
+    expect(getSelectPropertyKey('properties.foo')).toBe("properties['foo']");
+    expect(getSelectPropertyKey('properties.foo', undefined, undefined, undefined, 'e')).toBe(
+      "e.properties['foo']",
+    );
+    expect(getSelectPropertyKey('profile.properties.plan')).toBe(
+      "profile.properties['plan']",
+    );
+    expect(getSelectPropertyKey('properties.a.*')).toBe(
+      "arrayMap(x -> trim(x), mapValues(mapExtractKeyLike(properties, 'a.*')))",
+    );
+    expect(getSelectPropertyKey('country')).toBe('country');
+  });
+});
+
+describe('sql-builder / getWhere', () => {
+  it('parenthesises each clause so an OR cannot re-group its neighbours', () => {
+    const { sb, getWhere } = createSqlBuilder();
+    sb.where.project = "project_id = 'p'";
+    sb.where.f0 = "name = 'a' OR 1 = 1";
+    expect(getWhere()).toBe("WHERE (project_id = 'p') AND (name = 'a' OR 1 = 1)");
+  });
+
+  it('is empty when there are no clauses', () => {
+    const { getWhere } = createSqlBuilder();
+    expect(getWhere()).toBe('');
+  });
+});
+
+describe('chart SQL with a hostile property key', () => {
+  const base = {
+    interval: 'day',
+    startDate: START,
+    endDate: END,
+    projectId: PROJECT_ID,
+    timezone: 'UTC',
+  };
+  const event = (overrides: Record<string, unknown> = {}) => ({
+    id: 'A',
+    name: 'screen_view',
+    segment: 'event',
+    filters: [],
+    ...overrides,
+  });
+
+  it('keeps the project scope for a filter name', async () => {
+    const sql = await getChartSql({
+      event: event({
+        filters: [
+          {
+            id: 'f1',
+            name: BREAKOUT_PROPERTY,
+            operator: 'is',
+            value: ['pro'],
+          },
+        ],
+      }),
+      breakdowns: [],
+      ...base,
+    });
+    expectNoInjectedPredicate(sql);
+  });
+
+  it('keeps the project scope for a breakdown name', async () => {
+    const sql = await getChartSql({
+      event: event(),
+      breakdowns: [{ id: 'b', name: BREAKOUT_PROPERTY }],
+      ...base,
+    });
+    expectNoInjectedPredicate(sql);
+  });
+
+  it('keeps the project scope for a math-metric property', async () => {
+    const sql = await getChartSql({
+      event: event({
+        segment: 'property_average',
+        property: BREAKOUT_PROPERTY,
+      }),
+      breakdowns: [],
+      ...base,
+    });
+    expectNoInjectedPredicate(sql);
+  });
+
+  it('keeps the project scope in aggregate chart SQL', async () => {
+    const sql = await getAggregateChartSql({
+      event: event({
+        segment: 'property_sum',
+        property: BREAKOUT_PROPERTY,
+      }),
+      breakdowns: [{ id: 'b', name: BREAKOUT_PROPERTY }],
+      ...base,
+    });
+    expectNoInjectedPredicate(sql);
+  });
+});
+
+describe('event SQL with a hostile property key', () => {
+  const filters = [
+    {
+      id: 'f1',
+      name: BREAKOUT_PROPERTY,
+      operator: 'is' as const,
+      value: ['pro'],
+    },
+  ];
+
+  it('keeps the project scope in the event list query', async () => {
+    capturedSql.length = 0;
+    await getEventList({
+      projectId: PROJECT_ID,
+      take: 10,
+      cursor: 0,
+      filters,
+      startDate: new Date(START),
+      endDate: new Date(END),
+    } as any);
+    expect(capturedSql).toHaveLength(1);
+    expectNoInjectedPredicate(capturedSql[0]!);
+  });
+
+  it('keeps the project scope in the event count query', async () => {
+    capturedSql.length = 0;
+    await getEventsCount({
+      projectId: PROJECT_ID,
+      filters,
+      startDate: new Date(START),
+      endDate: new Date(END),
+    } as any);
+    expect(capturedSql).toHaveLength(1);
+    expectNoInjectedPredicate(capturedSql[0]!);
+  });
+});
+
+describe('profile-property narrowing with a quoted key', () => {
+  const key = "pl'an";
+  const name = `profile.properties.${key}`;
+
+  it('narrows the key and rewrites its reference to the CTE column', () => {
+    const { keys, needsFullMap } = collectProfilePropertyKeys([{ name }]);
+    expect(keys).toEqual([key]);
+    expect(needsFullMap).toBe(false);
+
+    const cteSelect = profilePropertiesCteSelect(keys, needsFullMap);
+    expect(cteSelect).toBe(
+      "properties['pl\\'an'] as `profile.properties.pl'an`",
+    );
+
+    const ref = getSelectPropertyKey(name);
+    const rewritten = rewriteProfilePropertyRefs(`SELECT ${ref}`, keys);
+    expect(rewritten).toBe('SELECT `profile.properties.pl\'an`');
+  });
+
+  it('falls back to the full Map for keys it cannot alias', () => {
+    const { keys, needsFullMap } = collectProfilePropertyKeys([
+      { name: 'profile.properties.a\\b' },
+    ]);
+    expect(keys).toEqual([]);
+    expect(needsFullMap).toBe(true);
+    expect(profilePropertiesCteSelect(keys, needsFullMap)).toBe(
+      'properties as "profile.properties"',
+    );
+  });
+
+  it('leaves ordinary keys narrowing exactly as before', () => {
+    const { keys, needsFullMap } = collectProfilePropertyKeys([
+      { name: 'profile.properties.plan' },
+    ]);
+    expect(keys).toEqual(['plan']);
+    expect(needsFullMap).toBe(false);
+    expect(profilePropertiesCteSelect(keys, needsFullMap)).toBe(
+      "properties['plan'] as `profile.properties.plan`",
+    );
+    expect(
+      rewriteProfilePropertyRefs(
+        `SELECT ${getSelectPropertyKey('profile.properties.plan')}`,
+        keys,
+      ),
+    ).toBe('SELECT `profile.properties.plan`');
+  });
+});

--- a/packages/db/src/sql-builder.ts
+++ b/packages/db/src/sql-builder.ts
@@ -32,8 +32,17 @@ export function createSqlBuilder() {
     fill: undefined,
   };
 
+  // Each clause is parenthesised before the ` AND ` join: a clause with a
+  // top-level OR in it would otherwise re-group its neighbours, so a single
+  // filter could widen what the whole WHERE matches.
+  const joinWhere = (obj: Record<string, string>) =>
+    Object.values(obj)
+      .filter(Boolean)
+      .map((clause) => `(${clause})`)
+      .join(' AND ');
+
   const getWhere = () =>
-    Object.keys(sb.where).length ? `WHERE ${join(sb.where, ' AND ')}` : '';
+    Object.keys(sb.where).length ? `WHERE ${joinWhere(sb.where)}` : '';
   const getHaving = () =>
     Object.keys(sb.having).length ? `HAVING ${join(sb.having, ' AND ')}` : '';
   const getFrom = () => `FROM ${sb.from}`;


### PR DESCRIPTION
## What changed

A property path (`properties.foo`, `profile.properties.plan`) reaches the SQL builders as free text: a filter name, a breakdown name, or a math-metric property, all of which come from a saved report or an API call. `getSelectPropertyKey` turned that path into a Map access by concatenating the key between literal quotes:

```ts
return `${aliasPrefix}${match}['${property.replace(new RegExp(`^${match}.`), '')}']`;
```

A key containing a single quote therefore stopped being one Map access. It closed the string literal, and the remainder of the key was parsed as SQL, sitting in the same WHERE list as the `project_id` predicate that scopes the query to one project. A key like `x'] = '' OR 1 = 1 OR properties['y` produced a valid query with an extra boolean operator in it.

Three changes:

1. `getSelectPropertyKey` builds the non-wildcard Map access with `sqlstring.escape`, the same way the wildcard branch and the group/profile helpers next to it already do. Ordinary keys render byte-for-byte as before; keys with a quote or backslash now stay inside the literal.
2. `rewriteProfilePropertyRefs` searches for the reference text through a shared `profilePropertyRef` helper, so it keeps matching what `getSelectPropertyKey` emits. Without this, a narrowed key with a quote would have kept a reference to a Map the profile CTE no longer selects.
3. `getWhere` in the SQL builder parenthesises each clause before joining with ` AND `. Previously a clause holding a top-level `OR` changed how its neighbours grouped.

## Evidence

- `packages/db/src/services/chart.service.ts:382` — the unescaped render (before this change).
- `packages/db/src/services/chart.service.ts:260`, `:280`, `:314`, `:377` — every other Map render in the same file goes through `sqlstring.escape`; so does the filter side at `packages/db/src/services/filter-where.service.ts:192` and `:211`.
- Callers that inline a caller-supplied name through that render: breakdowns at `packages/db/src/services/chart.service.ts:756` and `:1098`, math metrics at `:786` and `:1135`, and filters at `:1189` (`getEventFiltersWhereClause`), which the event list and event count queries use at `packages/db/src/services/event.service.ts:682` and `:766`.
- `packages/db/src/services/chart.service.ts:445` — `rewriteProfilePropertyRefs` matched the exact text `profile.properties['<key>']`.
- `packages/db/src/sql-builder.ts:36` — `getWhere` joined clauses with ` AND ` and no parentheses.

## Tests

New `packages/db/src/services/property-key-escaping.test.ts` (string assertions only, no ClickHouse needed):

- `getSelectPropertyKey` renders a key containing a quote, a backslash and a `]` as one escaped literal, and renders ordinary keys (`properties.foo`, the `e.`-qualified form, `profile.properties.plan`, the `properties.a.*` wildcard, plain columns) exactly as before.
- Chart SQL for a hostile filter name, breakdown name and math-metric property, plus the aggregate chart, keeps exactly one `project_id =` predicate and the payload stays inside the key literal. Same assertion for the event list and event count queries, captured through a mocked `chQuery`.
- Profile narrowing with a quoted key yields a CTE column and a matching rewritten reference; a key with a backslash still falls back to the full Map; ordinary keys narrow unchanged.
- `getWhere` parenthesises its clauses.

All ten of the injection assertions fail on the current code and pass with the change.

One existing assertion moved: `packages/db/src/services/funnel-sql.test.ts` pinned the funnel step pre-filter text, which now carries the extra parentheses from `getWhere`. The SQL means the same thing; the neighbouring assertion that counts each complete step condition twice is untouched.

## Deliberately left out

- `getAggregateChartSql` and `getChartSql` build the `one_event_per_user` subquery with `join(sb.where, ' AND ')` directly (`chart.service.ts:806`, `:1155`), which still has no parentheses. No builder emits an unparenthesised top-level `OR` today: `contains`, `regex`, `isNull` and the group branch all wrap their own clauses. Changing those two call sites is a wider edit than this needed.
- `transformPropertyKey`'s non-wildcard return (`chart.service.ts:245`) still concatenates quotes, but its only caller reaches it on the wildcard path and wraps the result in `sqlstring.escape`. Left alone.
- The narrowing guard that skips keys with a backtick or backslash is unchanged; those keys keep the full-Map fallback.
- No reformatting. `biome check` reports pre-existing complaints in these files (12 in `chart.service.ts`, 2 in `sql-builder.ts` before and after this change); the new test file follows the style of its neighbours rather than the formatter's output.

## Checks

- `vitest run` over `packages/db/src/services` — 168 passed, 25 skipped. `retention.service.test.ts` fails in this environment because it needs a reachable ClickHouse; it fails identically without this change.
- Full workspace run produces the same set of failing files with and without the change (all of them need ClickHouse, Redis or Postgres, none of which run here).
- `tsc --noEmit` in `packages/db` — 26 errors, all pre-existing, in `notification.service.ts`, `organization.service.ts` and `insights/store.ts`. None in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of property keys containing quotes or backslashes in generated queries.
  * Prevented special characters in property keys from affecting project-scoping filters.
  * Corrected filter grouping to ensure conditions containing `OR` do not broaden results unexpectedly.
  * Updated funnel filtering to preserve correct condition grouping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->