### PR TITLE
fix(react-native): Expo SDK 55 peers + safe User-Agent init

### DIFF
--- a/packages/sdks/react-native/index.ts
+++ b/packages/sdks/react-native/index.ts
@@ -5,12 +5,31 @@ import type {
 } from '@openpanel/sdk';
 import { OpenPanel as OpenPanelBase } from '@openpanel/sdk';
 import * as Application from 'expo-application';
-import Constants from 'expo-constants';
+import * as ExpoConstants from 'expo-constants';
 import { AppState, Platform } from 'react-native';
 
 export * from '@openpanel/sdk';
 
 const QUEUE_STORAGE_KEY = '@openpanel/offline_queue';
+
+/**
+ * Metro/CJS interop can nest the real module under `.default` when this
+ * package is consumed as ESM. Prefer the same `import *` shape we already
+ * use for expo-application, and fall back if the helper is missing so init
+ * never crashes (e.g. Expo SDK 55+ with previously unmet peers).
+ */
+function getWebViewUserAgent(): Promise<string | null> {
+  const mod = ExpoConstants as typeof ExpoConstants & {
+    default?: typeof ExpoConstants;
+  };
+  const constants = (mod.default ?? mod) as {
+    getWebViewUserAgentAsync?: () => Promise<string | null>;
+  };
+  if (typeof constants.getWebViewUserAgentAsync !== 'function') {
+    return Promise.resolve(null);
+  }
+  return constants.getWebViewUserAgentAsync();
+}
 
 interface StorageLike {
   getItem(key: string): Promise<string | null>;
@@ -59,7 +78,7 @@ export class OpenPanel extends OpenPanelBase {
       sdkVersion: process.env.REACT_NATIVE_VERSION!,
     });
 
-    this.api.addHeader('User-Agent', Constants.getWebViewUserAgentAsync());
+    this.api.addHeader('User-Agent', getWebViewUserAgent());
     this.storage = options.storage;
 
     if (options.networkInfo) {

--- a/packages/sdks/react-native/package.json
+++ b/packages/sdks/react-native/package.json
@@ -20,8 +20,8 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "expo-application": "5 - 7",
-    "expo-constants": "14 - 18",
+    "expo-application": ">=5",
+    "expo-constants": ">=14",
     "react-native": "*"
   }
 }

--- a/packages/sdks/react-native/package.json
+++ b/packages/sdks/react-native/package.json
@@ -20,8 +20,8 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "expo-application": ">=5",
-    "expo-constants": ">=14",
+    "expo-application": "5 - 7 || 50 - 55",
+    "expo-constants": "14 - 18 || 50 - 55",
     "react-native": "*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1844,10 +1844,10 @@ importers:
         specifier: workspace:1.3.1-local
         version: link:../sdk
       expo-application:
-        specifier: 5 - 7
+        specifier: 5 - 7 || 50 - 55
         version: 5.3.1(expo@50.0.7(@babel/core@7.29.0(supports-color@10.2.0))(@react-native/babel-preset@0.73.21(@babel/core@7.29.0(supports-color@10.2.0))(@babel/preset-env@7.23.9(@babel/core@7.29.0(supports-color@10.2.0))(supports-color@10.2.0))(supports-color@10.2.0))(bluebird@3.7.2)(react-native@0.73.6(@babel/core@7.29.0(supports-color@10.2.0))(@babel/preset-env@7.23.9(@babel/core@7.29.0(supports-color@10.2.0))(supports-color@10.2.0))(react@18.2.0)(supports-color@10.2.0))(react@18.2.0)(supports-color@10.2.0))
       expo-constants:
-        specifier: 14 - 18
+        specifier: 14 - 18 || 50 - 55
         version: 15.4.5(expo@50.0.7(@babel/core@7.29.0(supports-color@10.2.0))(@react-native/babel-preset@0.73.21(@babel/core@7.29.0(supports-color@10.2.0))(@babel/preset-env@7.23.9(@babel/core@7.29.0(supports-color@10.2.0))(supports-color@10.2.0))(supports-color@10.2.0))(bluebird@3.7.2)(react-native@0.73.6(@babel/core@7.29.0(supports-color@10.2.0))(@babel/preset-env@7.23.9(@babel/core@7.29.0(supports-color@10.2.0))(supports-color@10.2.0))(react@18.2.0)(supports-color@10.2.0))(react@18.2.0)(supports-color@10.2.0))(supports-color@10.2.0)
       react-native:
         specifier: '*'


### PR DESCRIPTION
## Summary
- Fixes [#358](https://github.com/Openpanel-dev/openpanel/issues/358): `@openpanel/react-native` crashed on Expo SDK 55 with `getWebViewUserAgentAsync is not a function`, and declared peers that rejected Expo’s current `55.x` packages.
- Bound Expo peers to `5 - 7 || 50 - 55` / `14 - 18 || 50 - 55` so SDK 55 installs cleanly without open-ended ranges.
- Resolve the User-Agent helper via `import *` + `.default` fallback (same shape as `expo-application`), and skip the header when the helper is absent so init never throws.

## Test plan
- [ ] Install `@openpanel/react-native` in an Expo SDK 55 app with `expo-application@55` / `expo-constants@55` and confirm peer warnings are gone
- [ ] Construct `new OpenPanel({ clientId, apiUrl })` and confirm the app boots (no `getWebViewUserAgentAsync` TypeError)
- [ ] Confirm events still send; User-Agent header is set when the Expo helper is available
- [ ] Smoke on an older Expo install (pre-55) if available — peers remain compatible