### PR TITLE
feat(org): edit organization member roles (#396)

### DIFF
--- a/apps/start/src/components/settings/members/columns.tsx
+++ b/apps/start/src/components/settings/members/columns.tsx
@@ -112,7 +112,7 @@ export function useColumns() {
               pushModal('EditMember', row.original);
             }}
           >
-            Edit access
+            Edit member
           </DropdownMenuItem>
           <DropdownMenuItem
             className="text-destructive"

--- a/apps/start/src/components/settings/members/columns.tsx
+++ b/apps/start/src/components/settings/members/columns.tsx
@@ -1,17 +1,19 @@
-import { TooltipComplete } from '@/components/tooltip-complete';
-import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
-import { useTRPC } from '@/integrations/trpc/react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import type { ColumnDef } from '@tanstack/react-table';
-import { toast } from 'sonner';
-
 import { ColumnCreatedAt } from '@/components/column-created-at';
 import { Badge } from '@/components/ui/badge';
 import { createActionColumn } from '@/components/ui/data-table/data-table-helpers';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { useTRPC } from '@/integrations/trpc/react';
 import { pushModal } from '@/modals';
 import type { IServiceMember } from '@openpanel/db';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouteContext } from '@tanstack/react-router';
+import type { ColumnDef } from '@tanstack/react-table';
+import { toast } from 'sonner';
 
 export function useColumns() {
+  const { session } = useRouteContext({ strict: false });
+  const currentUserId = session?.userId;
+
   const columns: ColumnDef<IServiceMember>[] = [
     {
       accessorKey: 'user',
@@ -87,6 +89,7 @@ export function useColumns() {
     createActionColumn(({ row }) => {
       const queryClient = useQueryClient();
       const trpc = useTRPC();
+      const isSelf = !!currentUserId && row.original.userId === currentUserId;
       const revoke = useMutation(
         trpc.organization.removeMember.mutationOptions({
           onSuccess() {
@@ -107,13 +110,15 @@ export function useColumns() {
 
       return (
         <>
-          <DropdownMenuItem
-            onClick={() => {
-              pushModal('EditMember', row.original);
-            }}
-          >
-            Edit member
-          </DropdownMenuItem>
+          {!isSelf && (
+            <DropdownMenuItem
+              onClick={() => {
+                pushModal('EditMember', row.original);
+              }}
+            >
+              Edit member
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem
             className="text-destructive"
             onClick={() => {

--- a/apps/start/src/modals/edit-member.tsx
+++ b/apps/start/src/modals/edit-member.tsx
@@ -1,5 +1,7 @@
 import { ButtonContainer } from '@/components/button-container';
 import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { ProjectAccessGrants } from '@/components/settings/project-access-grants';
 import { useTRPC } from '@/integrations/trpc/react';
 import { handleError } from '@/integrations/trpc/react';
@@ -12,6 +14,8 @@ import type { IProjectAccessGrant } from '@openpanel/validation';
 
 import { popModal } from '.';
 import { ModalContent, ModalHeader } from './Modal/Container';
+
+type OrgRole = 'org:admin' | 'org:member';
 
 type EditMemberProps = IServiceMember;
 
@@ -27,41 +31,100 @@ export default function EditMember(member: EditMemberProps) {
     })) ?? [];
 
   const [access, setAccess] = useState<IProjectAccessGrant[]>(toGrants);
+  const [role, setRole] = useState<OrgRole>(
+    member.role === 'org:admin' ? 'org:admin' : 'org:member',
+  );
 
   const projectsQuery = useQuery(
     trpc.project.list.queryOptions({ organizationId: member.organizationId }),
   );
 
-  const mutation = useMutation(
+  const invalidateMembers = () =>
+    queryClient.invalidateQueries(trpc.organization.members.pathFilter());
+
+  const updateAccess = useMutation(
     trpc.organization.updateMemberAccess.mutationOptions({
       onError(error) {
         handleError(error);
         setAccess(toGrants());
       },
-      onSuccess() {
-        toast.success('Access updated');
-        // Refresh members list so access column reflects changes
-        queryClient.invalidateQueries(trpc.organization.members.pathFilter());
-        popModal();
+    }),
+  );
+
+  const updateRole = useMutation(
+    trpc.organization.updateMemberRole.mutationOptions({
+      onError(error) {
+        handleError(error);
+        setRole(member.role === 'org:admin' ? 'org:admin' : 'org:member');
       },
     }),
   );
 
   const projects = projectsQuery.data ?? [];
+  const isPending = updateAccess.isPending || updateRole.isPending;
+  const roleChanged = role !== member.role;
+
+  const memberName = member.user
+    ? [member.user.firstName, member.user.lastName].filter(Boolean).join(' ')
+    : null;
+
+  const onSave = async () => {
+    if (!member.user) {
+      return;
+    }
+
+    try {
+      if (roleChanged) {
+        await updateRole.mutateAsync({
+          userId: member.user.id,
+          organizationId: member.organizationId,
+          role,
+        });
+      }
+
+      await updateAccess.mutateAsync({
+        userId: member.user.id,
+        organizationId: member.organizationId,
+        access,
+      });
+
+      toast.success('Member updated');
+      invalidateMembers();
+      popModal();
+    } catch {
+      // Errors are handled by each mutation's onError.
+    }
+  };
 
   return (
     <ModalContent>
       <ModalHeader
-        title={
-          member.user
-            ? `Edit access for ${[member.user.firstName, member.user.lastName]
-                .filter(Boolean)
-                .join(' ')}`
-            : 'Edit member access'
-        }
+        title={memberName ? `Edit ${memberName}` : 'Edit member'}
       />
 
       <div className="col gap-4">
+        <div>
+          <Label>Organization role</Label>
+          <RadioGroup
+            value={role}
+            onValueChange={(value) => setRole(value as OrgRole)}
+            className="mt-2 flex gap-4"
+          >
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="org:member" id="edit-member-role" />
+              <Label className="mb-0" htmlFor="edit-member-role">
+                Member
+              </Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="org:admin" id="edit-admin-role" />
+              <Label className="mb-0" htmlFor="edit-admin-role">
+                Admin
+              </Label>
+            </div>
+          </RadioGroup>
+        </div>
+
         <ProjectAccessGrants
           value={access}
           onChange={setAccess}
@@ -72,16 +135,7 @@ export default function EditMember(member: EditMemberProps) {
           <Button type="button" variant="outline" onClick={() => popModal()}>
             Cancel
           </Button>
-          <Button
-            onClick={() =>
-              mutation.mutate({
-                userId: member.user!.id,
-                organizationId: member.organizationId,
-                access: access,
-              })
-            }
-            disabled={mutation.isPending}
-          >
+          <Button onClick={onSave} disabled={isPending || !member.user}>
             Save
           </Button>
         </ButtonContainer>

--- a/apps/start/src/modals/edit-member.tsx
+++ b/apps/start/src/modals/edit-member.tsx
@@ -66,8 +66,9 @@ export default function EditMember(member: EditMemberProps) {
 
       <div className="col gap-4">
         <div>
-          <Label>Organization role</Label>
+          <Label id="edit-member-role-label">Organization role</Label>
           <RadioGroup
+            aria-labelledby="edit-member-role-label"
             value={role}
             onValueChange={(value) => setRole(value as OrgRole)}
             className="mt-2 flex gap-4"

--- a/apps/start/src/modals/edit-member.tsx
+++ b/apps/start/src/modals/edit-member.tsx
@@ -39,68 +39,30 @@ export default function EditMember(member: EditMemberProps) {
     trpc.project.list.queryOptions({ organizationId: member.organizationId }),
   );
 
-  const invalidateMembers = () =>
-    queryClient.invalidateQueries(trpc.organization.members.pathFilter());
-
-  const updateAccess = useMutation(
-    trpc.organization.updateMemberAccess.mutationOptions({
+  const mutation = useMutation(
+    trpc.organization.updateMember.mutationOptions({
       onError(error) {
         handleError(error);
         setAccess(toGrants());
-      },
-    }),
-  );
-
-  const updateRole = useMutation(
-    trpc.organization.updateMemberRole.mutationOptions({
-      onError(error) {
-        handleError(error);
         setRole(member.role === 'org:admin' ? 'org:admin' : 'org:member');
+      },
+      onSuccess() {
+        toast.success('Member updated');
+        queryClient.invalidateQueries(trpc.organization.members.pathFilter());
+        popModal();
       },
     }),
   );
 
   const projects = projectsQuery.data ?? [];
-  const isPending = updateAccess.isPending || updateRole.isPending;
-  const roleChanged = role !== member.role;
 
   const memberName = member.user
     ? [member.user.firstName, member.user.lastName].filter(Boolean).join(' ')
     : null;
 
-  const onSave = async () => {
-    if (!member.user) {
-      return;
-    }
-
-    try {
-      if (roleChanged) {
-        await updateRole.mutateAsync({
-          userId: member.user.id,
-          organizationId: member.organizationId,
-          role,
-        });
-      }
-
-      await updateAccess.mutateAsync({
-        userId: member.user.id,
-        organizationId: member.organizationId,
-        access,
-      });
-
-      toast.success('Member updated');
-      invalidateMembers();
-      popModal();
-    } catch {
-      // Errors are handled by each mutation's onError.
-    }
-  };
-
   return (
     <ModalContent>
-      <ModalHeader
-        title={memberName ? `Edit ${memberName}` : 'Edit member'}
-      />
+      <ModalHeader title={memberName ? `Edit ${memberName}` : 'Edit member'} />
 
       <div className="col gap-4">
         <div>
@@ -135,7 +97,20 @@ export default function EditMember(member: EditMemberProps) {
           <Button type="button" variant="outline" onClick={() => popModal()}>
             Cancel
           </Button>
-          <Button onClick={onSave} disabled={isPending || !member.user}>
+          <Button
+            onClick={() => {
+              if (!member.user) {
+                return;
+              }
+              mutation.mutate({
+                userId: member.user.id,
+                organizationId: member.organizationId,
+                role,
+                access,
+              });
+            }}
+            disabled={mutation.isPending || !member.user}
+          >
             Save
           </Button>
         </ButtonContainer>

--- a/packages/trpc/src/routers/organization.test.ts
+++ b/packages/trpc/src/routers/organization.test.ts
@@ -36,9 +36,12 @@ const {
     user: {
       findFirst: vi.fn(),
     },
-    $transaction: vi.fn((ops: unknown) =>
-      Array.isArray(ops) ? Promise.all(ops) : ops,
-    ),
+    $transaction: vi.fn(async (ops: unknown, _opts?: unknown) => {
+      if (typeof ops === 'function') {
+        return (ops as (tx: typeof dbMock) => unknown)(dbMock);
+      }
+      return Array.isArray(ops) ? Promise.all(ops) : ops;
+    }),
   },
   getOrganizationAccessMock: vi.fn(),
   getOrganizationsMock: vi.fn(),
@@ -48,6 +51,8 @@ const {
   getInviteByIdMock: vi.fn(),
   connectUserToOrganizationMock: vi.fn(),
 }));
+
+getOrganizationAccessMock.clear = vi.fn().mockResolvedValue(1);
 
 vi.mock('@openpanel/db', () => ({
   db: dbMock,
@@ -183,5 +188,76 @@ describe('organization.updateMemberRole', () => {
 
     expect(result.role).toBe('org:member');
     expect(dbMock.member.update).toHaveBeenCalled();
+  });
+
+  it('clears cached organization access for the updated member', async () => {
+    dbMock.member.findFirst.mockResolvedValue(MEMBER_ROW);
+    dbMock.member.update.mockResolvedValue({
+      ...MEMBER_ROW,
+      role: 'org:admin',
+    });
+
+    await adminCaller().updateMemberRole({
+      organizationId: ORG_ID,
+      userId: MEMBER_USER_ID,
+      role: 'org:admin',
+    });
+
+    expect(getOrganizationAccessMock.clear).toHaveBeenCalledWith({
+      userId: MEMBER_USER_ID,
+      organizationId: ORG_ID,
+    });
+  });
+
+  it('runs the last-admin check and role update in one transaction', async () => {
+    dbMock.member.findFirst.mockResolvedValue({
+      ...MEMBER_ROW,
+      userId: 'other-admin',
+      role: 'org:admin',
+    });
+    dbMock.member.count.mockResolvedValue(2);
+    dbMock.member.update.mockResolvedValue({
+      ...MEMBER_ROW,
+      userId: 'other-admin',
+      role: 'org:member',
+    });
+
+    await adminCaller().updateMemberRole({
+      organizationId: ORG_ID,
+      userId: 'other-admin',
+      role: 'org:member',
+    });
+
+    expect(dbMock.$transaction).toHaveBeenCalled();
+    const txArg = dbMock.$transaction.mock.calls[0]?.[0];
+    expect(typeof txArg).toBe('function');
+  });
+});
+
+describe('organization.updateMember', () => {
+  it('updates role and project access in one transaction', async () => {
+    dbMock.member.findFirst.mockResolvedValue(MEMBER_ROW);
+    dbMock.member.update.mockResolvedValue({
+      ...MEMBER_ROW,
+      role: 'org:admin',
+    });
+    dbMock.projectAccess.deleteMany.mockResolvedValue({ count: 0 });
+    dbMock.projectAccess.createMany.mockResolvedValue({ count: 1 });
+
+    await adminCaller().updateMember({
+      organizationId: ORG_ID,
+      userId: MEMBER_USER_ID,
+      role: 'org:admin',
+      access: [{ projectId: 'proj-1', level: 'write' }],
+    });
+
+    expect(dbMock.$transaction).toHaveBeenCalled();
+    expect(dbMock.member.update).toHaveBeenCalled();
+    expect(dbMock.projectAccess.deleteMany).toHaveBeenCalled();
+    expect(dbMock.projectAccess.createMany).toHaveBeenCalled();
+    expect(getOrganizationAccessMock.clear).toHaveBeenCalledWith({
+      userId: MEMBER_USER_ID,
+      organizationId: ORG_ID,
+    });
   });
 });

--- a/packages/trpc/src/routers/organization.test.ts
+++ b/packages/trpc/src/routers/organization.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  dbMock,
+  getOrganizationAccessMock,
+  getOrganizationsMock,
+  getOrganizationByIdMock,
+  getMembersMock,
+  getInvitesMock,
+  getInviteByIdMock,
+  connectUserToOrganizationMock,
+} = vi.hoisted(() => ({
+  dbMock: {
+    member: {
+      findFirst: vi.fn(),
+      count: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    projectAccess: {
+      deleteMany: vi.fn(),
+      createMany: vi.fn(),
+    },
+    organization: {
+      update: vi.fn(),
+    },
+    project: {
+      updateMany: vi.fn(),
+    },
+    invite: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+      findUniqueOrThrow: vi.fn(),
+    },
+    user: {
+      findFirst: vi.fn(),
+    },
+    $transaction: vi.fn((ops: unknown) =>
+      Array.isArray(ops) ? Promise.all(ops) : ops,
+    ),
+  },
+  getOrganizationAccessMock: vi.fn(),
+  getOrganizationsMock: vi.fn(),
+  getOrganizationByIdMock: vi.fn(),
+  getMembersMock: vi.fn(),
+  getInvitesMock: vi.fn(),
+  getInviteByIdMock: vi.fn(),
+  connectUserToOrganizationMock: vi.fn(),
+}));
+
+vi.mock('@openpanel/db', () => ({
+  db: dbMock,
+  getOrganizationAccess: getOrganizationAccessMock,
+  getOrganizations: getOrganizationsMock,
+  getOrganizationById: getOrganizationByIdMock,
+  getMembers: getMembersMock,
+  getInvites: getInvitesMock,
+  getInviteById: getInviteByIdMock,
+  connectUserToOrganization: connectUserToOrganizationMock,
+  getProjectAccess: vi.fn(),
+  getClientAccess: vi.fn(),
+  getProjectById: vi.fn(),
+  canWriteProject: vi.fn(),
+  runWithAlsSession: (_sessionId: string | null, fn: () => unknown) => fn(),
+}));
+
+vi.mock('@openpanel/email', () => ({
+  sendEmail: vi.fn(),
+}));
+
+vi.mock('@openpanel/common/server', () => ({
+  generateSecureId: vi.fn(() => 'invite_test'),
+}));
+
+const { organizationRouter } = await import('./organization');
+
+const ORG_ID = 'org-1';
+const ADMIN_ID = 'admin-1';
+const MEMBER_USER_ID = 'user-2';
+const MEMBER_ROW = {
+  id: 'member-row-2',
+  userId: MEMBER_USER_ID,
+  organizationId: ORG_ID,
+  role: 'org:member' as const,
+  email: 'member@example.com',
+};
+
+const adminCaller = () =>
+  organizationRouter.createCaller({
+    session: { userId: ADMIN_ID, session: { id: 'session-1' } },
+    req: { log: { info: vi.fn(), error: vi.fn() } },
+    res: {},
+    setCookie: vi.fn(),
+    cookies: {},
+  } as never);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getOrganizationAccessMock.mockResolvedValue({ role: 'org:admin' });
+});
+
+describe('organization.updateMemberRole', () => {
+  it('promotes a member to org:admin', async () => {
+    dbMock.member.findFirst.mockResolvedValue(MEMBER_ROW);
+    dbMock.member.update.mockResolvedValue({
+      ...MEMBER_ROW,
+      role: 'org:admin',
+    });
+
+    const result = await adminCaller().updateMemberRole({
+      organizationId: ORG_ID,
+      userId: MEMBER_USER_ID,
+      role: 'org:admin',
+    });
+
+    expect(dbMock.member.update).toHaveBeenCalledWith({
+      where: { id: MEMBER_ROW.id },
+      data: { role: 'org:admin' },
+    });
+    expect(result.role).toBe('org:admin');
+  });
+
+  it('rejects a plain org member from changing roles', async () => {
+    getOrganizationAccessMock.mockResolvedValue({ role: 'org:member' });
+
+    await expect(
+      adminCaller().updateMemberRole({
+        organizationId: ORG_ID,
+        userId: MEMBER_USER_ID,
+        role: 'org:admin',
+      }),
+    ).rejects.toThrow('You do not have access');
+  });
+
+  it('rejects updating your own role', async () => {
+    await expect(
+      adminCaller().updateMemberRole({
+        organizationId: ORG_ID,
+        userId: ADMIN_ID,
+        role: 'org:member',
+      }),
+    ).rejects.toThrow('You cannot update your own role');
+  });
+
+  it('refuses to demote the last organization admin', async () => {
+    dbMock.member.findFirst.mockResolvedValue({
+      ...MEMBER_ROW,
+      userId: 'other-admin',
+      role: 'org:admin',
+    });
+    dbMock.member.count.mockResolvedValue(1);
+
+    await expect(
+      adminCaller().updateMemberRole({
+        organizationId: ORG_ID,
+        userId: 'other-admin',
+        role: 'org:member',
+      }),
+    ).rejects.toThrow('last organization admin');
+
+    expect(dbMock.member.update).not.toHaveBeenCalled();
+  });
+
+  it('demotes an admin when another admin remains', async () => {
+    dbMock.member.findFirst.mockResolvedValue({
+      ...MEMBER_ROW,
+      userId: 'other-admin',
+      role: 'org:admin',
+    });
+    dbMock.member.count.mockResolvedValue(2);
+    dbMock.member.update.mockResolvedValue({
+      ...MEMBER_ROW,
+      userId: 'other-admin',
+      role: 'org:member',
+    });
+
+    const result = await adminCaller().updateMemberRole({
+      organizationId: ORG_ID,
+      userId: 'other-admin',
+      role: 'org:member',
+    });
+
+    expect(result.role).toBe('org:member');
+    expect(dbMock.member.update).toHaveBeenCalled();
+  });
+});

--- a/packages/trpc/src/routers/organization.test.ts
+++ b/packages/trpc/src/routers/organization.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   dbMock,
+  txMock,
   getOrganizationAccessMock,
   getOrganizationsMock,
   getOrganizationByIdMock,
@@ -9,8 +10,21 @@ const {
   getInvitesMock,
   getInviteByIdMock,
   connectUserToOrganizationMock,
-} = vi.hoisted(() => ({
-  dbMock: {
+} = vi.hoisted(() => {
+  const txMock = {
+    member: {
+      findFirst: vi.fn(),
+      count: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    projectAccess: {
+      deleteMany: vi.fn(),
+      createMany: vi.fn(),
+    },
+  };
+
+  const dbMock = {
     member: {
       findFirst: vi.fn(),
       count: vi.fn(),
@@ -38,19 +52,24 @@ const {
     },
     $transaction: vi.fn(async (ops: unknown, _opts?: unknown) => {
       if (typeof ops === 'function') {
-        return (ops as (tx: typeof dbMock) => unknown)(dbMock);
+        return (ops as (tx: typeof txMock) => unknown)(txMock);
       }
       return Array.isArray(ops) ? Promise.all(ops) : ops;
     }),
-  },
-  getOrganizationAccessMock: vi.fn(),
-  getOrganizationsMock: vi.fn(),
-  getOrganizationByIdMock: vi.fn(),
-  getMembersMock: vi.fn(),
-  getInvitesMock: vi.fn(),
-  getInviteByIdMock: vi.fn(),
-  connectUserToOrganizationMock: vi.fn(),
-}));
+  };
+
+  return {
+    dbMock,
+    txMock,
+    getOrganizationAccessMock: vi.fn(),
+    getOrganizationsMock: vi.fn(),
+    getOrganizationByIdMock: vi.fn(),
+    getMembersMock: vi.fn(),
+    getInvitesMock: vi.fn(),
+    getInviteByIdMock: vi.fn(),
+    connectUserToOrganizationMock: vi.fn(),
+  };
+});
 
 getOrganizationAccessMock.clear = vi.fn().mockResolvedValue(1);
 
@@ -107,8 +126,8 @@ beforeEach(() => {
 
 describe('organization.updateMemberRole', () => {
   it('promotes a member to org:admin', async () => {
-    dbMock.member.findFirst.mockResolvedValue(MEMBER_ROW);
-    dbMock.member.update.mockResolvedValue({
+    txMock.member.findFirst.mockResolvedValue(MEMBER_ROW);
+    txMock.member.update.mockResolvedValue({
       ...MEMBER_ROW,
       role: 'org:admin',
     });
@@ -119,10 +138,11 @@ describe('organization.updateMemberRole', () => {
       role: 'org:admin',
     });
 
-    expect(dbMock.member.update).toHaveBeenCalledWith({
+    expect(txMock.member.update).toHaveBeenCalledWith({
       where: { id: MEMBER_ROW.id },
       data: { role: 'org:admin' },
     });
+    expect(dbMock.member.update).not.toHaveBeenCalled();
     expect(result.role).toBe('org:admin');
   });
 
@@ -149,12 +169,12 @@ describe('organization.updateMemberRole', () => {
   });
 
   it('refuses to demote the last organization admin', async () => {
-    dbMock.member.findFirst.mockResolvedValue({
+    txMock.member.findFirst.mockResolvedValue({
       ...MEMBER_ROW,
       userId: 'other-admin',
       role: 'org:admin',
     });
-    dbMock.member.count.mockResolvedValue(1);
+    txMock.member.count.mockResolvedValue(1);
 
     await expect(
       adminCaller().updateMemberRole({
@@ -164,17 +184,17 @@ describe('organization.updateMemberRole', () => {
       }),
     ).rejects.toThrow('last organization admin');
 
-    expect(dbMock.member.update).not.toHaveBeenCalled();
+    expect(txMock.member.update).not.toHaveBeenCalled();
   });
 
   it('demotes an admin when another admin remains', async () => {
-    dbMock.member.findFirst.mockResolvedValue({
+    txMock.member.findFirst.mockResolvedValue({
       ...MEMBER_ROW,
       userId: 'other-admin',
       role: 'org:admin',
     });
-    dbMock.member.count.mockResolvedValue(2);
-    dbMock.member.update.mockResolvedValue({
+    txMock.member.count.mockResolvedValue(2);
+    txMock.member.update.mockResolvedValue({
       ...MEMBER_ROW,
       userId: 'other-admin',
       role: 'org:member',
@@ -187,12 +207,13 @@ describe('organization.updateMemberRole', () => {
     });
 
     expect(result.role).toBe('org:member');
-    expect(dbMock.member.update).toHaveBeenCalled();
+    expect(txMock.member.update).toHaveBeenCalled();
+    expect(dbMock.member.update).not.toHaveBeenCalled();
   });
 
   it('clears cached organization access for the updated member', async () => {
-    dbMock.member.findFirst.mockResolvedValue(MEMBER_ROW);
-    dbMock.member.update.mockResolvedValue({
+    txMock.member.findFirst.mockResolvedValue(MEMBER_ROW);
+    txMock.member.update.mockResolvedValue({
       ...MEMBER_ROW,
       role: 'org:admin',
     });
@@ -210,13 +231,13 @@ describe('organization.updateMemberRole', () => {
   });
 
   it('runs the last-admin check and role update in one transaction', async () => {
-    dbMock.member.findFirst.mockResolvedValue({
+    txMock.member.findFirst.mockResolvedValue({
       ...MEMBER_ROW,
       userId: 'other-admin',
       role: 'org:admin',
     });
-    dbMock.member.count.mockResolvedValue(2);
-    dbMock.member.update.mockResolvedValue({
+    txMock.member.count.mockResolvedValue(2);
+    txMock.member.update.mockResolvedValue({
       ...MEMBER_ROW,
       userId: 'other-admin',
       role: 'org:member',
@@ -229,20 +250,22 @@ describe('organization.updateMemberRole', () => {
     });
 
     expect(dbMock.$transaction).toHaveBeenCalled();
-    const txArg = dbMock.$transaction.mock.calls[0]?.[0];
-    expect(typeof txArg).toBe('function');
+    expect(txMock.member.count).toHaveBeenCalled();
+    expect(txMock.member.update).toHaveBeenCalled();
+    expect(dbMock.member.count).not.toHaveBeenCalled();
+    expect(dbMock.member.update).not.toHaveBeenCalled();
   });
 });
 
 describe('organization.updateMember', () => {
   it('updates role and project access in one transaction', async () => {
-    dbMock.member.findFirst.mockResolvedValue(MEMBER_ROW);
-    dbMock.member.update.mockResolvedValue({
+    txMock.member.findFirst.mockResolvedValue(MEMBER_ROW);
+    txMock.member.update.mockResolvedValue({
       ...MEMBER_ROW,
       role: 'org:admin',
     });
-    dbMock.projectAccess.deleteMany.mockResolvedValue({ count: 0 });
-    dbMock.projectAccess.createMany.mockResolvedValue({ count: 1 });
+    txMock.projectAccess.deleteMany.mockResolvedValue({ count: 0 });
+    txMock.projectAccess.createMany.mockResolvedValue({ count: 1 });
 
     await adminCaller().updateMember({
       organizationId: ORG_ID,
@@ -252,9 +275,11 @@ describe('organization.updateMember', () => {
     });
 
     expect(dbMock.$transaction).toHaveBeenCalled();
-    expect(dbMock.member.update).toHaveBeenCalled();
-    expect(dbMock.projectAccess.deleteMany).toHaveBeenCalled();
-    expect(dbMock.projectAccess.createMany).toHaveBeenCalled();
+    expect(txMock.member.update).toHaveBeenCalled();
+    expect(txMock.projectAccess.deleteMany).toHaveBeenCalled();
+    expect(txMock.projectAccess.createMany).toHaveBeenCalled();
+    expect(dbMock.member.update).not.toHaveBeenCalled();
+    expect(dbMock.projectAccess.deleteMany).not.toHaveBeenCalled();
     expect(getOrganizationAccessMock.clear).toHaveBeenCalledWith({
       userId: MEMBER_USER_ID,
       organizationId: ORG_ID,

--- a/packages/trpc/src/routers/organization.ts
+++ b/packages/trpc/src/routers/organization.ts
@@ -12,6 +12,7 @@ import {
 import {
   zEditOrganization,
   zInviteUser,
+  zUpdateMember,
   zUpdateMemberAccess,
   zUpdateMemberRole,
 } from '@openpanel/validation';
@@ -381,40 +382,135 @@ export const organizationRouter = createTRPCRouter({
         throw new TRPCForbiddenError('You do not have access to this project');
       }
 
-      const member = await db.member.findFirst({
-        where: {
-          userId: input.userId,
-          organizationId: input.organizationId,
+      const updated = await db.$transaction(
+        async (tx) => {
+          const member = await tx.member.findFirst({
+            where: {
+              userId: input.userId,
+              organizationId: input.organizationId,
+            },
+          });
+
+          if (!member) {
+            throw new TRPCBadRequestError('Member not found');
+          }
+
+          if (member.role === 'org:admin' && input.role === 'org:member') {
+            const adminCount = await tx.member.count({
+              where: {
+                organizationId: input.organizationId,
+                role: 'org:admin',
+              },
+            });
+
+            if (adminCount <= 1) {
+              throw new TRPCBadRequestError(
+                'Cannot demote the last organization admin',
+              );
+            }
+          }
+
+          return tx.member.update({
+            where: {
+              id: member.id,
+            },
+            data: {
+              role: input.role,
+            },
+          });
         },
+        { isolationLevel: 'Serializable' },
+      );
+
+      await getOrganizationAccess.clear({
+        userId: input.userId,
+        organizationId: input.organizationId,
       });
 
-      if (!member) {
-        throw new TRPCBadRequestError('Member not found');
+      return updated;
+    }),
+
+  /** Role + project access in one transaction (Members edit modal). */
+  updateMember: protectedProcedure
+    .input(zUpdateMember)
+    .mutation(async ({ input, ctx }) => {
+      if (input.userId === ctx.session.userId) {
+        throw new TRPCForbiddenError('You cannot update your own membership');
       }
 
-      if (member.role === 'org:admin' && input.role === 'org:member') {
-        const adminCount = await db.member.count({
-          where: {
-            organizationId: input.organizationId,
-            role: 'org:admin',
-          },
-        });
-
-        if (adminCount <= 1) {
-          throw new TRPCBadRequestError(
-            'Cannot demote the last organization admin',
-          );
-        }
-      }
-
-      return db.member.update({
-        where: {
-          id: member.id,
-        },
-        data: {
-          role: input.role,
-        },
+      const access = await getOrganizationAccess({
+        userId: ctx.session.userId,
+        organizationId: input.organizationId,
       });
+
+      if (access?.role !== 'org:admin') {
+        throw new TRPCForbiddenError('You do not have access to this project');
+      }
+
+      const updated = await db.$transaction(
+        async (tx) => {
+          const member = await tx.member.findFirst({
+            where: {
+              userId: input.userId,
+              organizationId: input.organizationId,
+            },
+          });
+
+          if (!member) {
+            throw new TRPCBadRequestError('Member not found');
+          }
+
+          if (member.role === 'org:admin' && input.role === 'org:member') {
+            const adminCount = await tx.member.count({
+              where: {
+                organizationId: input.organizationId,
+                role: 'org:admin',
+              },
+            });
+
+            if (adminCount <= 1) {
+              throw new TRPCBadRequestError(
+                'Cannot demote the last organization admin',
+              );
+            }
+          }
+
+          const memberRow = await tx.member.update({
+            where: {
+              id: member.id,
+            },
+            data: {
+              role: input.role,
+            },
+          });
+
+          await tx.projectAccess.deleteMany({
+            where: {
+              userId: input.userId,
+              organizationId: input.organizationId,
+            },
+          });
+
+          await tx.projectAccess.createMany({
+            data: input.access.map((grant) => ({
+              userId: input.userId,
+              organizationId: input.organizationId,
+              projectId: grant.projectId,
+              level: grant.level,
+            })),
+          });
+
+          return memberRow;
+        },
+        { isolationLevel: 'Serializable' },
+      );
+
+      await getOrganizationAccess.clear({
+        userId: input.userId,
+        organizationId: input.organizationId,
+      });
+
+      return updated;
     }),
 
   members: protectedProcedure

--- a/packages/trpc/src/routers/organization.ts
+++ b/packages/trpc/src/routers/organization.ts
@@ -13,6 +13,7 @@ import {
   zEditOrganization,
   zInviteUser,
   zUpdateMemberAccess,
+  zUpdateMemberRole,
 } from '@openpanel/validation';
 
 import { generateSecureId } from '@openpanel/common/server';
@@ -362,6 +363,58 @@ export const organizationRouter = createTRPCRouter({
           })),
         }),
       ]);
+    }),
+
+  updateMemberRole: protectedProcedure
+    .input(zUpdateMemberRole)
+    .mutation(async ({ input, ctx }) => {
+      if (input.userId === ctx.session.userId) {
+        throw new TRPCForbiddenError('You cannot update your own role');
+      }
+
+      const access = await getOrganizationAccess({
+        userId: ctx.session.userId,
+        organizationId: input.organizationId,
+      });
+
+      if (access?.role !== 'org:admin') {
+        throw new TRPCForbiddenError('You do not have access to this project');
+      }
+
+      const member = await db.member.findFirst({
+        where: {
+          userId: input.userId,
+          organizationId: input.organizationId,
+        },
+      });
+
+      if (!member) {
+        throw new TRPCBadRequestError('Member not found');
+      }
+
+      if (member.role === 'org:admin' && input.role === 'org:member') {
+        const adminCount = await db.member.count({
+          where: {
+            organizationId: input.organizationId,
+            role: 'org:admin',
+          },
+        });
+
+        if (adminCount <= 1) {
+          throw new TRPCBadRequestError(
+            'Cannot demote the last organization admin',
+          );
+        }
+      }
+
+      return db.member.update({
+        where: {
+          id: member.id,
+        },
+        data: {
+          role: input.role,
+        },
+      });
     }),
 
   members: protectedProcedure

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -353,6 +353,13 @@ export const zUpdateMemberRole = z.object({
   role: z.enum(['org:admin', 'org:member']),
 });
 
+export const zUpdateMember = z.object({
+  userId: z.string(),
+  organizationId: z.string(),
+  role: z.enum(['org:admin', 'org:member']),
+  access: z.array(zProjectAccessGrant),
+});
+
 export const zShareOverview = z.object({
   organizationId: z.string(),
   projectId: z.string(),

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -347,6 +347,12 @@ export const zUpdateMemberAccess = z.object({
   access: z.array(zProjectAccessGrant),
 });
 
+export const zUpdateMemberRole = z.object({
+  userId: z.string(),
+  organizationId: z.string(),
+  role: z.enum(['org:admin', 'org:member']),
+});
+
 export const zShareOverview = z.object({
   organizationId: z.string(),
   projectId: z.string(),


### PR DESCRIPTION
## Summary
- Fixes [#396](https://github.com/Openpanel-dev/openpanel/issues/396): organization role was display-only on the Members page.
- Adds `organization.updateMember` to save role (`org:admin` | `org:member`) and project access together in a serializable transaction. Caller must be admin, cannot edit their own membership, and cannot demote the last org admin.
- Extends the existing Edit member modal with a role radio (same options as invite) and renames the row action to **Edit member**.

Latest follow-up: the role radio group has an accessible name through `aria-labelledby`. This follow-up was reviewed by reading the source; builds, tests, lint, and typecheck were not run.

## Test plan
- [ ] As org admin, open Members → row menu → Edit member → switch Member ↔ Admin → Save; role badge updates
- [ ] As org member, confirm you cannot reach the Members admin UI / mutation is forbidden
- [ ] Attempt to demote the sole remaining admin → error, role unchanged
- [ ] Attempt to change your own role via API → forbidden
- [ ] CI: `packages/trpc` `organization.updateMember` tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Organization administrators can update a member’s organization role and project access together.
  - The member editor includes organization-role options and displays the member’s name.
  - Updates provide safeguards against unauthorized changes, self-updates, and removing the last organization administrator.

- **Improvements**
  - Renamed the member action from “Edit access” to “Edit member.”
  - Edit actions are unavailable for your own membership.
  - Saving is disabled while an update is in progress or when the member has no associated user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
