### PR TITLE
feat(embed): auto-resize share iframes (#224)

### DIFF
--- a/apps/start/public/openpanel-embed.js
+++ b/apps/start/public/openpanel-embed.js
@@ -1,0 +1,91 @@
+/**
+ * OpenPanel share embed host — auto-sizes iframes marked with
+ * data-openpanel-embed and answers viewport queries so in-frame dialogs
+ * can center on the visible slice (parent scroll ≠ iframe mid-point).
+ *
+ * Usage:
+ *   <iframe data-openpanel-embed src="https://…/share/overview/…" …></iframe>
+ *   <script async src="https://…/openpanel-embed.js"></script>
+ */
+(() => {
+  const SOURCE = 'openpanel-embed';
+  const SELECTOR = 'iframe[data-openpanel-embed]';
+
+  function iframes() {
+    return Array.from(document.querySelectorAll(SELECTOR));
+  }
+
+  function viewportFor(iframe) {
+    const rect = iframe.getBoundingClientRect();
+    const visibleTop = Math.max(0, -rect.top);
+    const visibleBottom = Math.min(rect.height, window.innerHeight - rect.top);
+    const visibleHeight = Math.max(
+      0,
+      visibleBottom - visibleTop,
+    ) || Math.min(rect.height, window.innerHeight);
+    return { visibleTop, visibleHeight };
+  }
+
+  function replyViewport(iframe, source) {
+    const { visibleTop, visibleHeight } = viewportFor(iframe);
+    source.postMessage(
+      { source: SOURCE, type: 'viewport', visibleTop, visibleHeight },
+      '*',
+    );
+  }
+
+  function onMessage(event) {
+    const data = event.data;
+    if (!data || data.source !== SOURCE) {
+      return;
+    }
+
+    const iframe = iframes().find((el) => el.contentWindow === event.source);
+    if (!iframe) {
+      return;
+    }
+
+    if (data.type === 'resize' && typeof data.height === 'number') {
+      const next = Math.max(0, Math.ceil(data.height));
+      if (String(iframe.height) !== String(next)) {
+        iframe.style.height = `${next}px`;
+        iframe.setAttribute('height', String(next));
+      }
+      return;
+    }
+
+    if (data.type === 'request-viewport' && event.source) {
+      replyViewport(iframe, event.source);
+    }
+  }
+
+  function broadcastViewport() {
+    for (const iframe of iframes()) {
+      if (iframe.contentWindow) {
+        replyViewport(iframe, iframe.contentWindow);
+      }
+    }
+  }
+
+  window.addEventListener('message', onMessage);
+  window.addEventListener('scroll', broadcastViewport, { passive: true });
+  window.addEventListener('resize', broadcastViewport);
+
+  function init() {
+    for (const iframe of iframes()) {
+      iframe.setAttribute('scrolling', 'no');
+      if (!iframe.style.width) {
+        iframe.style.width = '100%';
+      }
+      if (!iframe.style.border) {
+        iframe.style.border = '0';
+      }
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/apps/start/public/openpanel-embed.js
+++ b/apps/start/public/openpanel-embed.js
@@ -17,12 +17,9 @@
 
   function viewportFor(iframe) {
     const rect = iframe.getBoundingClientRect();
-    const visibleTop = Math.max(0, -rect.top);
+    const visibleTop = Math.min(rect.height, Math.max(0, -rect.top));
     const visibleBottom = Math.min(rect.height, window.innerHeight - rect.top);
-    const visibleHeight = Math.max(
-      0,
-      visibleBottom - visibleTop,
-    ) || Math.min(rect.height, window.innerHeight);
+    const visibleHeight = Math.max(0, visibleBottom - visibleTop);
     return { visibleTop, visibleHeight };
   }
 
@@ -51,6 +48,12 @@
         iframe.style.height = `${next}px`;
         iframe.setAttribute('height', String(next));
       }
+      if (event.source) {
+        event.source.postMessage(
+          { source: SOURCE, type: 'resize-ack', height: next },
+          '*',
+        );
+      }
       return;
     }
 
@@ -63,6 +66,17 @@
     for (const iframe of iframes()) {
       if (iframe.contentWindow) {
         replyViewport(iframe, iframe.contentWindow);
+      }
+    }
+  }
+
+  function pingIframes() {
+    for (const iframe of iframes()) {
+      if (iframe.contentWindow) {
+        iframe.contentWindow.postMessage(
+          { source: SOURCE, type: 'request-resize' },
+          '*',
+        );
       }
     }
   }
@@ -80,7 +94,16 @@
       if (!iframe.style.border) {
         iframe.style.border = '0';
       }
+      iframe.addEventListener('load', () => {
+        if (iframe.contentWindow) {
+          iframe.contentWindow.postMessage(
+            { source: SOURCE, type: 'request-resize' },
+            '*',
+          );
+        }
+      });
     }
+    pingIframes();
   }
 
   if (document.readyState === 'loading') {

--- a/apps/start/src/components/ui/dialog.tsx
+++ b/apps/start/src/components/ui/dialog.tsx
@@ -2,12 +2,23 @@ import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { XIcon } from 'lucide-react';
 import type * as React from 'react';
 
+import { useEmbedViewport, isInIframe } from '@/hooks/use-embed-viewport';
+import { embeddedDialogCenterY } from '@/utils/embed-viewport';
 import { cn } from '@/lib/utils';
 
 function Dialog({
+  modal,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+  // Scroll-lock + focus trap fight iframe auto-height (parent owns the scroll).
+  const embedded = typeof window !== 'undefined' && isInIframe();
+  return (
+    <DialogPrimitive.Root
+      data-slot="dialog"
+      modal={embedded ? false : modal}
+      {...props}
+    />
+  );
 }
 
 function DialogTrigger({
@@ -30,8 +41,19 @@ function DialogClose({
 
 function DialogOverlay({
   className,
+  style,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  const viewport = useEmbedViewport();
+  const embeddedStyle =
+    viewport != null
+      ? {
+          top: viewport.visibleTop,
+          height: viewport.visibleHeight,
+          bottom: 'auto' as const,
+        }
+      : undefined;
+
   return (
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
@@ -39,6 +61,7 @@ function DialogOverlay({
         'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
         className,
       )}
+      style={{ ...embeddedStyle, ...style }}
       {...props}
     />
   );
@@ -48,10 +71,20 @@ function DialogContent({
   className,
   children,
   showCloseButton = false,
+  style,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
 }) {
+  const viewport = useEmbedViewport();
+  const embeddedStyle =
+    viewport != null
+      ? {
+          top: embeddedDialogCenterY(viewport),
+          maxHeight: Math.min(viewport.visibleHeight * 0.9, 720),
+        }
+      : undefined;
+
   // Not using DialogPortal because it's breaking useRef's for some reason
   return (
     <div data-slot="dialog-portal">
@@ -66,6 +99,7 @@ function DialogContent({
           'bg-def-100 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg [&>*]:min-w-0',
           className,
         )}
+        style={{ ...embeddedStyle, ...style }}
         {...props}
       >
         {children}

--- a/apps/start/src/components/ui/dialog.tsx
+++ b/apps/start/src/components/ui/dialog.tsx
@@ -6,6 +6,9 @@ import { useEmbedViewport, isInIframe } from '@/hooks/use-embed-viewport';
 import { embeddedDialogCenterY } from '@/utils/embed-viewport';
 import { cn } from '@/lib/utils';
 
+const overlayClassName =
+  'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50';
+
 function Dialog({
   modal,
   ...props
@@ -44,9 +47,10 @@ function DialogOverlay({
   style,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  const embedded = typeof window !== 'undefined' && isInIframe();
   const viewport = useEmbedViewport();
   const embeddedStyle =
-    viewport != null
+    viewport != null && viewport.visibleHeight > 0
       ? {
           top: viewport.visibleTop,
           height: viewport.visibleHeight,
@@ -54,14 +58,23 @@ function DialogOverlay({
         }
       : undefined;
 
+  // Radix drops Overlay when modal={false}; paint our own so embeds keep a backdrop.
+  if (embedded) {
+    return (
+      <div
+        data-slot="dialog-overlay"
+        aria-hidden
+        className={cn(overlayClassName, className)}
+        style={{ ...embeddedStyle, ...style }}
+      />
+    );
+  }
+
   return (
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
-      className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
-        className,
-      )}
-      style={{ ...embeddedStyle, ...style }}
+      className={cn(overlayClassName, className)}
+      style={style}
       {...props}
     />
   );
@@ -78,7 +91,7 @@ function DialogContent({
 }) {
   const viewport = useEmbedViewport();
   const embeddedStyle =
-    viewport != null
+    viewport != null && viewport.visibleHeight > 0
       ? {
           top: embeddedDialogCenterY(viewport),
           maxHeight: Math.min(viewport.visibleHeight * 0.9, 720),

--- a/apps/start/src/hooks/measure-embed-content-height.test.ts
+++ b/apps/start/src/hooks/measure-embed-content-height.test.ts
@@ -10,6 +10,6 @@ describe('measureEmbedContentHeight', () => {
     vi.stubGlobal('document', undefined);
     vi.stubGlobal('HTMLElement', undefined);
 
-    expect(measureEmbedContentHeight(null)).toBe(0);
+    expect(measureEmbedContentHeight()).toBe(0);
   });
 });

--- a/apps/start/src/hooks/measure-embed-content-height.test.ts
+++ b/apps/start/src/hooks/measure-embed-content-height.test.ts
@@ -1,0 +1,15 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { measureEmbedContentHeight } from './use-embed-viewport';
+
+describe('measureEmbedContentHeight', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns 0 without reading HTMLElement when document is undefined', () => {
+    vi.stubGlobal('document', undefined);
+    vi.stubGlobal('HTMLElement', undefined);
+
+    expect(measureEmbedContentHeight(null)).toBe(0);
+  });
+});

--- a/apps/start/src/hooks/use-embed-viewport.ts
+++ b/apps/start/src/hooks/use-embed-viewport.ts
@@ -56,11 +56,12 @@ export function measureEmbedContentHeight(
     ? null
     : document.querySelector('[data-openpanel-embed-root]'),
 ): number {
-  if (root instanceof HTMLElement) {
-    return Math.ceil(root.getBoundingClientRect().height);
-  }
+  // Guard before `instanceof HTMLElement` — that global is missing without a DOM.
   if (typeof document === 'undefined') {
     return 0;
+  }
+  if (root instanceof HTMLElement) {
+    return Math.ceil(root.getBoundingClientRect().height);
   }
   const body = document.body;
   if (!body) {

--- a/apps/start/src/hooks/use-embed-viewport.ts
+++ b/apps/start/src/hooks/use-embed-viewport.ts
@@ -16,6 +16,12 @@ type ViewportMessage = {
   visibleHeight: number;
 };
 
+type ResizeAckMessage = {
+  source: typeof SOURCE;
+  type: 'resize-ack';
+  height: number;
+};
+
 function isViewportMessage(data: unknown): data is ViewportMessage {
   if (!data || typeof data !== 'object') {
     return false;
@@ -27,6 +33,48 @@ function isViewportMessage(data: unknown): data is ViewportMessage {
     typeof msg.visibleTop === 'number' &&
     typeof msg.visibleHeight === 'number'
   );
+}
+
+function isResizeAckMessage(data: unknown): data is ResizeAckMessage {
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+  const msg = data as Record<string, unknown>;
+  return (
+    msg.source === SOURCE &&
+    msg.type === 'resize-ack' &&
+    typeof msg.height === 'number'
+  );
+}
+
+/**
+ * Height of the share content itself — not documentElement.scrollHeight, which
+ * floors at the iframe viewport and can never shrink after the host expands.
+ */
+export function measureEmbedContentHeight(
+  root: Element | null | undefined = typeof document === 'undefined'
+    ? null
+    : document.querySelector('[data-openpanel-embed-root]'),
+): number {
+  if (root instanceof HTMLElement) {
+    return Math.ceil(root.getBoundingClientRect().height);
+  }
+  if (typeof document === 'undefined') {
+    return 0;
+  }
+  const body = document.body;
+  if (!body) {
+    return 0;
+  }
+  let maxBottom = 0;
+  for (const child of Array.from(body.children)) {
+    if (!(child instanceof HTMLElement)) {
+      continue;
+    }
+    const rect = child.getBoundingClientRect();
+    maxBottom = Math.max(maxBottom, rect.bottom);
+  }
+  return Math.ceil(Math.max(0, maxBottom - body.getBoundingClientRect().top));
 }
 
 /**
@@ -70,37 +118,89 @@ export function useEmbedViewport(): EmbedViewport | null {
   return viewport;
 }
 
-/** Report document height to the parent embed host. */
+/** Report content height to the parent embed host until acknowledged. */
 export function useReportEmbedHeight(enabled = true) {
   useEffect(() => {
     if (!enabled || !isInIframe()) {
       return;
     }
 
+    let acked = false;
+    let lastHeight = -1;
+    let retries = 0;
+    let retryTimer: number | undefined;
+
     const publish = () => {
-      const height = Math.ceil(
-        Math.max(
-          document.documentElement.scrollHeight,
-          document.body?.scrollHeight ?? 0,
-        ),
-      );
+      const height = measureEmbedContentHeight();
+      lastHeight = height;
       window.parent.postMessage(
         { source: SOURCE, type: 'resize', height },
         '*',
       );
     };
 
+    const scheduleRetry = () => {
+      if (acked || retries >= 20) {
+        return;
+      }
+      retries += 1;
+      retryTimer = window.setTimeout(() => {
+        publish();
+        scheduleRetry();
+      }, 200);
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      if (!isResizeAckMessage(event.data)) {
+        return;
+      }
+      if (event.data.height === lastHeight) {
+        acked = true;
+        if (retryTimer !== undefined) {
+          window.clearTimeout(retryTimer);
+        }
+      }
+    };
+
+    const onHostPing = (event: MessageEvent) => {
+      const data = event.data;
+      if (
+        data &&
+        typeof data === 'object' &&
+        (data as { source?: string; type?: string }).source === SOURCE &&
+        (data as { type?: string }).type === 'request-resize'
+      ) {
+        publish();
+      }
+    };
+
+    window.addEventListener('message', onMessage);
+    window.addEventListener('message', onHostPing);
     publish();
-    const ro = new ResizeObserver(publish);
-    ro.observe(document.documentElement);
-    if (document.body) {
+    scheduleRetry();
+
+    const root = document.querySelector('[data-openpanel-embed-root]');
+    const ro = new ResizeObserver(() => {
+      acked = false;
+      retries = 0;
+      publish();
+      scheduleRetry();
+    });
+    if (root) {
+      ro.observe(root);
+    } else if (document.body) {
       ro.observe(document.body);
     }
     window.addEventListener('load', publish);
 
     return () => {
-      ro.disconnect();
+      window.removeEventListener('message', onMessage);
+      window.removeEventListener('message', onHostPing);
       window.removeEventListener('load', publish);
+      if (retryTimer !== undefined) {
+        window.clearTimeout(retryTimer);
+      }
+      ro.disconnect();
     };
   }, [enabled]);
 }

--- a/apps/start/src/hooks/use-embed-viewport.ts
+++ b/apps/start/src/hooks/use-embed-viewport.ts
@@ -1,0 +1,108 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  type EmbedViewport,
+  isInIframe,
+  viewportFromIframeRect,
+} from '@/utils/embed-viewport';
+
+const SOURCE = 'openpanel-embed';
+
+type ViewportMessage = {
+  source: typeof SOURCE;
+  type: 'viewport';
+  visibleTop: number;
+  visibleHeight: number;
+};
+
+function isViewportMessage(data: unknown): data is ViewportMessage {
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+  const msg = data as Record<string, unknown>;
+  return (
+    msg.source === SOURCE &&
+    msg.type === 'viewport' &&
+    typeof msg.visibleTop === 'number' &&
+    typeof msg.visibleHeight === 'number'
+  );
+}
+
+/**
+ * While framed by openpanel-embed.js, keep the visible slice in sync so
+ * overlays can pin to what the user actually sees (not mid-document).
+ */
+export function useEmbedViewport(): EmbedViewport | null {
+  const [viewport, setViewport] = useState<EmbedViewport | null>(null);
+
+  useEffect(() => {
+    if (!isInIframe()) {
+      return;
+    }
+
+    const onMessage = (event: MessageEvent) => {
+      if (!isViewportMessage(event.data)) {
+        return;
+      }
+      setViewport({
+        visibleTop: event.data.visibleTop,
+        visibleHeight: event.data.visibleHeight,
+      });
+    };
+
+    window.addEventListener('message', onMessage);
+    window.parent.postMessage({ source: SOURCE, type: 'request-viewport' }, '*');
+
+    const interval = window.setInterval(() => {
+      window.parent.postMessage(
+        { source: SOURCE, type: 'request-viewport' },
+        '*',
+      );
+    }, 250);
+
+    return () => {
+      window.removeEventListener('message', onMessage);
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  return viewport;
+}
+
+/** Report document height to the parent embed host. */
+export function useReportEmbedHeight(enabled = true) {
+  useEffect(() => {
+    if (!enabled || !isInIframe()) {
+      return;
+    }
+
+    const publish = () => {
+      const height = Math.ceil(
+        Math.max(
+          document.documentElement.scrollHeight,
+          document.body?.scrollHeight ?? 0,
+        ),
+      );
+      window.parent.postMessage(
+        { source: SOURCE, type: 'resize', height },
+        '*',
+      );
+    };
+
+    publish();
+    const ro = new ResizeObserver(publish);
+    ro.observe(document.documentElement);
+    if (document.body) {
+      ro.observe(document.body);
+    }
+    window.addEventListener('load', publish);
+
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('load', publish);
+    };
+  }, [enabled]);
+}
+
+export { isInIframe, viewportFromIframeRect };

--- a/apps/start/src/modals/share-overview-modal.tsx
+++ b/apps/start/src/modals/share-overview-modal.tsx
@@ -27,6 +27,7 @@ export default function ShareOverviewModal() {
   const { projectId, organizationId } = useAppParams();
   const navigate = useNavigate();
   const [copied, setCopied] = useState(false);
+  const [copiedEmbed, setCopiedEmbed] = useState(false);
 
   const trpc = useTRPC();
   const queryClient = useQueryClient();
@@ -43,7 +44,10 @@ export default function ShareOverviewModal() {
   const shareUrl = existingShare?.id
     ? `${window.location.origin}/share/overview/${existingShare.id}`
     : '';
-
+  const embedScriptUrl = `${window.location.origin}/openpanel-embed.js`;
+  const embedCode = shareUrl
+    ? `<iframe data-openpanel-embed src="${shareUrl}" style="width:100%;border:0;min-height:400px" title="OpenPanel"></iframe>\n<script async src="${embedScriptUrl}"></script>`
+    : '';
   const { register, handleSubmit, watch } = useForm<IForm>({
     resolver: zodResolver(validator),
     defaultValues: {
@@ -88,6 +92,13 @@ export default function ShareOverviewModal() {
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
     toast('Link copied to clipboard');
+  };
+
+  const handleCopyEmbed = () => {
+    navigator.clipboard.writeText(embedCode);
+    setCopiedEmbed(true);
+    setTimeout(() => setCopiedEmbed(false), 2000);
+    toast('Embed code copied to clipboard');
   };
 
   const handleMakePrivate = () => {
@@ -151,6 +162,32 @@ export default function ShareOverviewModal() {
                 <TrashIcon className="size-4" />
               </Button>
             </Tooltiper>
+          </div>
+          <div className="space-y-2">
+            <p className="text-xs text-muted-foreground">
+              Embed (auto-resizes to content height):
+            </p>
+            <div className="flex items-start gap-1">
+              <textarea
+                readOnly
+                value={embedCode}
+                className="flex-1 text-xs font-mono bg-background border rounded-md p-2 min-h-[72px]"
+              />
+              <Tooltiper content="Copy embed code">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleCopyEmbed}
+                >
+                  {copiedEmbed ? (
+                    <CheckCircle2 className="size-4" />
+                  ) : (
+                    <Copy className="size-4" />
+                  )}
+                </Button>
+              </Tooltiper>
+            </div>
           </div>
         </div>
       )}

--- a/apps/start/src/modals/share-overview-modal.tsx
+++ b/apps/start/src/modals/share-overview-modal.tsx
@@ -94,11 +94,18 @@ export default function ShareOverviewModal() {
     toast('Link copied to clipboard');
   };
 
-  const handleCopyEmbed = () => {
-    navigator.clipboard.writeText(embedCode);
-    setCopiedEmbed(true);
-    setTimeout(() => setCopiedEmbed(false), 2000);
-    toast('Embed code copied to clipboard');
+  const handleCopyEmbed = async () => {
+    try {
+      if (!navigator.clipboard) {
+        throw new Error('Clipboard API unavailable');
+      }
+      await navigator.clipboard.writeText(embedCode);
+      setCopiedEmbed(true);
+      setTimeout(() => setCopiedEmbed(false), 2000);
+      toast('Embed code copied to clipboard');
+    } catch {
+      toast('Could not copy embed code');
+    }
   };
 
   const handleMakePrivate = () => {

--- a/apps/start/src/routeTree.gen.ts
+++ b/apps/start/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as WidgetTestRouteImport } from './routes/widget/test'
 import { Route as WidgetRealtimeRouteImport } from './routes/widget/realtime'
 import { Route as WidgetCounterRouteImport } from './routes/widget/counter'
 import { Route as WidgetBadgeRouteImport } from './routes/widget/badge'
+import { Route as IframeTestRouteImport } from './routes/iframe-test'
 import { Route as ApiHealthcheckRouteImport } from './routes/api/healthcheck'
 import { Route as ApiConfigRouteImport } from './routes/api/config'
 import { Route as PublicOnboardingRouteImport } from './routes/_public.onboarding'
@@ -182,6 +183,11 @@ const WidgetBadgeRoute = WidgetBadgeRouteImport.update({
 const ApiHealthcheckRoute = ApiHealthcheckRouteImport.update({
   id: '/api/healthcheck',
   path: '/api/healthcheck',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const IframeTestRoute = IframeTestRouteImport.update({
+  id: '/iframe-test',
+  path: '/iframe-test',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiConfigRoute = ApiConfigRouteImport.update({
@@ -711,6 +717,7 @@ export interface FileRoutesByFullPath {
   '/widget/badge': typeof WidgetBadgeRoute
   '/widget/counter': typeof WidgetCounterRoute
   '/widget/realtime': typeof WidgetRealtimeRoute
+  '/iframe-test': typeof IframeTestRoute
   '/widget/test': typeof WidgetTestRoute
   '/$organizationId/$projectId': typeof AppOrganizationIdProjectIdRouteWithChildren
   '/$organizationId/billing': typeof AppOrganizationIdBillingRoute
@@ -798,6 +805,7 @@ export interface FileRoutesByTo {
   '/widget/badge': typeof WidgetBadgeRoute
   '/widget/counter': typeof WidgetCounterRoute
   '/widget/realtime': typeof WidgetRealtimeRoute
+  '/iframe-test': typeof IframeTestRoute
   '/widget/test': typeof WidgetTestRoute
   '/$organizationId/billing': typeof AppOrganizationIdBillingRoute
   '/$organizationId/settings': typeof AppOrganizationIdSettingsRoute
@@ -880,6 +888,7 @@ export interface FileRoutesById {
   '/widget/badge': typeof WidgetBadgeRoute
   '/widget/counter': typeof WidgetCounterRoute
   '/widget/realtime': typeof WidgetRealtimeRoute
+  '/iframe-test': typeof IframeTestRoute
   '/widget/test': typeof WidgetTestRoute
   '/_app/$organizationId/$projectId': typeof AppOrganizationIdProjectIdRouteWithChildren
   '/_app/$organizationId/billing': typeof AppOrganizationIdBillingRoute
@@ -980,6 +989,7 @@ export interface FileRouteTypes {
     | '/widget/badge'
     | '/widget/counter'
     | '/widget/realtime'
+    | '/iframe-test'
     | '/widget/test'
     | '/$organizationId/$projectId'
     | '/$organizationId/billing'
@@ -1067,6 +1077,7 @@ export interface FileRouteTypes {
     | '/widget/badge'
     | '/widget/counter'
     | '/widget/realtime'
+    | '/iframe-test'
     | '/widget/test'
     | '/$organizationId/billing'
     | '/$organizationId/settings'
@@ -1148,6 +1159,7 @@ export interface FileRouteTypes {
     | '/widget/badge'
     | '/widget/counter'
     | '/widget/realtime'
+    | '/iframe-test'
     | '/widget/test'
     | '/_app/$organizationId/$projectId'
     | '/_app/$organizationId/billing'
@@ -1245,6 +1257,7 @@ export interface RootRouteChildren {
   WidgetBadgeRoute: typeof WidgetBadgeRoute
   WidgetCounterRoute: typeof WidgetCounterRoute
   WidgetRealtimeRoute: typeof WidgetRealtimeRoute
+  IframeTestRoute: typeof IframeTestRoute
   WidgetTestRoute: typeof WidgetTestRoute
   ShareDashboardShareIdRoute: typeof ShareDashboardShareIdRoute
   ShareOverviewShareIdRoute: typeof ShareOverviewShareIdRoute
@@ -1293,6 +1306,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/iframe-test': {
+      id: '/iframe-test'
+      path: '/iframe-test'
+      fullPath: '/iframe-test'
+      preLoaderRoute: typeof IframeTestRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/widget/test': {
@@ -2499,6 +2519,7 @@ const rootRouteChildren: RootRouteChildren = {
   WidgetBadgeRoute: WidgetBadgeRoute,
   WidgetCounterRoute: WidgetCounterRoute,
   WidgetRealtimeRoute: WidgetRealtimeRoute,
+  IframeTestRoute: IframeTestRoute,
   WidgetTestRoute: WidgetTestRoute,
   ShareDashboardShareIdRoute: ShareDashboardShareIdRoute,
   ShareOverviewShareIdRoute: ShareOverviewShareIdRoute,

--- a/apps/start/src/routes/iframe-test.tsx
+++ b/apps/start/src/routes/iframe-test.tsx
@@ -1,0 +1,35 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useEffect } from 'react';
+
+export const Route = createFileRoute('/iframe-test')({
+  component: IframeTestLayout,
+});
+
+function IframeTestLayout() {
+  useEffect(() => {
+    const script = document.createElement('script');
+    script.src = '/openpanel-embed.js';
+    script.async = true;
+    document.body.appendChild(script);
+    return () => {
+      script.remove();
+    };
+  }, []);
+
+  return (
+    <div className="w-full min-h-screen center-center p-8">
+      <div className="border-8 border-border rounded-lg p-4 w-full max-w-5xl space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Local harness for share embeds. Point the iframe at a public share URL
+          and confirm the frame grows with content and modals stay in view.
+        </p>
+        <iframe
+          data-openpanel-embed
+          src="/share/overview/demo"
+          style={{ width: '100%', minHeight: 400 }}
+          title="OpenPanel share embed test"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/start/src/routes/share.dashboard.$shareId.tsx
+++ b/apps/start/src/routes/share.dashboard.$shareId.tsx
@@ -1,3 +1,4 @@
+import { useReportEmbedHeight } from '@/hooks/use-embed-viewport';
 import { ShareEnterPassword } from '@/components/auth/share-enter-password';
 import { FullPageEmptyState } from '@/components/full-page-empty-state';
 import FullPageLoadingState from '@/components/full-page-loading-state';
@@ -82,6 +83,7 @@ function RouteComponent() {
   const { header } = useSearch({ from: '/share/dashboard/$shareId' });
   const trpc = useTRPC();
   const { range, startDate, endDate, interval } = useOverviewOptions();
+  useReportEmbedHeight();
 
   const shareQuery = useSuspenseQuery(
     trpc.share.dashboard.queryOptions({

--- a/apps/start/src/routes/share.dashboard.$shareId.tsx
+++ b/apps/start/src/routes/share.dashboard.$shareId.tsx
@@ -118,7 +118,7 @@ function RouteComponent() {
   const layouts = useReportLayouts(reports);
 
   return (
-    <div>
+    <div data-openpanel-embed-root>
       {isHeaderVisible && (
         <div className="mx-auto max-w-7xl">
           <LoginNavbar className="relative p-4" />

--- a/apps/start/src/routes/share.overview.$shareId.tsx
+++ b/apps/start/src/routes/share.overview.$shareId.tsx
@@ -1,3 +1,4 @@
+import { useReportEmbedHeight } from '@/hooks/use-embed-viewport';
 import { ShareEnterPassword } from '@/components/auth/share-enter-password';
 import { FullPageEmptyState } from '@/components/full-page-empty-state';
 import FullPageLoadingState from '@/components/full-page-loading-state';
@@ -75,6 +76,7 @@ function RouteComponent() {
       shareId,
     }),
   );
+  useReportEmbedHeight();
 
   if (shareQuery.isLoading) {
     return <div>Loading...</div>;

--- a/apps/start/src/routes/share.overview.$shareId.tsx
+++ b/apps/start/src/routes/share.overview.$shareId.tsx
@@ -100,7 +100,7 @@ function RouteComponent() {
     header !== '0' && header !== 0 && header !== 'false' && header !== false;
 
   return (
-    <div>
+    <div data-openpanel-embed-root>
       {isHeaderVisible && (
         <div className="mx-auto max-w-7xl">
           <LoginNavbar className="relative p-4" />

--- a/apps/start/src/utils/embed-viewport.test.ts
+++ b/apps/start/src/utils/embed-viewport.test.ts
@@ -17,6 +17,18 @@ describe('viewportFromIframeRect', () => {
       viewportFromIframeRect({ top: 100, bottom: 900, height: 800 }, 1000),
     ).toEqual({ visibleTop: 0, visibleHeight: 800 });
   });
+
+  it('returns zero height when the iframe is fully above the parent viewport', () => {
+    expect(
+      viewportFromIframeRect({ top: -2000, bottom: -200, height: 1800 }, 800),
+    ).toEqual({ visibleTop: 1800, visibleHeight: 0 });
+  });
+
+  it('returns zero height when the iframe is fully below the parent viewport', () => {
+    expect(
+      viewportFromIframeRect({ top: 1200, bottom: 2200, height: 1000 }, 800),
+    ).toEqual({ visibleTop: 0, visibleHeight: 0 });
+  });
 });
 
 describe('embeddedDialogCenterY', () => {

--- a/apps/start/src/utils/embed-viewport.test.ts
+++ b/apps/start/src/utils/embed-viewport.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+  embeddedDialogCenterY,
+  viewportFromIframeRect,
+} from './embed-viewport';
+
+describe('viewportFromIframeRect', () => {
+  it('when the iframe top is above the parent viewport, visibleTop tracks scroll into the iframe', () => {
+    // Parent scrolled so iframe top is 400px above the viewport; parent is 800 tall.
+    expect(
+      viewportFromIframeRect({ top: -400, bottom: 1600, height: 2000 }, 800),
+    ).toEqual({ visibleTop: 400, visibleHeight: 800 });
+  });
+
+  it('when the iframe sits fully in view, visibleTop is 0', () => {
+    expect(
+      viewportFromIframeRect({ top: 100, bottom: 900, height: 800 }, 1000),
+    ).toEqual({ visibleTop: 0, visibleHeight: 800 });
+  });
+});
+
+describe('embeddedDialogCenterY', () => {
+  it('centers the dialog in the visible slice', () => {
+    expect(
+      embeddedDialogCenterY({ visibleTop: 400, visibleHeight: 800 }),
+    ).toBe(800);
+  });
+});

--- a/apps/start/src/utils/embed-viewport.ts
+++ b/apps/start/src/utils/embed-viewport.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure helpers for OpenPanel share embeds (no DOM).
+ * Parent page scrolls a tall iframe; dialogs must center in the *visible* slice.
+ */
+
+export type EmbedViewport = {
+  /** Distance from the top of the iframe document to the top of the visible slice */
+  visibleTop: number;
+  /** Height of the visible slice inside the iframe (px) */
+  visibleHeight: number;
+};
+
+export function isInIframe(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  try {
+    return window.self !== window.top;
+  } catch {
+    // Cross-origin parent access can throw; being framed still means embedded.
+    return true;
+  }
+}
+
+/** Center Y (iframe document coords) for a dialog in the visible slice. */
+export function embeddedDialogCenterY(viewport: EmbedViewport): number {
+  return viewport.visibleTop + viewport.visibleHeight / 2;
+}
+
+/**
+ * Map the iframe element's getBoundingClientRect() + parent viewport
+ * into the visible slice inside the iframe document.
+ */
+export function viewportFromIframeRect(
+  rect: { top: number; bottom: number; height: number },
+  parentInnerHeight: number,
+): EmbedViewport {
+  const visibleTop = Math.max(0, -rect.top);
+  const visibleBottom = Math.min(rect.height, parentInnerHeight - rect.top);
+  const visibleHeight = Math.max(0, visibleBottom - visibleTop);
+  return {
+    visibleTop,
+    visibleHeight: visibleHeight || Math.min(rect.height, parentInnerHeight),
+  };
+}

--- a/apps/start/src/utils/embed-viewport.ts
+++ b/apps/start/src/utils/embed-viewport.ts
@@ -35,11 +35,11 @@ export function viewportFromIframeRect(
   rect: { top: number; bottom: number; height: number },
   parentInnerHeight: number,
 ): EmbedViewport {
-  const visibleTop = Math.max(0, -rect.top);
+  const visibleTop = Math.min(rect.height, Math.max(0, -rect.top));
   const visibleBottom = Math.min(rect.height, parentInnerHeight - rect.top);
   const visibleHeight = Math.max(0, visibleBottom - visibleTop);
   return {
     visibleTop,
-    visibleHeight: visibleHeight || Math.min(rect.height, parentInnerHeight),
+    visibleHeight,
   };
 }


### PR DESCRIPTION
## Summary
- Add `openpanel-embed.js` host script: auto-height for `iframe[data-openpanel-embed]` via `postMessage` (same idea as Plausible’s embed host)
- Share overview/dashboard report height to the parent; Share Overview modal includes copyable embed snippet
- Fix Radix dialogs when embedded: disable scroll-lock and pin overlay/content to the **visible** iframe slice (addresses the modal centering issue on Carl’s WIP)

Builds on the approach in `upstream/feature/iframe-resize`, without pulling in `@iframe-resizer` (license/weight).

Fixes #224

## Test plan
- [ ] Public share overview: copy embed code from Share modal, paste on a host page with the script → iframe grows with content
- [ ] Scroll the host page and open an overview modal (e.g. top pages) → dialog appears in the visible area, page still scrolls
- [ ] Same checks for share dashboard
- [ ] Non-embed app dialogs unchanged
- [ ] CI: `embed-viewport` unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for embedding shared overviews and dashboards in external pages.
  - Embedded content now automatically adjusts its height and responds to viewport changes.
  - Dialogs display correctly within embedded views without interfering with host-page scrolling.
  - Added an iframe testing route for embed previews.

- **Bug Fixes**
  - Improved feedback when copying embed code fails.
  - Corrected viewport handling when embedded content is fully outside the visible area.

- **Tests**
  - Added coverage for embedded viewport calculations and content-height measurement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->