### PR TITLE
fix(funnel): stop the breakdown limit from dropping lower funnel steps

### DIFF
--- a/packages/db/src/services/funnel.service.test.ts
+++ b/packages/db/src/services/funnel.service.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { FunnelService } from './funnel.service';
+
+// toSeries is pure — it only reshapes rows — so the client is never touched.
+const service = new FunnelService({} as any);
+
+const BREAKDOWNS = [{ name: 'path' }];
+
+/**
+ * The funnel query is ordered by `level DESC`, so every level-5 row arrives
+ * before any level-4 row, and so on. Rows are shaped as the query returns them.
+ */
+const rowsOrderedByLevelDesc = (
+  paths: string[],
+  perLevel: Record<number, number>,
+) =>
+  [5, 4, 3, 2, 1].flatMap((level) =>
+    paths.map((path) => ({
+      level,
+      count: perLevel[level]!,
+      b_0: path,
+    })),
+  );
+
+describe('FunnelService.toSeries', () => {
+  it('keeps every level of a series once the limit is reached', () => {
+    // 3 paths but a limit of 2: the third is dropped, the first two must still
+    // carry all five of their levels.
+    const rows = rowsOrderedByLevelDesc(
+      ['/a', '/b', '/c'],
+      { 5: 128, 4: 22, 3: 1, 2: 105, 1: 67 },
+    );
+
+    const series = service.toSeries(rows, BREAKDOWNS, 2);
+
+    expect(series).toHaveLength(2);
+    for (const s of series) {
+      expect(s.map((row) => row.level).sort()).toEqual([1, 2, 3, 4, 5]);
+    }
+  });
+
+  it('caps the number of series at the limit', () => {
+    const rows = rowsOrderedByLevelDesc(
+      ['/a', '/b', '/c', '/d'],
+      { 5: 1, 4: 1, 3: 1, 2: 1, 1: 1 },
+    );
+
+    expect(service.toSeries(rows, BREAKDOWNS, 2)).toHaveLength(2);
+    expect(service.toSeries(rows, BREAKDOWNS, 4)).toHaveLength(4);
+    expect(service.toSeries(rows, BREAKDOWNS, undefined)).toHaveLength(4);
+  });
+
+  it('does not flatten a funnel into an all-100% series when limited', () => {
+    // Regression: dropping the lower-level rows left each series holding only
+    // its deepest level, which fillFunnel then accumulated into every step —
+    // rendering an identical count at 100% for all steps.
+    const rows = rowsOrderedByLevelDesc(
+      ['/a', '/b'],
+      { 5: 128, 4: 22, 3: 1, 2: 105, 1: 67 },
+    );
+
+    const [first] = service.toSeries(rows, BREAKDOWNS, 1);
+
+    expect(first).toBeDefined();
+    const counts = first!
+      .sort((a, b) => a.level - b.level)
+      .map((row) => row.count);
+    // 67, 105, 1, 22, 128 — distinct per level, not five copies of 128.
+    expect(counts).toEqual([67, 105, 1, 22, 128]);
+    expect(new Set(counts).size).toBeGreaterThan(1);
+  });
+
+  it('returns a single series when there are no breakdowns', () => {
+    const rows = [
+      { level: 2, count: 5 },
+      { level: 1, count: 9 },
+    ];
+
+    const series = service.toSeries(rows, [], 1);
+
+    expect(series).toHaveLength(1);
+    expect(series[0]).toHaveLength(2);
+  });
+});

--- a/packages/db/src/services/funnel.service.ts
+++ b/packages/db/src/services/funnel.service.ts
@@ -203,14 +203,20 @@ export class FunnelService {
     // Group by breakdown values (normalize empty/null to "Not set")
     const series = funnel.reduce(
       (acc, f) => {
-        if (limit && Object.keys(acc).length >= limit) {
-          return acc;
-        }
-
         const key = breakdowns
           .map((b, index) => normalizeBreakdownValue(f[`b_${index}`]))
           .join('|');
         if (!acc[key]) {
+          // The limit caps how many breakdown series we return, so it must only
+          // reject NEW keys. Bailing out of the whole reduce here would drop the
+          // remaining rows of series already accepted: the query is ordered by
+          // level DESC, so those rows are the lower funnel steps, and losing them
+          // leaves each series holding only its deepest level. fillFunnel then
+          // accumulates that single row into every step, so every step reports an
+          // identical count at 100%.
+          if (limit && Object.keys(acc).length >= limit) {
+            return acc;
+          }
           acc[key] = [];
         }
         acc[key]!.push({


### PR DESCRIPTION
## The bug

When a funnel has a breakdown and **more distinct breakdown values than `limit`**, every step of every breakdown row reports an identical count at 100% — the funnel looks like it converts perfectly end to end.

Observed on a report with 185 distinct paths against a limit of 50:

```
/script-to-video      128 100%   128 100%   128 100%   128 100%   128 100%
```

The underlying rows for that path:

```
by_level   1:67  2:105  3:1  4:22  5:128
correct    323 → 256 → 151 → 150 → 128     100% / 79.3% / 46.7% / 46.4% / 39.6%
```

`128` is the deepest-level count, repeated across every step.

## Cause

`toSeries` bails out of the entire reduce once the accumulator holds `limit` keys:

```js
const series = funnel.reduce((acc, f) => {
    if (limit && Object.keys(acc).length >= limit) {
      return acc;                    // drops EVERY remaining row
    }
    const key = breakdowns.map((b, i) => normalizeBreakdownValue(f[`b_${i}`])).join('|');
    if (!acc[key]) acc[key] = [];
    acc[key].push({ level: f.level, count: f.count, ... });
    return acc;
}, {});
```

The funnel query ends with `ORDER BY level DESC`, so rows arrive grouped by depth — all max-level rows first, then the next level down, and so on. The limit is therefore reached while only max-level rows have been seen, and every subsequent row is discarded — **including the lower-level rows belonging to series already accepted**.

Each series is left holding one row. `fillFunnel` accumulates bottom-up, so that single count propagates into every step, and `totalSessions` (taken from the level-1 entry) becomes equal to it — making every percent exactly 100%:

```js
fillFunnel([{ level: 5, count: 128 }], 5)
  filled     [1:0,   2:0,   3:0,   4:0,   5:128]
  accumulate [1:128, 2:128, 3:128, 4:128, 5:128]
  totalSessions = 128  →  percent = 100% at every step
```

Reports with fewer breakdown values than their limit are unaffected, which is why this only shows up once a breakdown dimension grows past the limit.

## Fix

The limit caps how many series are *returned*, so it should only reject keys that are **new**:

```js
const key = breakdowns.map((b, i) => normalizeBreakdownValue(f[`b_${i}`])).join('|');
if (!acc[key]) {
  if (limit && Object.keys(acc).length >= limit) return acc;
  acc[key] = [];
}
acc[key].push(...);
```

The number of series returned is unchanged — still capped at `limit`.

## Verification

Simulated against this branch's `toSeries` (including `normalizeBreakdownValue`) and `fillFunnel`, with rows in the exact `level DESC` order the query produces — 3 breakdown values, `limit: 2`:

```
BEFORE | series: 2 | rows in series[0]: 1
       steps: 128 -> 128 -> 128 -> 128 -> 128
    percents: 100.0% 100.0% 100.0% 100.0% 100.0%

AFTER  | series: 2 | rows in series[0]: 5
       steps: 323 -> 256 -> 151 -> 150 -> 128
    percents: 100.0% 79.3% 46.7% 46.4% 39.6%
```

Series count stays capped at 2 in both cases.

The same change was verified end to end on a downstream deployment against live data: the corrected numbers match the ClickHouse rows exactly.

## Tests

Adds `packages/db/src/services/funnel.service.test.ts` covering:

- every level of a series is kept once the limit is reached
- the number of series is still capped at the limit
- a limited series is not flattened into an all-100% funnel
- the no-breakdown path still returns a single series

Two of the four fail without this change. Note: these were executed against a fork whose `toSeries` is identical to this file's; I wasn't able to install this repo's dependencies locally to run the suite here, so CI is the real check on them.

## Also worth a look (not changed here)

Which series survive the limit is "first `limit` keys encountered in `level DESC` order" — biased toward series that converted deepest rather than the largest. Results are sorted by total afterwards, so ordering looks right, but a high-traffic breakdown value that never converts deeply can still be dropped. Selecting the top-N by total before slicing would be more predictable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed funnel breakdown limits so retained series continue to include all funnel levels.
  * Prevented limited breakdowns from incorrectly appearing as flattened 100% series.
  * Ensured empty breakdowns still produce a single series.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->