### PR TITLE
fix(worker): don't crash the worker when /metrics collection fails

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -78,7 +78,11 @@ async function start() {
         res.end(metrics);
       })
       .catch((error) => {
-        res.status(500).end(error);
+        // res.end() only accepts a string/Buffer; passing a raw Error object
+        // throws a TypeError inside this catch, which is unhandled and crashes
+        // the worker. Since /metrics is scraped on every pod, one failing
+        // collector can take down the whole fleet. Stringify to be safe.
+        res.status(500).end(String(error?.message ?? error));
       });
   });
 


### PR DESCRIPTION
### Problem

The `/metrics` endpoint's error handler passes a raw `Error` object to `res.end()`:

```js
.catch((error) => {
  res.status(500).end(error);
});
```

`res.end()` only accepts a string or Buffer. If `register.metrics()` rejects — e.g. a custom collector makes a Redis/DB call that throws during a failover — then `res.end(error)` throws a `TypeError` **inside the catch**, which is unhandled and **exits the process**.

Because `/metrics` is scraped on every pod by the metrics backend, a single failing collector can crash the **entire worker fleet** at once. We hit exactly this in production during a managed-Redis failover: a collector's Redis call threw, and every worker died together.

### Fix

Stringify the error before passing it to `res.end()`, so a metrics-collection failure returns a clean `500` instead of crashing the worker:

```js
res.status(500).end(String(error?.message ?? error));
```

One-line change, no behavior change on the success path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for the metrics endpoint so server errors are returned safely and consistently in HTTP 500 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->