### PR TITLE
perf(charts): restrict profile joins to the event window

### DIFF
--- a/packages/db/src/services/chart-sql.test.ts
+++ b/packages/db/src/services/chart-sql.test.ts
@@ -729,7 +729,7 @@ describe('chart.service / profile event window', () => {
         projectId: PROJECT_ID,
         timezone: 'UTC',
       });
-      expect(sql).toContain(`id IN (SELECT profile_id FROM events WHERE project_id = '${PROJECT_ID}' AND created_at >= toDateTime('${formatClickhouseDate('2026-09-01 00:00:00')}') AND created_at <= toDateTime('${formatClickhouseDate('2026-09-02 00:00:00')}') AND name = 'screen_view')`);
+      expect(sql).toContain(`id IN (SELECT profile_id FROM events WHERE project_id = '${PROJECT_ID}' AND created_at >= toDateTime('${formatClickhouseDate('2026-09-01 00:00:00')}') AND created_at <= toDateTime('${formatClickhouseDate('2026-09-02 00:00:00')}') AND name = ('screen_view'))`);
       expect(sql).toContain('FROM profiles FINAL');
       if (chReachable) await explain(sql);
     });

--- a/packages/db/src/services/chart-sql.test.ts
+++ b/packages/db/src/services/chart-sql.test.ts
@@ -13,7 +13,7 @@
  */
 import type { IChartBreakdown, IChartEvent } from '@openpanel/validation';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
-import { ch } from '../clickhouse/client';
+import { ch, formatClickhouseDate } from '../clickhouse/client';
 import {
   getAggregateChartSql as _getAggregateChartSql,
   getChartSql as _getChartSql,
@@ -712,4 +712,40 @@ describe('chart.service / single-pass total_count', () => {
     });
     await explain(sql);
   });
+});
+
+describe('chart.service / profile event window', () => {
+  for (const [name, build] of [
+    ['timeseries', getChartSql],
+    ['aggregate', getAggregateChartSql],
+  ] as const) {
+    it(`${name} restricts profile reads to the same project, event and dates`, async () => {
+      const sql = await build({
+        event: event(),
+        breakdowns: [breakdown('profile.properties.plan')],
+        interval: 'day',
+        startDate: '2026-09-01 00:00:00',
+        endDate: '2026-09-02 00:00:00',
+        projectId: PROJECT_ID,
+        timezone: 'UTC',
+      });
+      expect(sql).toContain(`id IN (SELECT profile_id FROM events WHERE project_id = '${PROJECT_ID}' AND created_at >= toDateTime('${formatClickhouseDate('2026-09-01 00:00:00')}') AND created_at <= toDateTime('${formatClickhouseDate('2026-09-02 00:00:00')}') AND name = 'screen_view')`);
+      expect(sql).toContain('FROM profiles FINAL');
+      if (chReachable) await explain(sql);
+    });
+
+    it(`${name} keeps all event names for wildcard series`, async () => {
+      const sql = await build({
+        event: event({ name: '*' }),
+        breakdowns: [breakdown('profile.properties.plan')],
+        interval: 'day',
+        startDate: '',
+        endDate: '',
+        projectId: PROJECT_ID,
+        timezone: 'UTC',
+      });
+      expect(sql).toContain(`id IN (SELECT profile_id FROM events WHERE project_id = '${PROJECT_ID}')`);
+      expect(sql).not.toContain("name = '*'");
+    });
+  }
 });

--- a/packages/db/src/services/chart.service.ts
+++ b/packages/db/src/services/chart.service.ts
@@ -462,6 +462,26 @@ export function rewriteProfilePropertyRefs(sql: string, keys: string[]): string 
   return out;
 }
 
+function profileEventWindow({
+  projectId,
+  startDate,
+  endDate,
+  event,
+}: Pick<IGetChartDataInput, 'projectId' | 'startDate' | 'endDate' | 'event'>) {
+  const conditions = [`project_id = ${sqlstring.escape(projectId)}`];
+  if (startDate) {
+    conditions.push(`created_at >= toDateTime('${formatClickhouseDate(startDate)}')`);
+  }
+  if (endDate) {
+    conditions.push(`created_at <= toDateTime('${formatClickhouseDate(endDate)}')`);
+  }
+  if (event.name !== '*') {
+    conditions.push(`name = ${sqlstring.escape(event.name)}`);
+  }
+  // Filter by the join key before FINAL without excluding profiles updated outside the event window.
+  return `id IN (SELECT profile_id FROM ${TABLE_NAMES.events} WHERE ${conditions.join(' AND ')})`;
+}
+
 export async function getChartSql({
   event,
   breakdowns: initialBreakdowns,
@@ -691,7 +711,8 @@ export async function getChartSql({
       'profile',
       `SELECT ${selectFields.join(', ')}
       FROM ${TABLE_NAMES.profiles} FINAL
-      WHERE project_id = ${sqlstring.escape(projectId)}`
+      WHERE project_id = ${sqlstring.escape(projectId)}
+      AND ${profileEventWindow({ projectId, startDate, endDate, event })}`
     );
 
     // Use the CTE reference in the main query
@@ -1073,7 +1094,8 @@ export async function getAggregateChartSql({
       'profile',
       `SELECT ${selectFields.join(', ')}
       FROM ${TABLE_NAMES.profiles} FINAL
-      WHERE project_id = ${sqlstring.escape(projectId)}`
+      WHERE project_id = ${sqlstring.escape(projectId)}
+      AND ${profileEventWindow({ projectId, startDate, endDate, event })}`
     );
 
     sb.joins.profiles = profilesJoinRef;

--- a/packages/db/src/services/chart.service.ts
+++ b/packages/db/src/services/chart.service.ts
@@ -9,7 +9,8 @@ import {
   type IReportInput,
 } from '@openpanel/validation';
 import sqlstring from 'sqlstring';
-import { formatClickhouseDate, TABLE_NAMES } from '../clickhouse/client';
+import { ch, formatClickhouseDate, TABLE_NAMES } from '../clickhouse/client';
+import { clix } from '../clickhouse/query-builder';
 import { db } from '../prisma-client';
 import { createSqlBuilder } from '../sql-builder';
 import { buildTypedClause, hasTypedCast, isTypedOperator } from './filter-cast';
@@ -468,18 +469,22 @@ function profileEventWindow({
   endDate,
   event,
 }: Pick<IGetChartDataInput, 'projectId' | 'startDate' | 'endDate' | 'event'>) {
-  const conditions = [`project_id = ${sqlstring.escape(projectId)}`];
+  const query = clix(ch)
+    .select(['profile_id'])
+    .from(TABLE_NAMES.events)
+    .where('project_id', '=', projectId);
   if (startDate) {
-    conditions.push(`created_at >= toDateTime('${formatClickhouseDate(startDate)}')`);
+    query.where('created_at', '>=', clix.datetime(startDate, 'toDateTime'));
   }
   if (endDate) {
-    conditions.push(`created_at <= toDateTime('${formatClickhouseDate(endDate)}')`);
+    query.where('created_at', '<=', clix.datetime(endDate, 'toDateTime'));
   }
   if (event.name !== '*') {
-    conditions.push(`name = ${sqlstring.escape(event.name)}`);
+    // Event names must remain string literals, even when they look like dates.
+    query.where('name', '=', clix.exp(sqlstring.escape(event.name)));
   }
   // Filter by the join key before FINAL without excluding profiles updated outside the event window.
-  return `id IN (SELECT profile_id FROM ${TABLE_NAMES.events} WHERE ${conditions.join(' AND ')})`;
+  return `id IN (${query.toSQL()})`;
 }
 
 export async function getChartSql({


### PR DESCRIPTION
Chart profile joins now restrict `profiles FINAL` to profile IDs appearing in the same project's selected event and time window. This applies to aggregate and time-series charts and retains FINAL deduplication and the existing property-key projection. Profile update timestamps are not filtered, so recent profile changes still apply to older events.

Fixes #426.

Latest follow-up (`505f9d6a`): the profile-ID subquery uses `clix(ch)`. Source review only; tests, ClickHouse checks, and typecheck have not been rerun for this revision.

Validation of the previous revision (`a84ed917`): four focused SQL regression tests passed, including ClickHouse EXPLAIN for both builders; the DB package typecheck passes. Executing SQL produced by the actual builders on ClickHouse 26.2 returned identical results before and after the change for aggregate/time-series charts, profile filters, wildcard events, missing profiles and an empty period. Fixtures included a profile updated outside the event window and the same profile ID in another project.

A single synthetic comparison with 500,000 profiles and 100 relevant events measured peak memory of 62.5 → 7.4 MB for aggregate queries and 60.9 → 7.4 MB for time-series queries. Runtime was 123 → 36 ms and 108 → 41 ms respectively. These are fixture measurements, not a production performance guarantee; wide windows may benefit less.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chart and aggregate chart results now include only profiles with matching events from the selected project and date range.
  * Event-specific chart filtering now matches the selected event name accurately.
  * Wildcard event searches continue to match events across names while still respecting project and date filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
